### PR TITLE
#69 [MODIFY] 회원탈퇴 페이지 UI 수정 및 API 연동

### DIFF
--- a/src/apis/userInfo.js
+++ b/src/apis/userInfo.js
@@ -1,0 +1,19 @@
+import { authAxios } from '../axios';
+
+const ENDPOINT = '/v1/users';
+
+export const withdrawAccount = async (navigate) => {
+  try {
+    const response = await authAxios.delete(`${ENDPOINT}/withdraw`);
+
+    if (response.status === 200) {
+      alert('회원 탈퇴가 완료되었습니다.');
+      navigate('/home');
+    }
+
+    return response;
+  } catch (error) {
+    alert('회원 탈퇴에 실패했습니다. 다시 시도해주세요.');
+    return error.response;
+  }
+};

--- a/src/pages/MyPage/DeleteAccountPage/DeleteAccountPage.jsx
+++ b/src/pages/MyPage/DeleteAccountPage/DeleteAccountPage.jsx
@@ -1,24 +1,17 @@
-import { Link } from 'react-router-dom';
-
-import { Icon } from '../../../components/Icon';
-
 import styles from './DeleteAccountPage.module.css';
+import { Link } from 'react-router-dom';
+import { CloseAppBar } from '../../../components/AppBar';
 
 const descriptions = [
-  '• 아이디, 이메일, 학번은 .. 목적으로 6개월간 보관됩니다',
-  '• 보유 포인트 및 포인트 기록은 복구가 불가능합니다',
-  '• 등등..',
+  '• 회원탈퇴 시 모든 정보가 영구적으로 삭제되며, 다시는 복구할 수 없습니다.',
+  '• 보유 포인트 및 포인트 기록은 복구가 불가능합니다.',
 ];
 
 export default function DeleteAccountPage() {
   return (
     <main className={styles.deleteAccountPage}>
-      <div className={styles.closeIconWrapper}>
-        <Link to='/my-page' className={styles.closeIcon}>
-          <Icon id='x' />
-        </Link>
-      </div>
-      <div className={styles.titleDescWrapper}>
+      <CloseAppBar alignRight={true} stroke='#000' />
+      <section className={styles.titleDescWrapper}>
         <h1 className={styles.title}>탈퇴 시 아래 내용을 확인해주세요</h1>
         <div className={styles.descWrapper}>
           {descriptions.map((desc, index) => (
@@ -27,9 +20,9 @@ export default function DeleteAccountPage() {
             </p>
           ))}
         </div>
-      </div>
+      </section>
       <div className={styles.buttonWrapper}>
-        <Link to='/my-page' className={styles.goBackButton}>
+        <Link to='/my-page?tab=policy' className={styles.goBackButton}>
           뒤로가기
         </Link>
         <button className={styles.deleteAccountButton}>탈퇴하기</button>

--- a/src/pages/MyPage/DeleteAccountPage/DeleteAccountPage.jsx
+++ b/src/pages/MyPage/DeleteAccountPage/DeleteAccountPage.jsx
@@ -8,6 +8,10 @@ const descriptions = [
 ];
 
 export default function DeleteAccountPage() {
+  const handleDeleteAccount = () => {
+    alert('정말 탈퇴하시겠습니까?');
+  };
+
   return (
     <main className={styles.deleteAccountPage}>
       <CloseAppBar alignRight={true} stroke='#000' />
@@ -25,7 +29,12 @@ export default function DeleteAccountPage() {
         <Link to='/my-page?tab=policy' className={styles.goBackButton}>
           뒤로가기
         </Link>
-        <button className={styles.deleteAccountButton}>탈퇴하기</button>
+        <button
+          className={styles.deleteAccountButton}
+          onClick={handleDeleteAccount}
+        >
+          탈퇴하기
+        </button>
       </div>
     </main>
   );

--- a/src/pages/MyPage/DeleteAccountPage/DeleteAccountPage.jsx
+++ b/src/pages/MyPage/DeleteAccountPage/DeleteAccountPage.jsx
@@ -22,27 +22,31 @@ export default function DeleteAccountPage() {
   return (
     <main className={styles.deleteAccountPage}>
       <CloseAppBar alignRight={true} stroke='#000' />
-      <section className={styles.titleDescWrapper}>
-        <h1 className={styles.title}>탈퇴 시 아래 내용을 확인해주세요</h1>
-        <div className={styles.descWrapper}>
-          {descriptions.map((desc, index) => (
-            <p key={index} className={styles.desc}>
-              {desc}
-            </p>
-          ))}
+
+      <section className={styles.contentContainer}>
+        <div className={styles.titleDescWrapper}>
+          <h1 className={styles.title}>탈퇴 시 아래 내용을 확인해주세요</h1>
+          <div className={styles.descWrapper}>
+            {descriptions.map((desc, index) => (
+              <p key={index} className={styles.desc}>
+                {desc}
+              </p>
+            ))}
+          </div>
+        </div>
+
+        <div className={styles.buttonWrapper}>
+          <Link to='/my-page?tab=policy' className={styles.goBackButton}>
+            뒤로가기
+          </Link>
+          <button
+            className={styles.deleteAccountButton}
+            onClick={handleDeleteAccount}
+          >
+            탈퇴하기
+          </button>
         </div>
       </section>
-      <div className={styles.buttonWrapper}>
-        <Link to='/my-page?tab=policy' className={styles.goBackButton}>
-          뒤로가기
-        </Link>
-        <button
-          className={styles.deleteAccountButton}
-          onClick={handleDeleteAccount}
-        >
-          탈퇴하기
-        </button>
-      </div>
     </main>
   );
 }

--- a/src/pages/MyPage/DeleteAccountPage/DeleteAccountPage.jsx
+++ b/src/pages/MyPage/DeleteAccountPage/DeleteAccountPage.jsx
@@ -1,6 +1,8 @@
 import styles from './DeleteAccountPage.module.css';
 import { Link } from 'react-router-dom';
 import { CloseAppBar } from '../../../components/AppBar';
+import { withdrawAccount } from '../../../apis/userInfo';
+import { useNavigate } from 'react-router-dom';
 
 const descriptions = [
   '• 회원탈퇴 시 모든 정보가 영구적으로 삭제되며, 다시는 복구할 수 없습니다.',
@@ -8,8 +10,13 @@ const descriptions = [
 ];
 
 export default function DeleteAccountPage() {
-  const handleDeleteAccount = () => {
-    alert('정말 탈퇴하시겠습니까?');
+  const navigate = useNavigate();
+
+  const handleDeleteAccount = async () => {
+    const confirmation = window.confirm('정말로 탈퇴하시겠습니까?');
+    if (confirmation) {
+      await withdrawAccount(navigate);
+    }
   };
 
   return (

--- a/src/pages/MyPage/DeleteAccountPage/DeleteAccountPage.module.css
+++ b/src/pages/MyPage/DeleteAccountPage/DeleteAccountPage.module.css
@@ -1,15 +1,20 @@
 .deleteAccountPage {
   display: flex;
   flex-direction: column;
-  padding: 1.25rem;
   width: 100%;
   height: 100vh;
+}
+
+.contentContainer {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 1.25rem;
 }
 
 .titleDescWrapper {
   display: flex;
   flex-direction: column;
-  padding-top: 14px;
   gap: 14px;
   flex-grow: 1;
 }

--- a/src/pages/MyPage/DeleteAccountPage/DeleteAccountPage.module.css
+++ b/src/pages/MyPage/DeleteAccountPage/DeleteAccountPage.module.css
@@ -6,29 +6,11 @@
   height: 100vh;
 }
 
-/* 삭제 아이콘 */
-.closeIconWrapper {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  padding: 0.4375rem 0;
-  width: 100%;
-}
-
-.closeIcon {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 1rem;
-  height: 1rem;
-}
-
-/* 본문 */
 .titleDescWrapper {
   display: flex;
   flex-direction: column;
-  padding: 0.4375rem 0;
-  gap: 0.875rem;
+  padding-top: 14px;
+  gap: 14px;
   flex-grow: 1;
 }
 


### PR DESCRIPTION
## 🎯 관련 이슈

close #69

<br />

## 🚀 작업 내용

- close 버튼 구현
- 탈퇴 관련 문구 내용 일부 수정
- `뒤로가기` 버튼 클릭시 이전 페이지의 해당 탭으로 이동하는 기능 구현
- `탈퇴하기` 버튼 클릭시 alert창 띄우는 기능 구현
- 회원탈퇴 API 연동

  <img width="400" alt="image" src="https://github.com/user-attachments/assets/3341ad62-9dbd-470b-8437-39a79313390e">

<br />

## 📸 스크린샷

| <image src="https://github.com/user-attachments/assets/652118f0-f7eb-4280-a383-738ef0aca4dd" width="250"> |
| :---------------------: |
|회원 탈퇴 페이지 |




<br />


