### PR TITLE
#80 [FIX] localhost:3000에 있을 때 Navbar의 홈 아이콘이 활성화되지 않는 문제 해결

### DIFF
--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -13,7 +13,7 @@ const NAVBAR_ = {
 
 export default function Navbar() {
   const { pathname } = useLocation();
-  const currentMenu = pathname.split('/')[1];
+  const currentMenu = pathname.split('/')[1] || 'home';
 
   return (
     <nav className={styles.nav}>


### PR DESCRIPTION
## 🎯 관련 이슈

close #80

<br />

## 🔎 발견된 장애가 있었나요?

- localhost:3000에 있을 때 Navbar의 홈 아이콘이 활성화 되지 않는 문제가 있었습니다.
- pathname을 split한 결과가 빈 문자열이면 `currentMenu`에 'home'을 할당해 문제를 해결했습니다.
  ```js
  const currentMenu = pathname.split('/')[1] || 'home';
  ```

<br />

## 📸 스크린샷

| <img width="679" alt="image" src="https://github.com/user-attachments/assets/6c5b20b1-0174-4b97-b883-0ae3e9696801"> |
| :---------------------: |