### PR TITLE
#156 [FEAT] 공지글 조회 API 연결

### DIFF
--- a/src/apis/notice.js
+++ b/src/apis/notice.js
@@ -1,0 +1,12 @@
+import { authAxios } from '../axios';
+
+export const getNoticeList = async (boardId) => {
+  const response = await authAxios.get(`/v1/notices/boards/${boardId}`);
+  return response.data.result;
+};
+
+export const getNoticeLine = async (boardId) => {
+    const response = await authAxios.get(`/v1/notices/boards/${boardId}/top`);
+    return response.data.result;
+  };
+  

--- a/src/pages/BoardPage/BoardListPage/BoardListPage.jsx
+++ b/src/pages/BoardPage/BoardListPage/BoardListPage.jsx
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { getPostList } from '@/apis/postList.js';
+import { getNoticeLine } from '@/apis/notice.js';
 
 import { useIntersect } from '@/hooks';
 
@@ -36,6 +37,22 @@ export default function BoardListPage() {
         return lastPage.length > 0 ? (lastPageParam || 0) + 1 : undefined;
       },
     });
+
+  const [noticeTitle, setNoticeTitle] = useState('');
+
+  useEffect(() => {
+    const fetchNoticeLine = async () => {
+      try {
+        const data = await getNoticeLine(currentBoard.id);
+        setNoticeTitle(data.title || ''); // Update state with fetched title
+      } catch (error) {
+        console.error('Failed to fetch notice line', error);
+        setNoticeTitle(''); // Fallback in case of error
+      }
+    };
+
+    fetchNoticeLine();
+  }, [currentBoard.id]);
 
   const ref = useIntersect(
     async (entry, observer) => {
@@ -74,7 +91,7 @@ export default function BoardListPage() {
           onClick={handleNavClick('./notice')}
         >
           <Icon id='notice-bell' width={11} height={13} />
-          <p>[필독] 공지사항</p>
+          <p>[필독]&nbsp;&nbsp;{noticeTitle}</p>
         </div>
       </div>
       <PTR onRefresh={handleRefresh}>

--- a/src/pages/NoticeListPage/NoticeListPage.jsx
+++ b/src/pages/NoticeListPage/NoticeListPage.jsx
@@ -1,34 +1,54 @@
+import { useState, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styles from './NoticeListPage.module.css';
 import { BackAppBar } from '../../components/AppBar';
-import { NOTICE_LIST } from '../../dummy/data/noticeList.js';
 import { NoticeBar } from '../../components/NoticeBar';
+import { getNoticeList } from '../../apis/notice.js';
+import { BOARD_MENUS } from '../../constants';
 
 export default function NoticeListPage() {
   const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const [noticeList, setNoticeList] = useState([]);
+
+  const currentBoardTextId = pathname.split('/')[2];
+  const currentBoard =
+    BOARD_MENUS.find((menu) => menu.textId === currentBoardTextId) || {};
+
+  useEffect(() => {
+    const fetchNoticeList = async () => {
+      try {
+        const data = await getNoticeList(currentBoard.id);
+        setNoticeList(data || []);
+      } catch (error) {
+        console.error('Failed to fetch notice list', error);
+        setNoticeList([]);
+      }
+    };
+
+    fetchNoticeList();
+  }, [currentBoard.id]);
+
   const handleNavClick = (to) => {
     return () => {
       navigate(to);
     };
   };
 
-  const titleMap = {
-    'first-snow': '첫눈온방 공지',
-    'large-snow': '함박눈방 공지',
-    'permanent-snow': '만년설방 공지',
-    besookt: '베숙트',
-  };
-
-  const { pathname } = useLocation();
-  const currentPath = pathname.split('/')[2];
-  const currentBoard = titleMap[currentPath] || '';
-
   return (
     <div className={styles.container}>
-      <BackAppBar title={currentBoard} hasNotice={true} />
+      <BackAppBar title={currentBoard.textId} hasNotice={true} />
       <div className={styles.content}>
-        {NOTICE_LIST &&
-          NOTICE_LIST.map((post) => <NoticeBar key={post.postId} data={post} onClick={handleNavClick('/post')}/>)}
+        {Array.isArray(noticeList) &&
+          noticeList.map((post) => (
+            <NoticeBar
+              key={post.postId}
+              data={post}
+              onClick={handleNavClick(
+                `/board/${currentBoardTextId}/post/${post.postId}`
+              )}
+            />
+          ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## 🎯 관련 이슈

close #156

<br />

## 🚀 작업 내용

- 각 게시판에서의 공지글 리스트 조회 API 연결
- 공지글 클릭 시, 공지글(=게시글) 상세 페이지로 이동
- 각 게시판에서의 공지글 1줄 조회 API 연결

<br />

## 📸 스크린샷
<img width="611" alt="스크린샷 2024-08-22 오후 4 32 28" src="https://github.com/user-attachments/assets/ad41fb22-3e4a-4c30-a389-cb0605d6727a">
<img width="611" alt="스크린샷 2024-08-22 오후 4 32 40" src="https://github.com/user-attachments/assets/0e986981-38d3-4b29-8d15-fe292d5345b8">
<img width="611" alt="스크린샷 2024-08-22 오후 4 32 52" src="https://github.com/user-attachments/assets/f3823db0-dabe-4d5f-ac42-2312be75225d">

<br />