### PR TITLE
#87 [FEAT] 포인트 내역 보기 페이지 UI 구현

### DIFF
--- a/src/pages/MyPage/ViewPointListPage/ViewPointListPage.jsx
+++ b/src/pages/MyPage/ViewPointListPage/ViewPointListPage.jsx
@@ -39,7 +39,93 @@ export default function ViewPointListPage() {
                 <time className={styles.pointDate}>2024.06.01 15:23:00</time>
               </div>
             </div>
+            <span className={styles.chargePoint}>+ 2</span>
+          </section>
+
+          <section className={styles.pointBox}>
+            <div className={styles.pointIconContentWrapper}>
+              <Icon id='heart-plus' />
+              <div className={styles.pointContent}>
+                <h2 className={styles.pointTitle}>게시글 포인트</h2>
+                <p className={styles.pointDesc}>뫔뫄</p>
+                <time className={styles.pointDate}>2024.06.01 15:23:00</time>
+              </div>
+            </div>
             <span className={styles.chargePoint}>+ 3</span>
+          </section>
+
+          <section className={styles.pointBox}>
+            <div className={styles.pointIconContentWrapper}>
+              <Icon id='heart-plus' />
+              <div className={styles.pointContent}>
+                <h2 className={styles.pointTitle}>댓글 포인트</h2>
+                <p className={styles.pointDesc}>
+                  어제 간식으로 나온거 맛있던데 총학 공지에 나와있는...
+                </p>
+                <time className={styles.pointDate}>2024.06.01 15:23:00</time>
+              </div>
+            </div>
+            <span className={styles.chargePoint}>+ 1</span>
+          </section>
+
+          <section className={styles.pointBox}>
+            <div className={styles.pointIconContentWrapper}>
+              <Icon id='heart-minus' />
+              <div className={styles.pointContent}>
+                <h2 className={styles.pointTitle}>시험후기 다운로드</h2>
+                <p className={styles.pointDesc}>서양미술사/이교수</p>
+                <time className={styles.pointDate}>2024.06.01 15:23:00</time>
+              </div>
+            </div>
+            <span className={styles.chargePoint}>- 50</span>
+          </section>
+
+          <section className={styles.pointBox}>
+            <div className={styles.pointIconContentWrapper}>
+              <Icon id='heart-plus' />
+              <div className={styles.pointContent}>
+                <h2 className={styles.pointTitle}>인증 포인트</h2>
+                <time className={styles.pointDate}>2024.06.01 15:23:00</time>
+              </div>
+            </div>
+            <span className={styles.chargePoint}>+ 50</span>
+          </section>
+
+          <section className={styles.pointBox}>
+            <div className={styles.pointIconContentWrapper}>
+              <Icon id='heart-plus' />
+              <div className={styles.pointContent}>
+                <h2 className={styles.pointTitle}>신고 포상 포인트</h2>
+                <time className={styles.pointDate}>2024.06.01 15:23:00</time>
+              </div>
+            </div>
+            <span className={styles.chargePoint}>+ 10</span>
+          </section>
+
+          <section className={styles.pointBox}>
+            <div className={styles.pointIconContentWrapper}>
+              <Icon id='heart-minus' />
+              <div className={styles.pointContent}>
+                <h2 className={styles.pointTitle}>게시글 삭제 포인트</h2>
+                <p className={styles.pointDesc}>아 미친 지각 각임</p>
+                <time className={styles.pointDate}>2024.06.01 15:23:00</time>
+              </div>
+            </div>
+            <span className={styles.chargePoint}>- 3</span>
+          </section>
+
+          <section className={styles.pointBox}>
+            <div className={styles.pointIconContentWrapper}>
+              <Icon id='heart-minus' />
+              <div className={styles.pointContent}>
+                <h2 className={styles.pointTitle}>댓글 삭제 포인트</h2>
+                <p className={styles.pointDesc}>
+                  어제 간식으로 나온거 맛있던데 총학 공지에 나와있는...
+                </p>
+                <time className={styles.pointDate}>2024.06.01 15:23:00</time>
+              </div>
+            </div>
+            <span className={styles.chargePoint}>- 3</span>
           </section>
         </article>
       </section>

--- a/src/pages/MyPage/ViewPointListPage/ViewPointListPage.jsx
+++ b/src/pages/MyPage/ViewPointListPage/ViewPointListPage.jsx
@@ -3,6 +3,65 @@ import { Icon } from '../../../components/Icon';
 import styles from './ViewPointListPage.module.css';
 import { BackAppBar } from '../../../components/AppBar';
 
+const pointData = [
+  {
+    id: 1,
+    title: '출석 포인트',
+    desc: '',
+    date: '2024.06.01 15:23:00',
+    point: 2,
+  },
+  {
+    id: 2,
+    title: '게시글 포인트',
+    desc: '뫔뫄',
+    date: '2024.06.01 15:23:00',
+    point: 3,
+  },
+  {
+    id: 3,
+    title: '댓글 포인트',
+    desc: '어제 간식으로 나온거 맛있던데 총학 공지에 나와있는...',
+    date: '2024.06.01 15:23:00',
+    point: 1,
+  },
+  {
+    id: 4,
+    title: '시험후기 다운로드',
+    desc: '서양미술사/이교수',
+    date: '2024.06.01 15:23:00',
+    point: -50,
+  },
+  {
+    id: 5,
+    title: '인증 포인트',
+    desc: '',
+    date: '2024.06.01 15:23:00',
+    point: 50,
+  },
+  {
+    id: 6,
+    title: '신고 포상 포인트',
+    desc: '',
+    date: '2024.06.01 15:23:00',
+    point: 10,
+  },
+  {
+    id: 7,
+    title: '게시글 삭제 포인트',
+    desc: '아 미친 지각 각임',
+    date: '2024.06.01 15:23:00',
+    point: -3,
+  },
+  {
+    id: 8,
+    title: '댓글 삭제 포인트',
+    desc: '어제 간식으로 나온거 맛있던데 총학 공지에 나와있는...',
+    date: '2024.06.01 15:23:00',
+    point: -3,
+  },
+];
+
 export default function ViewPointListPage() {
   const chargePointsRef = useRef([]);
 
@@ -11,6 +70,13 @@ export default function ViewPointListPage() {
       const value = point.textContent.replace(/\s/g, '');
       if (parseInt(value) < 0) {
         point.classList.add(styles.negative);
+
+        const pointTitleElement = point
+          .closest(`.${styles.pointBox}`)
+          .querySelector(`.${styles.pointTitle}`);
+        if (pointTitleElement) {
+          pointTitleElement.classList.add(styles.negative);
+        }
       }
     });
   }, []);
