### PR TITLE
#101 [FEAT] 로그인 상태에 따라 Header에 로그인/로그아웃 버튼 핸들링

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,13 +1,31 @@
+import { Link } from 'react-router-dom';
+
 import { Icon } from '../../components/Icon';
 import { MenuIcon } from '../MenuIcon';
 import styles from './Header.module.css';
+
+import { USER } from '../../dummy/data';
 
 export default function Header({ className }) {
   return (
     <>
       <header className={`${styles.header} ${className}`}>
         <Icon id='logo' width={151} height={27} />
-        <MenuIcon />
+        <div className={styles.action}>
+          {USER.isLogin ? (
+            <button
+              className={styles.button}
+              onClick={() => localStorage.removeItem('token')}
+            >
+              로그아웃
+            </button>
+          ) : (
+            <Link className={styles.button} to='/login'>
+              로그인
+            </Link>
+          )}
+          <MenuIcon />
+        </div>
       </header>
     </>
   );

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -6,8 +6,18 @@
   align-items: center;
 }
 
-.login {
+.action {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.button {
   background-color: white;
-  color: #00368e;
   font-weight: bold;
+  font-weight: 500;
+  font-size: 13px;
+  line-height: 130%;
+  letter-spacing: -0.5px;
+  color: #00368e;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100..900&display=swap');
+@import url('https://spoqa.github.io/spoqa-han-sans/css/SpoqaHanSansNeo.css');
 
 :root {
   --default-margin: 1.25rem;
@@ -89,6 +90,7 @@ html {
 body {
   margin: 0;
   font-family:
+    'Spoqa Han Sans Neo',
     'Noto Sans KR',
     -apple-system,
     BlinkMacSystemFont,


### PR DESCRIPTION
## 🎯 관련 이슈

close #101

<br />

## 🚀 작업 내용

- 로그인 상태에 따라 Header에 로그인/로그아웃 버튼 핸들링

<br />

## 📸 스크린샷

| <img width="323" alt="image" src="https://github.com/user-attachments/assets/b567be33-e283-4dd7-bd4a-cb9baa58ddcd"> | <img width="323" alt="image" src="https://github.com/user-attachments/assets/1b09bed6-4da8-45f6-975c-47e83d3dc7cd"> |
| :---------------------: | :---------------------: |
| 로그인 상태인 경우 | 미로그인 상태인 경우 |


