### PR TITLE
#150 [STYLE] 시험후기 작성 페이지 온라인 선택 필드 추가 & 글작성 플로팅 버튼 추가

### DIFF
--- a/src/components/WriteButton/WriteButton.jsx
+++ b/src/components/WriteButton/WriteButton.jsx
@@ -1,0 +1,15 @@
+import { Link } from 'react-router-dom';
+
+import { Icon } from '@/components/Icon/index.js';
+
+import styles from './WriteButton.module.css';
+
+export default function WriteButton({ to }) {
+  return (
+    <Link to={to}>
+      <button className={styles.button}>
+        <Icon id='pencil' width='30' height='30' />
+      </button>
+    </Link>
+  );
+}

--- a/src/components/WriteButton/WriteButton.module.css
+++ b/src/components/WriteButton/WriteButton.module.css
@@ -1,0 +1,22 @@
+.button {
+  width: 72px;
+  height: 72px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: fixed;
+  right: 15px;
+  bottom: 100px;
+  border-radius: 100%;
+  background: rgba(255, 255, 255, 0.7);
+  box-shadow: 4px 4px 19.1px rgba(0, 0, 0, 0.15);
+  backdrop-filter: blur(7.05px);
+  z-index: 1;
+}
+
+@media only screen and (min-width: 600px) {
+  /* (100vw  - 600px) / 2 - 15px */
+  .button {
+    right: calc(100vw / 2 - 600px / 2 + 15px);
+  }
+}

--- a/src/components/WriteButton/index.js
+++ b/src/components/WriteButton/index.js
@@ -1,0 +1,1 @@
+export { default as WriteButton } from './WriteButton';

--- a/src/pages/BoardPage/BoardListPage/BoardListPage.jsx
+++ b/src/pages/BoardPage/BoardListPage/BoardListPage.jsx
@@ -99,7 +99,7 @@ export default function BoardListPage() {
         setIsOpen={setIsModalOpen}
       />
       <Target ref={ref} height='100px' />
-      <WriteButton to='/board/exam-review-write' />
+      <WriteButton to='/post-write' />
     </div>
   );
 }

--- a/src/pages/BoardPage/BoardListPage/BoardListPage.jsx
+++ b/src/pages/BoardPage/BoardListPage/BoardListPage.jsx
@@ -2,18 +2,22 @@ import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
-import styles from './BoardListPage.module.css';
+import { getPostList } from '@/apis/postList.js';
 
-import Icon from '../../../components/Icon/Icon.jsx';
-import { BackAppBar } from '../../../components/AppBar';
-import { PostBar } from '../../../components/PostBar';
-import { Sponser } from '../../../components/Sponser';
-import { OptionModal } from '../../../components/Modal';
-import PTR from '../../../components/PTR/PTR.jsx';
-import { getPostList } from '../../../apis/postList.js';
-import { Target } from '../../../components/Target/index.js';
-import { BOARD_MENUS } from '../../../constants/boardMenus.js';
 import { useIntersect } from '@/hooks';
+
+import { BackAppBar } from '@/components/AppBar';
+import { Icon } from '@/components/Icon';
+import { OptionModal } from '@/components/Modal';
+import { PostBar } from '@/components/PostBar';
+import { Sponser } from '@/components/Sponser';
+import { Target } from '@/components/Target/index.js';
+import { WriteButton } from '@/components/WriteButton';
+import PTR from '@/components/PTR/PTR.jsx';
+
+import { BOARD_MENUS } from '@/constants';
+
+import styles from './BoardListPage.module.css';
 
 export default function BoardListPage() {
   const { pathname } = useLocation();
@@ -86,14 +90,6 @@ export default function BoardListPage() {
             ))}
         </div>
       </PTR>
-      <div className={styles.pencil_icon}>
-        <Icon
-          id='pencil-circle'
-          width={105}
-          height={105}
-          onClick={handleNavClick('/post-write')}
-        />
-      </div>
       <div className={styles.sponser}>
         <Sponser />
       </div>
@@ -103,6 +99,7 @@ export default function BoardListPage() {
         setIsOpen={setIsModalOpen}
       />
       <Target ref={ref} height='100px' />
+      <WriteButton to='/board/exam-review-write' />
     </div>
   );
 }

--- a/src/pages/BoardPage/BoardListPage/BoardListPage.module.css
+++ b/src/pages/BoardPage/BoardListPage/BoardListPage.module.css
@@ -24,16 +24,6 @@ body {
   gap: 9px;
 }
 
