### PR TITLE
#105 [FIX] 시험후기 리스트 API 에러 핸들링

### DIFF
--- a/src/ProtectedRoute.jsx
+++ b/src/ProtectedRoute.jsx
@@ -3,6 +3,7 @@ import { USER } from './dummy/data';
 
 export default function ProtectedRoute({ roles, children }) {
   if (!USER || !USER.isLogin) {
+    alert('로그인이 필요한 기능입니다.');
     return <Navigate to='/' replace={true} />;
   }
 

--- a/src/apis/examReview.js
+++ b/src/apis/examReview.js
@@ -3,13 +3,8 @@ import { authAxios } from '../axios';
 const ENDPOINT = '/v1/reviews/review';
 
 export const getReviewList = async (page = 0) => {
-  try {
-    const response = await authAxios.get(`/v1/reviews/32/list/${page}`);
-    return response.data.result;
-  } catch (error) {
-    console.error(error);
-    alert('데이터를 불러오지 못 했습니다.');
-  }
+  const response = await authAxios.get(`/v1/reviews/32/list/${page}`);
+  return response.data.result;
 };
 
 export const postExamReview = async ({ data, file }) => {

--- a/src/contexts/ToastContext.jsx
+++ b/src/contexts/ToastContext.jsx
@@ -1,16 +1,18 @@
 import { createContext, useState, useContext } from 'react';
-import Toast from '../components/Toast/Toast.jsx';
+import { Toast } from '../components/Toast';
 
 const ToastContext = createContext();
 
 export function ToastProvider({ children }) {
   const [toasts, setToasts] = useState([]);
+
   const addToast = (toast) => {
     if (toasts.find((item) => item.id === toast.id)) {
       removeToast(toast);
     }
     setToasts((prev) => [...prev, toast]);
   };
+
   const removeToast = (toast) => {
     setToasts((prev) => prev.filter((item) => item.id !== toast.id));
   };

--- a/src/index.js
+++ b/src/index.js
@@ -157,7 +157,13 @@ const router = createBrowserRouter([
   },
 ]);
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 0,
+    },
+  },
+});
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(

--- a/src/pages/ExamReviewPage/ExamReviewPage/ExamReviewPage.jsx
+++ b/src/pages/ExamReviewPage/ExamReviewPage/ExamReviewPage.jsx
@@ -15,17 +15,18 @@ import { getReviewList } from '../../../apis/examReview.js';
 import styles from './ExamReviewPage.module.css';
 
 export default function ExamReviewPage() {
-  const { data, hasNextPage, isFetching, fetchNextPage } = useInfiniteQuery({
-    queryKey: ['reviewList'],
-    queryFn: ({ pageParam }) => getReviewList(pageParam),
-    initialPageParam: 0,
-    getNextPageParam: (lastPage, allPages, lastPageParam) => {
-      if (lastPage.length === 0) {
-        return undefined;
-      }
-      return lastPageParam + 1;
-    },
-  });
+  const { data, hasNextPage, isFetching, status, fetchNextPage } =
+    useInfiniteQuery({
+      queryKey: ['reviewList'],
+      queryFn: ({ pageParam }) => getReviewList(pageParam),
+      initialPageParam: 0,
+      getNextPageParam: (lastPage, allPages, lastPageParam) => {
+        if (lastPage?.length === 0) {
+          return undefined;
+        }
+        return lastPageParam + 1;
+      },
+    });
 
   const ref = useIntersect(
     async (entry, observer) => {
@@ -49,15 +50,16 @@ export default function ExamReviewPage() {
       />
       <PTR>
         <ul className={styles.list}>
-          {reviewList.map((post) => (
-            <Link
-              className={styles.to}
-              key={post.postId}
-              to={`/review/${post.postId}`}
-            >
-              <PostBar data={post} />
-            </Link>
-          ))}
+          {status !== 'error' &&
+            reviewList.map((post) => (
+              <Link
+                className={styles.to}
+                key={post.postId}
+                to={`/review/${post.postId}`}
+              >
+                <PostBar data={post} />
+              </Link>
+            ))}
         </ul>
         {isFetching && <Loading />}
         <Target ref={ref} height='100px' />


### PR DESCRIPTION
## 🎯 관련 이슈

close #105

<br />

## 📸 스크린샷

| <img width="323" alt="image" src="https://github.com/user-attachments/assets/6041af2c-afd6-4209-a317-174118f621d5"> |
| :---------------------: |
| API 에러가 발생한 경우 |

<br />

## 🔎 발견된 장애가 있었나요?

- 시험후기 리스트 API가 에러를 응답으로 보낼 때 화면이 죽어버리는 문제가 발생했습니다.
- 에러를 응답으로 받아도 화면이 죽지 않도록, `useInfiniteQuery`에서 `status`를 꺼내 값이 'error'이면 응답 결과를 렌더링하지 못하게 막았습니다.

## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

- ProtectedRoute.jsx 로그인 권한 확인 로직에 alert 추가했습니다.
- 미로그인 사용자가 로그인이 필요한 기능에 접근 시 alert으로 경고창이 발생한 후 메인 페이지로 돌아갑니다.