### PR TITLE
#131 [MODIFY] bottom navigation이 필요없는 페이지는 제거 및 padding-bottom 크기 조정

### DIFF
--- a/src/pages/MyPage/ActivityPage/ActivityPage.module.css
+++ b/src/pages/MyPage/ActivityPage/ActivityPage.module.css
@@ -2,12 +2,13 @@
   display: flex;
   position: relative;
   flex-direction: column;
+  height: 100vh;
 }
 
 .contentWrapper {
   display: flex;
   flex-direction: column;
-  padding: 0 1.25rem 100px 1.25rem;
+  padding: 0 1.25rem 54px 1.25rem;
   width: 100%;
 }
 
@@ -26,6 +27,7 @@
 
 .contentListContainer {
   display: flex;
+  height: 100%;
   flex-direction: column;
   gap: 8px;
   margin-bottom: 100px;
@@ -35,10 +37,10 @@
   display: flex;
   position: fixed;
   margin: 0 auto;
-  bottom: 103px;
+  bottom: 54px;
   padding: 0 20px;
   width: 100%;
-  max-width: 450px;
+  max-width: 600px;
   background-size: cover;
 }
 

--- a/src/pages/MyPage/DeleteAccountPage/DeleteAccountPage.module.css
+++ b/src/pages/MyPage/DeleteAccountPage/DeleteAccountPage.module.css
@@ -9,12 +9,12 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  padding: 1.25rem;
 }
 
 .titleDescWrapper {
   display: flex;
   flex-direction: column;
+  padding: 20px;
   gap: 14px;
   flex-grow: 1;
 }
@@ -49,7 +49,7 @@
   bottom: 0;
   width: 100%;
   gap: 0.5rem;