-.pencil_icon {
-  display: flex;
-  justify-content: end;
-  width: 100%;
-  max-width: 450px;
-  position: fixed;
-  bottom: 120px;
-  z-index: 10;
-}
-
 .side_menu_btn {
   width: 20px;
   height: 15px;

--- a/src/pages/ExamReviewPage/ExamReviewPage/ExamReviewPage.jsx
+++ b/src/pages/ExamReviewPage/ExamReviewPage/ExamReviewPage.jsx
@@ -11,6 +11,7 @@ import { Loading } from '@/components/Loading';
 import { PostBar } from '@/components/PostBar';
 import { PTR } from '@/components/PTR';
 import { Search } from '@/components/Search';
+import { WriteButton } from '@/components/WriteButton';
 
 import { BOARD_ID, YEARS, SEMESTERS, EXAM_TYPES } from '@/constants';
 
@@ -102,6 +103,7 @@ export default function ExamReviewPage() {
         {isFetching && <Loading />}
         {reviewList.length > 0 && <Target ref={ref} height='100px' />}
       </PTR>
+      <WriteButton to='/board/exam-review-write' />
     </main>
   );
 }

--- a/src/pages/ExamReviewWritePage/ExamReviewWritePage.jsx
+++ b/src/pages/ExamReviewWritePage/ExamReviewWritePage.jsx
@@ -16,6 +16,7 @@ import { InputItem, InputList } from '@/components/Input';
 import { Textarea } from '@/components/Fieldset';
 
 import {
+  BOARD_ID,
   CLASS_NUMBERS,
   EXAM_TYPES,
   LECTURE_TYPES,
@@ -39,6 +40,7 @@ export default function ExamReviewWritePage() {
   const [lectureYear, setLectureYear] = useState({});
   const [semester, setSemester] = useState({});
   const [isPF, setIsPF] = useState(false);
+  const [isOnline, setIsOnline] = useState(false);
   const [classNumber, setClassNumber] = useState({});
   const [questionDetail, setQuestionDetail] = useState('');
   const [file, setFile] = useState();
@@ -68,20 +70,21 @@ export default function ExamReviewWritePage() {
 
   const data = {
     isPF,
-    boardId: 32,
+    boardId: BOARD_ID['exam-review'],
     classNumber: classNumber?.id,
     lectureName,
     professor,
+    questionDetail,
     semester: semester?.id,
     lectureType: lectureType?.id,
+    content: '',
     examType: examType?.id,
     lectureYear: lectureYear?.id,
-    title: '자료구조',
-    questionDetail,
-    isOnline: false,
-    category: 'testCategory',
-    content: '',
+    isOnline,
+    category: '',
   };
+
+  console.log(data);
 
   return (
     <main className={styles.main}>
@@ -172,6 +175,13 @@ export default function ExamReviewWritePage() {
         hasCheckbox
         value={isPF}
         setFn={setIsPF}
+      />
+      <CategoryFieldset
+        title='온라인(비대면 수업) 여부'
+        required
+        hasCheckbox
+        value={isOnline}
+        setFn={setIsOnline}
       />
       <CategoryFieldset title='수강 분반' required>
         <Dropdown

--- a/src/pages/ExamReviewWritePage/ExamReviewWritePage.jsx
+++ b/src/pages/ExamReviewWritePage/ExamReviewWritePage.jsx
@@ -84,8 +84,6 @@ export default function ExamReviewWritePage() {
     category: '',
   };
 
-  console.log(data);
-
   return (
     <main className={styles.main}>
       <CloseAppBar>


### PR DESCRIPTION
## 🎯 관련 이슈

close #150

<br />

## 🚀 작업 내용

- 시험후기 작성 페이지에서 온라인 수업 여부를 입력받는 선택 필드 추가
- 시험후기 게시판과 일반 게시판에 글작성 플로팅 버튼 추가

<br />

## 📸 스크린샷

| <img width="322" alt="image" src="https://github.com/user-attachments/assets/46c6db94-000c-4164-a735-27bd0c5f980b"> | <img width="322" alt="image" src="https://github.com/user-attachments/assets/72456889-28d1-42d8-bf0c-7de669d8783a"> | <img width="322" alt="image" src="https://github.com/user-attachments/assets/78c433fa-0e31-4282-afdd-bb3403368738"> |
| :---------------------: | :---------------------: | :---------------------: |
| 시험후기 작성 페이지 - `온라인 필드` | 시험후기 게시판 - 플로팅 버튼 | 일반 게시판 - 플로팅 버튼 |

<br />

## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

- `WriteButton` 컴포넌트는 글작성 플로팅 버튼입니다.