@@ -31,102 +97,24 @@ export default function ViewPointListPage() {
         </div>
 
         <article className={styles.pointListContainer}>
-          <section className={styles.pointBox}>
-            <div className={styles.pointIconContentWrapper}>
-              <Icon id='heart-plus' />
-              <div className={styles.pointContent}>
-                <h2 className={styles.pointTitle}>출석 포인트</h2>
-                <time className={styles.pointDate}>2024.06.01 15:23:00</time>
+          {pointData.map((item, index) => (
+            <section key={item.id} className={styles.pointBox}>
+              <div className={styles.pointIconContentWrapper}>
+                <Icon id={item.point > 0 ? 'heart-plus' : 'heart-minus'} />
+                <div className={styles.pointContent}>
+                  <h2 className={styles.pointTitle}>{item.title}</h2>
+                  {item.desc && <p className={styles.pointDesc}>{item.desc}</p>}
+                  <time className={styles.pointDate}>{item.date}</time>
+                </div>
               </div>
-            </div>
-            <span className={styles.chargePoint}>+ 2</span>
-          </section>
-
-          <section className={styles.pointBox}>
-            <div className={styles.pointIconContentWrapper}>
-              <Icon id='heart-plus' />
-              <div className={styles.pointContent}>
-                <h2 className={styles.pointTitle}>게시글 포인트</h2>
-                <p className={styles.pointDesc}>뫔뫄</p>
-                <time className={styles.pointDate}>2024.06.01 15:23:00</time>
-              </div>
-            </div>
-            <span className={styles.chargePoint}>+ 3</span>
-          </section>
-
-          <section className={styles.pointBox}>
-            <div className={styles.pointIconContentWrapper}>
-              <Icon id='heart-plus' />
-              <div className={styles.pointContent}>
-                <h2 className={styles.pointTitle}>댓글 포인트</h2>
-                <p className={styles.pointDesc}>
-                  어제 간식으로 나온거 맛있던데 총학 공지에 나와있는...
-                </p>
-                <time className={styles.pointDate}>2024.06.01 15:23:00</time>
-              </div>
-            </div>
-            <span className={styles.chargePoint}>+ 1</span>
-          </section>
-
-          <section className={styles.pointBox}>
-            <div className={styles.pointIconContentWrapper}>
-              <Icon id='heart-minus' />
-              <div className={styles.pointContent}>
-                <h2 className={styles.pointTitle}>시험후기 다운로드</h2>
-                <p className={styles.pointDesc}>서양미술사/이교수</p>
-                <time className={styles.pointDate}>2024.06.01 15:23:00</time>
-              </div>
-            </div>
-            <span className={styles.chargePoint}>- 50</span>
-          </section>
-
-          <section className={styles.pointBox}>
-            <div className={styles.pointIconContentWrapper}>
-              <Icon id='heart-plus' />
-              <div className={styles.pointContent}>
-                <h2 className={styles.pointTitle}>인증 포인트</h2>
-                <time className={styles.pointDate}>2024.06.01 15:23:00</time>
-              </div>
-            </div>
-            <span className={styles.chargePoint}>+ 50</span>
-          </section>
-
-          <section className={styles.pointBox}>
-            <div className={styles.pointIconContentWrapper}>
-              <Icon id='heart-plus' />
-              <div className={styles.pointContent}>
-                <h2 className={styles.pointTitle}>신고 포상 포인트</h2>
-                <time className={styles.pointDate}>2024.06.01 15:23:00</time>
-              </div>
-            </div>
-            <span className={styles.chargePoint}>+ 10</span>
-          </section>
-
-          <section className={styles.pointBox}>
-            <div className={styles.pointIconContentWrapper}>
-              <Icon id='heart-minus' />
-              <div className={styles.pointContent}>
-                <h2 className={styles.pointTitle}>게시글 삭제 포인트</h2>
-                <p className={styles.pointDesc}>아 미친 지각 각임</p>
-                <time className={styles.pointDate}>2024.06.01 15:23:00</time>
-              </div>
-            </div>
-            <span className={styles.chargePoint}>- 3</span>
-          </section>
-
-          <section className={styles.pointBox}>
-            <div className={styles.pointIconContentWrapper}>
-              <Icon id='heart-minus' />
-              <div className={styles.pointContent}>
-                <h2 className={styles.pointTitle}>댓글 삭제 포인트</h2>
-                <p className={styles.pointDesc}>
-                  어제 간식으로 나온거 맛있던데 총학 공지에 나와있는...
-                </p>
-                <time className={styles.pointDate}>2024.06.01 15:23:00</time>
-              </div>
-            </div>
-            <span className={styles.chargePoint}>- 3</span>
-          </section>
+              <span
+                ref={(el) => (chargePointsRef.current[index] = el)}
+                className={styles.chargePoint}
+              >
+                {item.point > 0 ? `+${item.point}` : `${item.point}`}
+              </span>
+            </section>
+          ))}
         </article>
       </section>
     </main>

--- a/src/pages/MyPage/ViewPointListPage/ViewPointListPage.jsx
+++ b/src/pages/MyPage/ViewPointListPage/ViewPointListPage.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
-import { Link } from 'react-router-dom';
 import { Icon } from '../../../components/Icon';
 import styles from './ViewPointListPage.module.css';
+import { BackAppBar } from '../../../components/AppBar';
 
 export default function ViewPointListPage() {
   const chargePointsRef = useRef([]);
@@ -17,147 +17,147 @@ export default function ViewPointListPage() {
 
   return (
     <main className={styles.viewPointListPage}>
-      <div className={styles.arrowBackIconWrapper}>
-        <Link to='/my-page' className={styles.arrowBackIcon}>
-          <Icon id='arrow-back' />
-        </Link>
-      </div>
-
-      <div className={styles.topContainer}>
-        <h1 className={styles.title}>보유 포인트</h1>
-        <h1 className={styles.totalPoint}>39</h1>
-      </div>
-
-      <div className={styles.pointListContainer}>
-        <div className={styles.pointBox}>
-          <div className={styles.pointWrapper}>
-            <div className={styles.pointIconWrapper}>
-              <Icon id='heart-plus' className={styles.icon} />
-            </div>
-            <div className={styles.pointContent}>
-              <div className={styles.pointTitle}>출석 포인트</div>
-              <div className={styles.pointDate}>2024.06.01 15:23:00</div>
-            </div>
-          </div>
-          <div className={styles.pointScore}>
-            <p className={styles.chargePoint}>+ 3</p>
+      <BackAppBar stroke='#000' />
+      <section className={styles.contentWrapper}>
+        <div className={styles.topContainer}>
+          <h1 className={styles.title}>보유 포인트</h1>
+          <div className={styles.totalPointWrapper}>
+            <Icon id='point-circle' />
+            <span className={styles.totalPoint}>39</span>
           </div>
         </div>
 
-        <div className={styles.pointBox}>
-          <div className={styles.pointWrapper}>
-            <div className={styles.pointIconWrapper}>
-              <Icon id='heart-plus' className={styles.icon} />
-            </div>
-            <div className={styles.pointContent}>
-              <div className={styles.pointTitle}>게시글 포인트</div>
-              <div className={styles.pointDesc}>뫔뫄</div>
-              <div className={styles.pointDate}>2024.06.01 15:23:00</div>
-            </div>
-          </div>
-          <div className={styles.pointScore}>
-            <p className={styles.chargePoint}>+ 3</p>
-          </div>
-        </div>
-
-        <div className={styles.pointBox}>
-          <div className={styles.pointWrapper}>
-            <div className={styles.pointIconWrapper}>
-              <Icon id='heart-plus' className={styles.icon} />
-            </div>
-            <div className={styles.pointContent}>
-              <div className={styles.pointTitle}>댓글 포인트</div>
-              <div className={styles.pointDesc}>
-                어제 간식으로 나온거 맛있던데 총학 공지에 나와있는...
+        <div className={styles.pointListContainer}>
+          <div className={styles.pointBox}>
+            <div className={styles.pointWrapper}>
+              <div className={styles.pointIconWrapper}>
+                <Icon id='heart-plus' className={styles.icon} />
               </div>
-              <div className={styles.pointDate}>2024.06.01 15:23:00</div>
-            </div>
-          </div>
-          <div className={styles.pointScore}>
-            <p className={styles.chargePoint}>+ 2</p>
-          </div>
-        </div>
-
-        <div className={styles.pointBox}>
-          <div className={styles.pointWrapper}>
-            <div className={styles.pointIconWrapper}>
-              <Icon id='heart-minus' className={styles.icon} />
-            </div>
-            <div className={styles.pointContent}>
-              <div className={styles.pointTitle}>시험후기 다운로드</div>
-              <div className={styles.pointDesc}>서양미술사/이교수</div>
-              <div className={styles.pointDate}>2024.06.01 15:23:00</div>
-            </div>
-          </div>
-          <div className={styles.pointScore}>
-            <p className={styles.chargePoint}>- 50</p>
-          </div>
-        </div>
-
-        <div className={styles.pointBox}>
-          <div className={styles.pointWrapper}>
-            <div className={styles.pointIconWrapper}>
-              <Icon id='heart-plus' className={styles.icon} />
-            </div>
-            <div className={styles.pointContent}>
-              <div className={styles.pointTitle}>인증 포인트</div>
-              <div className={styles.pointDate}>2024.06.01 15:23:00</div>
-            </div>
-          </div>
-          <div className={styles.pointScore}>
-            <p className={styles.chargePoint}>+ 50</p>
-          </div>
-        </div>
-
-        <div className={styles.pointBox}>
-          <div className={styles.pointWrapper}>
-            <div className={styles.pointIconWrapper}>
-              <Icon id='heart-plus' className={styles.icon} />
-            </div>
-            <div className={styles.pointContent}>
-              <div className={styles.pointTitle}>신고 포상 포인트</div>
-              <div className={styles.pointDate}>2024.06.01 15:23:00</div>
-            </div>
-          </div>
-          <div className={styles.pointScore}>
-            <p className={styles.chargePoint}>+ 10</p>
-          </div>
-        </div>
-
-        <div className={styles.pointBox}>
-          <div className={styles.pointWrapper}>
-            <div className={styles.pointIconWrapper}>
-              <Icon id='heart-minus' className={styles.icon} />
-            </div>
-            <div className={styles.pointContent}>
-              <div className={styles.pointTitle}>게시글 삭제 포인트</div>
-              <div className={styles.pointDesc}>아미친 지각 각임</div>
-              <div className={styles.pointDate}>2024.06.01 15:23:00</div>
-            </div>
-          </div>
-          <div className={styles.pointScore}>
-            <p className={styles.chargePoint}>- 3</p>
-          </div>
-        </div>
-
-        <div className={styles.pointBox}>
-          <div className={styles.pointWrapper}>
-            <div className={styles.pointIconWrapper}>
-              <Icon id='heart-minus' className={styles.icon} />
-            </div>
-            <div className={styles.pointContent}>
-              <div className={styles.pointTitle}>댓글 삭제 포인트</div>
-              <div className={styles.pointDesc}>
-                어제 간식으로 나온거 맛있던데 총학 공지에 나와있는...
+              <div className={styles.pointContent}>
+                <div className={styles.pointTitle}>출석 포인트</div>
+                <div className={styles.pointDate}>2024.06.01 15:23:00</div>
               </div>
-              <div className={styles.pointDate}>2024.06.01 15:23:00</div>
+            </div>
+            <div className={styles.pointScore}>
+              <p className={styles.chargePoint}>+ 3</p>
             </div>
           </div>
-          <div className={styles.pointScore}>
-            <p className={styles.chargePoint}>- 3</p>
+
+          <div className={styles.pointBox}>
+            <div className={styles.pointWrapper}>
+              <div className={styles.pointIconWrapper}>
+                <Icon id='heart-plus' className={styles.icon} />
+              </div>
+              <div className={styles.pointContent}>
+                <div className={styles.pointTitle}>게시글 포인트</div>
+                <div className={styles.pointDesc}>뫔뫄</div>
+                <div className={styles.pointDate}>2024.06.01 15:23:00</div>
+              </div>
+            </div>
+            <div className={styles.pointScore}>
+              <p className={styles.chargePoint}>+ 3</p>
+            </div>
+          </div>
+
+          <div className={styles.pointBox}>
+            <div className={styles.pointWrapper}>
+              <div className={styles.pointIconWrapper}>
+                <Icon id='heart-plus' className={styles.icon} />
+              </div>
+              <div className={styles.pointContent}>
+                <div className={styles.pointTitle}>댓글 포인트</div>
+                <div className={styles.pointDesc}>
+                  어제 간식으로 나온거 맛있던데 총학 공지에 나와있는...
+                </div>
+                <div className={styles.pointDate}>2024.06.01 15:23:00</div>
+              </div>
+            </div>
+            <div className={styles.pointScore}>
+              <p className={styles.chargePoint}>+ 2</p>
+            </div>
+          </div>
+
+          <div className={styles.pointBox}>
+            <div className={styles.pointWrapper}>
+              <div className={styles.pointIconWrapper}>
+                <Icon id='heart-minus' className={styles.icon} />
+              </div>
+              <div className={styles.pointContent}>
+                <div className={styles.pointTitle}>시험후기 다운로드</div>
+                <div className={styles.pointDesc}>서양미술사/이교수</div>
+                <div className={styles.pointDate}>2024.06.01 15:23:00</div>
+              </div>
+            </div>
+            <div className={styles.pointScore}>
+              <p className={styles.chargePoint}>- 50</p>
+            </div>
+          </div>
+
+          <div className={styles.pointBox}>
+            <div className={styles.pointWrapper}>
+              <div className={styles.pointIconWrapper}>
+                <Icon id='heart-plus' className={styles.icon} />
+              </div>
+              <div className={styles.pointContent}>
+                <div className={styles.pointTitle}>인증 포인트</div>
+                <div className={styles.pointDate}>2024.06.01 15:23:00</div>
+              </div>
+            </div>
+            <div className={styles.pointScore}>
+              <p className={styles.chargePoint}>+ 50</p>
+            </div>
+          </div>
+
+          <div className={styles.pointBox}>
+            <div className={styles.pointWrapper}>
+              <div className={styles.pointIconWrapper}>
+                <Icon id='heart-plus' className={styles.icon} />
+              </div>
+              <div className={styles.pointContent}>
+                <div className={styles.pointTitle}>신고 포상 포인트</div>
+                <div className={styles.pointDate}>2024.06.01 15:23:00</div>
+              </div>
+            </div>
+            <div className={styles.pointScore}>
+              <p className={styles.chargePoint}>+ 10</p>
+            </div>
+          </div>
+
+          <div className={styles.pointBox}>
+            <div className={styles.pointWrapper}>
+              <div className={styles.pointIconWrapper}>
+                <Icon id='heart-minus' className={styles.icon} />
+              </div>
+              <div className={styles.pointContent}>
+                <div className={styles.pointTitle}>게시글 삭제 포인트</div>
+                <div className={styles.pointDesc}>아미친 지각 각임</div>
+                <div className={styles.pointDate}>2024.06.01 15:23:00</div>
+              </div>
+            </div>
+            <div className={styles.pointScore}>
+              <p className={styles.chargePoint}>- 3</p>
+            </div>
+          </div>
+
+          <div className={styles.pointBox}>
+            <div className={styles.pointWrapper}>
+              <div className={styles.pointIconWrapper}>
+                <Icon id='heart-minus' className={styles.icon} />
+              </div>
+              <div className={styles.pointContent}>
+                <div className={styles.pointTitle}>댓글 삭제 포인트</div>
+                <div className={styles.pointDesc}>
+                  어제 간식으로 나온거 맛있던데 총학 공지에 나와있는...
+                </div>
+                <div className={styles.pointDate}>2024.06.01 15:23:00</div>
+              </div>
+            </div>
+            <div className={styles.pointScore}>
+              <p className={styles.chargePoint}>- 3</p>
+            </div>
           </div>
         </div>
-      </div>
+      </section>
     </main>
   );
 }

--- a/src/pages/MyPage/ViewPointListPage/ViewPointListPage.jsx
+++ b/src/pages/MyPage/ViewPointListPage/ViewPointListPage.jsx
@@ -17,7 +17,10 @@ export default function ViewPointListPage() {
 
   return (
     <main className={styles.viewPointListPage}>
-      <BackAppBar stroke='#000' />
+      <header>
+        <BackAppBar stroke='#000' />
+      </header>
+
       <section className={styles.contentWrapper}>
         <div className={styles.topContainer}>
           <h1 className={styles.title}>보유 포인트</h1>
@@ -27,136 +30,18 @@ export default function ViewPointListPage() {
           </div>
         </div>
 
-        <div className={styles.pointListContainer}>
-          <div className={styles.pointBox}>
-            <div className={styles.pointWrapper}>
-              <div className={styles.pointIconWrapper}>
-                <Icon id='heart-plus' className={styles.icon} />
-              </div>
+        <article className={styles.pointListContainer}>
+          <section className={styles.pointBox}>
+            <div className={styles.pointIconContentWrapper}>
+              <Icon id='heart-plus' />
               <div className={styles.pointContent}>
-                <div className={styles.pointTitle}>출석 포인트</div>
-                <div className={styles.pointDate}>2024.06.01 15:23:00</div>
+                <h2 className={styles.pointTitle}>출석 포인트</h2>
+                <time className={styles.pointDate}>2024.06.01 15:23:00</time>
               </div>
             </div>
-            <div className={styles.pointScore}>
-              <p className={styles.chargePoint}>+ 3</p>
-            </div>
-          </div>
-
-          <div className={styles.pointBox}>
-            <div className={styles.pointWrapper}>
-              <div className={styles.pointIconWrapper}>
-                <Icon id='heart-plus' className={styles.icon} />
-              </div>
-              <div className={styles.pointContent}>
-                <div className={styles.pointTitle}>게시글 포인트</div>
-                <div className={styles.pointDesc}>뫔뫄</div>
-                <div className={styles.pointDate}>2024.06.01 15:23:00</div>
-              </div>
-            </div>
-            <div className={styles.pointScore}>
-              <p className={styles.chargePoint}>+ 3</p>
-            </div>
-          </div>
-
-          <div className={styles.pointBox}>
-            <div className={styles.pointWrapper}>
-              <div className={styles.pointIconWrapper}>
-                <Icon id='heart-plus' className={styles.icon} />
-              </div>
-              <div className={styles.pointContent}>
-                <div className={styles.pointTitle}>댓글 포인트</div>
-                <div className={styles.pointDesc}>
-                  어제 간식으로 나온거 맛있던데 총학 공지에 나와있는...
-                </div>
-                <div className={styles.pointDate}>2024.06.01 15:23:00</div>
-              </div>
-            </div>
-            <div className={styles.pointScore}>
-              <p className={styles.chargePoint}>+ 2</p>
-            </div>
-          </div>
-
-          <div className={styles.pointBox}>
-            <div className={styles.pointWrapper}>
-              <div className={styles.pointIconWrapper}>
-                <Icon id='heart-minus' className={styles.icon} />
-              </div>
-              <div className={styles.pointContent}>
-                <div className={styles.pointTitle}>시험후기 다운로드</div>
-                <div className={styles.pointDesc}>서양미술사/이교수</div>
-                <div className={styles.pointDate}>2024.06.01 15:23:00</div>
-              </div>
-            </div>
-            <div className={styles.pointScore}>
-              <p className={styles.chargePoint}>- 50</p>
-            </div>
-          </div>
-
-          <div className={styles.pointBox}>
-            <div className={styles.pointWrapper}>
-              <div className={styles.pointIconWrapper}>
-                <Icon id='heart-plus' className={styles.icon} />
-              </div>
-              <div className={styles.pointContent}>
-                <div className={styles.pointTitle}>인증 포인트</div>
-                <div className={styles.pointDate}>2024.06.01 15:23:00</div>
-              </div>
-            </div>
-            <div className={styles.pointScore}>
-              <p className={styles.chargePoint}>+ 50</p>
-            </div>
-          </div>
-
-          <div className={styles.pointBox}>
-            <div className={styles.pointWrapper}>
-              <div className={styles.pointIconWrapper}>
-                <Icon id='heart-plus' className={styles.icon} />
-              </div>
-              <div className={styles.pointContent}>
-                <div className={styles.pointTitle}>신고 포상 포인트</div>
-                <div className={styles.pointDate}>2024.06.01 15:23:00</div>
-              </div>
-            </div>
-            <div className={styles.pointScore}>
-              <p className={styles.chargePoint}>+ 10</p>
-            </div>
-          </div>
-
-          <div className={styles.pointBox}>
-            <div className={styles.pointWrapper}>
-              <div className={styles.pointIconWrapper}>
-                <Icon id='heart-minus' className={styles.icon} />
-              </div>
-              <div className={styles.pointContent}>
-                <div className={styles.pointTitle}>게시글 삭제 포인트</div>
-                <div className={styles.pointDesc}>아미친 지각 각임</div>
-                <div className={styles.pointDate}>2024.06.01 15:23:00</div>
-              </div>
-            </div>
-            <div className={styles.pointScore}>
-              <p className={styles.chargePoint}>- 3</p>
-            </div>
-          </div>
-
-          <div className={styles.pointBox}>
-            <div className={styles.pointWrapper}>
-              <div className={styles.pointIconWrapper}>
-                <Icon id='heart-minus' className={styles.icon} />
-              </div>
-              <div className={styles.pointContent}>
-                <div className={styles.pointTitle}>댓글 삭제 포인트</div>
-                <div className={styles.pointDesc}>
-                  어제 간식으로 나온거 맛있던데 총학 공지에 나와있는...
-                </div>
-                <div className={styles.pointDate}>2024.06.01 15:23:00</div>
-              </div>
-            </div>
-            <div className={styles.pointScore}>
-              <p className={styles.chargePoint}>- 3</p>
-            </div>
-          </div>
-        </div>
+            <span className={styles.chargePoint}>+ 3</span>
+          </section>
+        </article>
       </section>
     </main>
   );

--- a/src/pages/MyPage/ViewPointListPage/ViewPointListPage.module.css
+++ b/src/pages/MyPage/ViewPointListPage/ViewPointListPage.module.css
@@ -1,42 +1,50 @@
 .viewPointListPage {
   display: flex;
   flex-direction: column;
-  padding: 1.125rem;
-  width: 100%;
-  gap: 1.125rem;
 }
 
-.arrowBackIconWrapper {
+.contentWrapper {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  padding: 0 1.25rem 100px 1.25rem;
   width: 100%;
-}
-
-.arrowBackIcon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 1rem;
-  height: 1rem;
-  padding: 0.625rem;
+  gap: 14px;
 }
 
 .topContainer {
   display: flex;
   justify-content: space-between;
+  padding: 14px 0;
 }
 
 .title {
+  font-size: 20px;
+  font-weight: 700;
+  line-height: 130%;
+  letter-spacing: -0.5px;
+}
+
+.totalPointWrapper {
   display: flex;
   justify-content: center;
-  font-size: 1rem;
-  font-weight: 700;
+  align-items: center;
+  gap: 4px;
+
+  svg {
+    width: 17px;
+    height: 17px;
+  }
 }
 
 .totalPoint {
-  font-size: 1rem;
+  color: var(--Blue-4, #00368e);
+  font-size: 14px;
   font-weight: 500;
+  line-height: 150%;
+  letter-spacing: -0.5px;
 }
+
+/* 위까지 수정완료 */
 
 .pointListContainer {
   display: flex;

--- a/src/pages/MyPage/ViewPointListPage/ViewPointListPage.module.css
+++ b/src/pages/MyPage/ViewPointListPage/ViewPointListPage.module.css
@@ -56,7 +56,7 @@
   align-items: center;
   border-radius: 5px;
   background: var(--Grey-1-1, #f4f4f4);
-  padding: 17px 15px;
+  padding: 15px;
 }
 
 .pointIconContentWrapper {
@@ -104,4 +104,8 @@
   font-weight: 500;
   line-height: 150%;
   letter-spacing: -0.5px;
+}
+
+.negative {
+  color: var(--Pink-2, #ff4b6c);
 }

--- a/src/pages/MyPage/ViewPointListPage/ViewPointListPage.module.css
+++ b/src/pages/MyPage/ViewPointListPage/ViewPointListPage.module.css
@@ -43,6 +43,7 @@
   letter-spacing: -0.5px;
 }
 
+/* 포인트 내역 */
 .pointListContainer {
   display: flex;
   flex-direction: column;
@@ -85,7 +86,7 @@
 
 .pointDesc {
   color: var(--grey-3, #484848);
-  font-style: normal;
+  font-size: 9px;
   line-height: 150%;
   letter-spacing: -0.5px;
 }

--- a/src/pages/MyPage/ViewPointListPage/ViewPointListPage.module.css
+++ b/src/pages/MyPage/ViewPointListPage/ViewPointListPage.module.css
@@ -8,7 +8,6 @@
   flex-direction: column;
   padding: 0 1.25rem 100px 1.25rem;
   width: 100%;
-  gap: 14px;
 }
 
 .topContainer {
@@ -44,68 +43,64 @@
   letter-spacing: -0.5px;
 }
 
-/* 위까지 수정완료 */
-
 .pointListContainer {
   display: flex;
   flex-direction: column;
+  gap: 10px;
 }
 
 .pointBox {
   display: flex;
   justify-content: space-between;
-  border-bottom: 1px solid #c7c7c7;
-  padding: 0.375rem 0;
+  align-items: center;
+  border-radius: 5px;
+  background: var(--Grey-1-1, #f4f4f4);
+  padding: 17px 15px;
 }
 
-.pointWrapper {
+.pointIconContentWrapper {
   display: flex;
-}
+  align-items: center;
+  gap: 15px;
 
-.pointIconWrapper {
-  display: flex;
-  width: 1.5rem;
-  height: 1.5rem;
-}
-
-.icon {
-  width: 100%;
-  height: auto;
-  padding: 4px 0;
+  svg {
+    width: 26px;
+    height: 23px;
+  }
 }
 
 .pointContent {
   display: flex;
   flex-direction: column;
-  padding: 0 0.625rem;
-  gap: 0.2rem;
+  gap: 3px;
 }
 
 .pointTitle {
-  font-size: 0.75rem;
+  color: var(--Blue-4, #00368e);
+  font-size: 12px;
   font-weight: 500;
+  line-height: 150%;
+  letter-spacing: -0.5px;
 }
 
 .pointDesc {
-  font-size: 0.5rem;
+  color: var(--grey-3, #484848);
+  font-style: normal;
+  line-height: 150%;
+  letter-spacing: -0.5px;
 }
 
 .pointDate {
-  color: #aeaeae;
-  font-size: 0.5rem;
-}
-
-.pointScore {
-  display: flex;
-  justify-content: flex-end;
+  color: var(--Grey-3-1, #898989);
+  font-size: 9px;
+  line-height: 150%;
+  letter-spacing: -0.5px;
 }
 
 .chargePoint {
-  color: #5f86bf;
-  text-align: right;
-  font-size: 0.75rem;
-  font-weight: 700;
-}
-.negative {
-  color: #ff4b6c;
+  color: var(--Blue-4, #00368e);
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 150%;
+  letter-spacing: -0.5px;
 }


### PR DESCRIPTION
## 🎯 관련 이슈

close #87

<br />

## 🚀 작업 내용

- 포인트 내역 보기 페이지 view 구현
- 상단에 BackAppBar 컴포넌트 사용
- 포인트 내역은 더미데이터 사용 (API는 추후 연동 예정)

<br />

## 📸 스크린샷

|<img width="289" alt="image" src="https://github.com/user-attachments/assets/a72248ad-8c83-4ef6-990d-432070871bb0"> |
| :---------------------: |
|포인트 내역 보기 |



<br />

