### PR TITLE
#126 [FEAT] 회원탈퇴 API 코드 개선 및 비밀번호 확인 입력창 추가

### DIFF
--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -1,19 +1,5 @@
-import { getPostList } from './postList.js';
-import {
-  deleteExamReview,
-  downloadExamReview,
-  editReviewDetail,
-  getReviewDetail,
-  getReviewList,
-  postExamReview,
-} from './examReview.js';
-
-export {
-  deleteExamReview,
-  downloadExamReview,
-  editReviewDetail,
-  getPostList,
-  getReviewDetail,
-  getReviewList,
-  postExamReview,
-};
+export * from './comment';
+export * from './examReview';
+export * from './postContent';
+export * from './postList';
+export * from './userInfo';

--- a/src/apis/userInfo.js
+++ b/src/apis/userInfo.js
@@ -1,19 +1,9 @@
 import { authAxios } from '../axios';
 
-const ENDPOINT = '/v1/users';
+export const withdrawAccount = async (body) => {
+  const { data } = await authAxios.delete('/v1/users/withdraw', {
+    data: body,
+  });
 
-export const withdrawAccount = async (navigate) => {
-  try {
-    const response = await authAxios.delete(`${ENDPOINT}/withdraw`);
-
-    if (response.status === 200) {
-      alert('회원 탈퇴가 완료되었습니다.');
-      navigate('/home');
-    }
-
-    return response;
-  } catch (error) {
-    alert('회원 탈퇴에 실패했습니다. 다시 시도해주세요.');
-    return error.response;
-  }
+  return data;
 };

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom';
+import { withdrawAccount } from '@/apis';
 
 const useAuth = () => {
   const navigate = useNavigate();
@@ -8,8 +9,21 @@ const useAuth = () => {
     navigate('/');
   };
 
+  const withdraw = async (currentPassword) => {
+    try {
+      await withdrawAccount({
+        currentPassword,
+      });
+      alert('회원 탈퇴가 완료되었습니다.');
+      logout();
+    } catch {
+      alert('회원 탈퇴에 실패했습니다. 다시 시도해주세요.');
+    }
+  };
+
   return {
     logout,
+    withdraw,
   };
 };
 

--- a/src/pages/MyPage/DeleteAccountPage/DeleteAccountPage.jsx
+++ b/src/pages/MyPage/DeleteAccountPage/DeleteAccountPage.jsx
@@ -1,8 +1,9 @@
 import styles from './DeleteAccountPage.module.css';
 import { Link } from 'react-router-dom';
 import { CloseAppBar } from '../../../components/AppBar';
-import { withdrawAccount } from '../../../apis/userInfo';
-import { useNavigate } from 'react-router-dom';
+
+import { useState } from 'react';
+import { useAuth } from '@/hooks';
 
 const descriptions = [
   '• 회원탈퇴 시 모든 정보가 영구적으로 삭제되며, 다시는 복구할 수 없습니다.',
@@ -10,12 +11,18 @@ const descriptions = [
 ];
 
 export default function DeleteAccountPage() {
-  const navigate = useNavigate();
+  const { withdraw } = useAuth();
+  const [password, setPassword] = useState('');
 
-  const handleDeleteAccount = async () => {
+  const handlePasswordInputChange = (event) => {
+    setPassword(event.target.value);
+  };
+
+  const handleDeleteAccountButtonClick = () => {
     const confirmation = window.confirm('정말로 탈퇴하시겠습니까?');
+
     if (confirmation) {
-      await withdrawAccount(navigate);
+      withdraw(password);
     }
   };
 
@@ -33,6 +40,12 @@ export default function DeleteAccountPage() {
               </p>
             ))}
           </div>
+
+          <input
+            type='password'
+            value={password}
+            onChange={handlePasswordInputChange}
+          />
         </div>
 
         <div className={styles.buttonWrapper}>
@@ -41,7 +54,7 @@ export default function DeleteAccountPage() {
           </Link>
           <button
             className={styles.deleteAccountButton}
-            onClick={handleDeleteAccount}
+            onClick={handleDeleteAccountButtonClick}
           >
             탈퇴하기
           </button>


### PR DESCRIPTION
## 🎯 관련 이슈

close #126

<br />

## 🚀 작업 내용

- 회원탈퇴 API 코드 개선
- 비밀번호 확인 입력창 임시 추가
- 회원 정보 관련 API 파일 생성

<br />

## 📸 스크린샷

| <image width='250' src='https://github.com/user-attachments/assets/c726a147-59ca-4c17-98e1-2af1f03aadb6' >|
| :---------------------: |
|회원 탈퇴 페이지|

<br />

## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

- 비밀번호를 입력해야 회원탈퇴 가능합니다. 그런데 현 UI에는 비밀번호 입력창이 없으므로, 디자이너에게 해당 부분 수정 작업을 요청해두었습니다. 디자인 수정 완료 후에 기능 완성하도록 하겠습니다.

<br />

