### PR TITLE
#56 [FIX] BoardCard 컴포넌트의 svg Cannot find module 에러 해결

### DIFF
--- a/src/components/BoardCard/BoardCard.jsx
+++ b/src/components/BoardCard/BoardCard.jsx
@@ -9,14 +9,12 @@ export default function BoardCard({
   desc,
   backgroundImage,
 }) {
-  const path = require(`../../assets/images/${backgroundImage}`);
-
   return (
     <Link className={`${styles.link} ${className}`} to={to}>
       <div
         className={styles.card}
         style={{
-          backgroundImage: `${USER?.isLogin ? `url(${path})` : ''}`,
+          backgroundImage: `${USER?.isLogin ? `url(${backgroundImage})` : ''}`,
         }}
       >
         <p className={`${styles.name} ${!USER?.isLogin && styles.notLogin}`}>


### PR DESCRIPTION
## 🎯 관련 이슈

close #56 

<br />

## 🚀 작업 내용

- BoardCard 컴포넌트의 Cannot find module 에러 해결

<br />

## 🔎 발견된 장애가 있었나요?

- `BOARD_MENUS` 상수의 image 속성값이 변경되어 발생한 에러입니다.
  - 기존
    ```js
    export const BOARD_MENUS = [
      {
        id: 'firstSnow',
        to: '/board/first-snow',
        title: '첫눈온방',
        desc: '눈송이 모두가 이용하는 커뮤니티',
        image: 'firstSnow.svg',
      }
    ];
    ```
  - 변경
    ```js
    import firstSnow from '../assets/images/firstSnow.svg';

    export const BOARD_MENUS = [
      {
        id: 'firstSnow',
        to: '/board/first-snow',
        title: '첫눈온방',
        desc: '새내기 전용 커뮤니티',
        image: firstSnow,
      }
    ];
    ```
- 기존은 파일명만 받아와 BoardCard에서 경로를 완성하여 렌더링했지만, `BOARD_MENUS`의 image 속성이 온전한 이미지로 변경되면서 BoardCard의 기존 코드에 문제가 발생하게 되었습니다.
- 변경된 상수 내용에 맞춰 BoardCard에서 `backgroundImage` prop으로 받아온 것을 inline css에 바로 사용하여 해결했습니다.

<br />

## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?
- `BOARD_MENUS` 상수의 image 속성값이 변경되어 `BOARD_MENUS`를 사용하고 있던 BoardCard 컴포넌트에 문제가 생긴 케이스였습니다.
- 다른 컴포넌트에 영향을 줄 수 있는 파일을 수정 시 PR 올리실 때 이곳에 알려주세요!
- 이번엔 `BOARD_MENUS`을 수정하지 않고 변경된 `BOARD_MENUS`에 맞춰 BoardCard 컴포넌트 코드를 수정했습니다.