-  padding-bottom: 6.25rem;
+  padding: 20px 20px 54px;
 }
 
 .goBackButton {

--- a/src/pages/MyPage/PolicyPage/PolicyPage.module.css
+++ b/src/pages/MyPage/PolicyPage/PolicyPage.module.css
@@ -6,7 +6,7 @@
 .contentWrapper {
   display: flex;
   flex-direction: column;
-  padding: 0 1.25rem 100px 1.25rem;
+  padding: 0 1.25rem 54px 1.25rem;
   width: 100%;
   gap: 14px;
 }

--- a/src/pages/MyPage/ViewPointListPage/ViewPointListPage.jsx
+++ b/src/pages/MyPage/ViewPointListPage/ViewPointListPage.jsx
@@ -60,6 +60,20 @@ const pointData = [
     date: '2024.06.01 15:23:00',
     point: -3,
   },
+  {
+    id: 8,
+    title: '댓글 삭제 포인트',
+    desc: '어제 간식으로 나온거 맛있던데 총학 공지에 나와있는...',
+    date: '2024.06.01 15:23:00',
+    point: -3,
+  },
+  {
+    id: 8,
+    title: '댓글 삭제 포인트',
+    desc: '어제 간식으로 나온거 맛있던데 총학 공지에 나와있는...',
+    date: '2024.06.01 15:23:00',
+    point: -3,
+  },
 ];
 
 export default function ViewPointListPage() {

--- a/src/pages/MyPage/ViewPointListPage/ViewPointListPage.module.css
+++ b/src/pages/MyPage/ViewPointListPage/ViewPointListPage.module.css
@@ -7,7 +7,7 @@
 .contentWrapper {
   display: flex;
   flex-direction: column;
-  padding: 0 1.25rem 42px 1.25rem;
+  padding: 0 1.25rem 54px 1.25rem;
   width: 100%;
 }
 

--- a/src/pages/MyPage/ViewPointListPage/ViewPointListPage.module.css
+++ b/src/pages/MyPage/ViewPointListPage/ViewPointListPage.module.css
@@ -1,12 +1,13 @@
 .viewPointListPage {
   display: flex;
   flex-direction: column;
+  height: 100vh;
 }
 
 .contentWrapper {
   display: flex;
   flex-direction: column;
-  padding: 0 1.25rem 100px 1.25rem;
+  padding: 0 1.25rem 42px 1.25rem;
   width: 100%;
 }
 

--- a/src/route.js
+++ b/src/route.js
@@ -164,6 +164,9 @@ export const routeList = [
       {
         path: '/my-page/view-point-list',
         element: <ViewPointListPage />,
+        meta: {
+          hideNav: true,
+        },
       },
       {
         path: '/my-page/delete-account',

--- a/src/route.js
+++ b/src/route.js
@@ -81,13 +81,31 @@ export const routeList = [
     element: <App />,
     errorElement: <ErrorPage />,
     children: [
-      { index: true, element: <MainPage /> },
-      { path: '/home', element: <MainPage /> },
-      { path: '/board', element: <BoardPage /> },
+      {
+        index: true,
+        element: <MainPage />,
+      },
+      {
+        path: '/home',
+        element: <MainPage />,
+      },
+      {
+        path: '/board',
+        element: <BoardPage />,
+      },
       ...boardRoutes,
-      { path: '/post', element: <PostPage /> },
-      { path: '/search/post', element: <PostSearchPage /> },
-      { path: '/post-write', element: <PostWritePage /> },
+      {
+        path: '/post',
+        element: <PostPage />,
+      },
+      {
+        path: '/search/post',
+        element: <PostSearchPage />,
+      },
+      {
+        path: '/post-write',
+        element: <PostWritePage />,
+      },
       {
         path: '/exam-review',
         element: (
@@ -103,70 +121,156 @@ export const routeList = [
             <ExamReviewDetailPage />
           </ProtectedRoute>
         ),
-        meta: { hideNav: true },
+        meta: {
+          hideNav: true,
+        },
       },
       {
         path: '/exam-review/:postId/edit',
         element: <ExamReviewEditPage />,
-        meta: { hideNav: true },
+        meta: {
+          hideNav: true,
+        },
       },
       {
         path: '/exam-review-write',
         element: <ExamReviewWritePage />,
-        meta: { hideNav: true },
+        meta: {
+          hideNav: true,
+        },
       },
-      { path: '/alert', element: <AlertPage /> },
-      { path: '/my-page', element: <MyPage /> },
-      { path: '/my-page/password', element: <ChangePasswordPage /> },
-      { path: '/my-page/edit-info', element: <EditInfoPage /> },
-      { path: '/my-page/view-point-list', element: <ViewPointListPage /> },
-      { path: '/my-page/delete-account', element: <DeleteAccountPage /> },
-      { path: '/my-page/privacy-policy', element: <PrivacyPolicyPage /> },
-      { path: '/my-page/service-policy', element: <ServicePolicyPage /> },
-      { path: '/my-page/my-post', element: <MyPostPage /> },
-      { path: '/my-page/comment', element: <CommentPage /> },
+      {
+        path: '/alert',
+        element: <AlertPage />,
+      },
+      {
+        path: '/my-page',
+        element: <MyPage />,
+      },
+      {
+        path: '/my-page/password',
+        element: <ChangePasswordPage />,
+        meta: {
+          hideNav: true,
+        },
+      },
+      {
+        path: '/my-page/edit-info',
+        element: <EditInfoPage />,
+        meta: {
+          hideNav: true,
+        },
+      },
+      {
+        path: '/my-page/view-point-list',
+        element: <ViewPointListPage />,
+      },
+      {
+        path: '/my-page/delete-account',
+        element: <DeleteAccountPage />,
+        meta: {
+          hideNav: true,
+        },
+      },
+      {
+        path: '/my-page/privacy-policy',
+        element: <PrivacyPolicyPage />,
+        meta: {
+          hideNav: true,
+        },
+      },
+      {
+        path: '/my-page/service-policy',
+        element: <ServicePolicyPage />,
+        meta: {
+          hideNav: true,
+        },
+      },
+      {
+        path: '/my-page/my-post',
+        element: <MyPostPage />,
+        meta: {
+          hideNav: true,
+        },
+      },
+      {
+        path: '/my-page/comment',
+        element: <CommentPage />,
+        meta: {
+          hideNav: true,
+        },
+      },
       {
         path: '/my-page/download-exam-review',
         element: <DownloadExamReviewPage />,
+        meta: {
+          hideNav: true,
+        },
       },
-      { path: '/about', element: <AboutPage /> },
-      { path: '/notice', element: <NoticeListPage /> },
-      { path: '/authentication', element: <AuthPage /> },
-      { path: '/help', element: <HelpPage /> },
+      {
+        path: '/about',
+        element: <AboutPage />,
+      },
+      {
+        path: '/notice',
+        element: <NoticeListPage />,
+      },
+      {
+        path: '/authentication',
+        element: <AuthPage />,
+      },
+      {
+        path: '/help',
+        element: <HelpPage />,
+      },
       {
         path: '/login',
         element: <LoginPage />,
-        meta: { hideNav: true },
+        meta: {
+          hideNav: true,
+        },
       },
       {
         path: '/find-id',
         element: <FindIdPage />,
-        meta: { hideNav: true },
+        meta: {
+          hideNav: true,
+        },
       },
       {
         path: '/find-pw',
         element: <FindPwPage />,
-        meta: { hideNav: true },
+        meta: {
+          hideNav: true,
+        },
       },
       {
         path: '/found-id',
         element: <FoundIdPage />,
-        meta: { hideNav: true },
+        meta: {
+          hideNav: true,
+        },
       },
       {
         path: '/found-pw',
         element: <FoundPwPage />,
-        meta: { hideNav: true },
+        meta: {
+          hideNav: true,
+        },
       },
       {
         path: '/not-found-id',
         element: <NotFoundIdPage />,
-        meta: { hideNav: true },
+        meta: {
+          hideNav: true,
+        },
       },
       {
         path: '/not-found-pw',
         element: <NotFoundPwPage />,
-        meta: { hideNav: true },
+        meta: {
+          hideNav: true,
+        },
       },
     ],
   },


### PR DESCRIPTION
## 🎯 관련 이슈

close #131

<br />

## 🚀 작업 내용

- bottom navigation이 필요없는 페이지는 제거
- padding-bottom 크기를 54px로 통일하여 조정

<br />


## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

- 1 depth 페이지 (메인홈, 게시판, 시험후기, 알림, 마이페이지)에는 `bottom navigation` 배치
- 2 depth 페이지에는 `bottom navigation` 노출 X

<br />

