### PR TITLE
#162 [FEAT] 포인트 내역 보기 페이지 API 연동

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@testing-library/react": "^13.0.0",
     "@testing-library/user-event": "^13.2.1",
     "axios": "^1.7.2",
+    "date-fns": "^3.6.0",
     "jsconfig-paths-webpack-plugin": "^0.1.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/apis/point.js
+++ b/src/apis/point.js
@@ -16,3 +16,11 @@ export const updatePoint = async ({
   });
   return response;
 };
+
+export const getPointList = async (params) => {
+  const { data } = await authAxios.get('/v1/points/log', {
+    params,
+  });
+
+  return data.result;
+};

--- a/src/constants/point.js
+++ b/src/constants/point.js
@@ -33,6 +33,32 @@ export const POINT_CATEGORY_ENUM = Object.freeze({
   ETC: 'ETC',
 });
 
+export const POINT_CATEGORY_KOREAN_ENUM = Object.freeze({
+  ATTENDANCE: '출석체크',
+  POST_CREATE: '게시글 작성',
+  POST_DELETE: '게시글 삭제',
+  COMMENT_CREATE: '댓글 작성',
+  COMMENT_DELETE: '댓글 삭제',
+  EXAM_REVIEW_CREATE: '시험후기 작성',
+  EXAM_REVIEW_DOWNLOAD: '시험후기 다운로드',
+  LECTURE_REVIEW_CREATE: '강의후기 작성',
+  POINT_REWARD_10_LIKES: '좋아요 10개 게시글',
+  POINT_REWARD_100_LIKES: '좋아요 100개 게시글',
+  POINT_REWARD_1000_LIKES: '좋아요 1,000개 게시글',
+  POINT_REWARD_USER_AUTH: '정회원 인증 기념',
+  POINT_REWARD_REPORT_GENERAL: '일반 신고 보상 (호칭, 도배 등)',
+  POINT_REWARD_REPORT_EXAM_REVIEW:
+    '시험후기 관련 신고 보상 (중복/허위 족보 등)',
+  POINT_REWARD_REPORT_OUTSIDER: '외부인 신고 보상',
+  POINT_REWARD_REPORT_PERMANENT_DEMOTION:
+    '영구강등에 해당하는 위반사항 신고 보상 (외부 유출, 아이디 공유 등)',
+  POINT_REWARD_ETC: '포인트 보상 - 기타 사유',
+  POINT_DEDUCTION_FlOODING: '포인트 차감 - 도배',
+  POINT_DEDUCTION_ETC: '포인트 차감 - 기타 사유',
+  EVENT: '이벤트',
+  ETC: '기타',
+});
+
 export const POINT_SOURCE_ENUM = Object.freeze({
   ATTENDANCE: 'ATTENDANCE', // 출석체크
   POST: 'POST', // 게시글

--- a/src/pages/MyPage/ViewPointListPage/ViewPointListPage.jsx
+++ b/src/pages/MyPage/ViewPointListPage/ViewPointListPage.jsx
@@ -56,7 +56,9 @@ export default function ViewPointListPage() {
           <h1 className={styles.title}>보유 포인트</h1>
           <div className={styles.totalPointWrapper}>
             <Icon id='point-circle' />
-            <span className={styles.totalPoint}>{userInfo.balance}</span>
+            <span className={styles.totalPoint}>
+              {userInfo.balance.toLocaleString()}
+            </span>
           </div>
         </div>
 
@@ -88,7 +90,7 @@ export default function ViewPointListPage() {
                   <span
                     className={`${styles.chargePoint} ${difference < 0 ? styles.negative : ''}`}
                   >
-                    {`${difference > 0 ? '+' : ''}${difference}`}
+                    {`${difference > 0 ? '+' : ''}${difference.toLocaleString()}`}
                   </span>
                 </li>
               )

--- a/src/pages/MyPage/ViewPointListPage/ViewPointListPage.jsx
+++ b/src/pages/MyPage/ViewPointListPage/ViewPointListPage.jsx
@@ -6,6 +6,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { getPointList } from '@/apis';
 import { useInView } from 'react-intersection-observer';
 import { format } from 'date-fns';
+import { POINT_CATEGORY_KOREAN_ENUM } from '@/constants/point';
 
 export default function ViewPointListPage() {
   const { userInfo, status } = useAuth({
@@ -74,7 +75,7 @@ export default function ViewPointListPage() {
                       <h2
                         className={`${styles.pointTitle} ${difference < 0 ? styles.negative : ''}`}
                       >
-                        {category}
+                        {POINT_CATEGORY_KOREAN_ENUM[category]}
                       </h2>
                       {reviewTitle && (
                         <span className={styles.pointDesc}>{reviewTitle}</span>

--- a/src/pages/MyPage/ViewPointListPage/ViewPointListPage.jsx
+++ b/src/pages/MyPage/ViewPointListPage/ViewPointListPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import styles from './ViewPointListPage.module.css';
 import { BackAppBar, Icon } from '@/components';
+import { useAuth } from '@/hooks';
 
 const pointData = [
   {
@@ -77,6 +78,9 @@ const pointData = [
 
 export default function ViewPointListPage() {
   const chargePointsRef = useRef([]);
+  const { userInfo, status } = useAuth({
+    isRequiredAuth: true,
+  });
 
   useEffect(() => {
     chargePointsRef.current.forEach((point) => {
@@ -94,6 +98,14 @@ export default function ViewPointListPage() {
     });
   }, []);
 
+  if (status === 'loading') {
+    return <div>loading...</div>;
+  }
+
+  if (status === 'unauthenticated') {
+    return null;
+  }
+
   return (
     <main className={styles.viewPointListPage}>
       <header>
@@ -105,7 +117,7 @@ export default function ViewPointListPage() {
           <h1 className={styles.title}>보유 포인트</h1>
           <div className={styles.totalPointWrapper}>
             <Icon id='point-circle' />
-            <span className={styles.totalPoint}>39</span>
+            <span className={styles.totalPoint}>{userInfo.balance}</span>
           </div>
         </div>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3968,6 +3968,11 @@ data-view-byte-offset@^1.0.0:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
+date-fns@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.6.0.tgz#f20ca4fe94f8b754951b24240676e8618c0206bf"
+  integrity sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==
+
 debug@2.6.9, debug@^2.6.0:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -8294,6 +8299,11 @@ react-error-overlay@^6.0.11:
   version "6.0.11"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
+
+react-intersection-observer@^9.13.0:
+  version "9.13.0"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-9.13.0.tgz#ee10827954cf6ccc204d027f8400a6ddb8df163a"
+  integrity sha512-y0UvBfjDiXqC8h0EWccyaj4dVBWMxgEx0t5RGNzQsvkfvZwugnKwxpu70StY4ivzYuMajavwUDjH4LJyIki9Lw==
 
 react-is@^16.13.1:
   version "16.13.1"


### PR DESCRIPTION
## 🎯 관련 이슈

close #162

<br />

## 🚀 작업 내용

- 잔여 포인트 API 연동 (페이지 상단)
- 포인트 내역 보기 페이지 API 연동
- `date-fns` 라이브러리 추가
- `POINT_CATEGORY_KOREAN_ENUM` 코드 추가

<br />

## 📸 스크린샷

| <img width='250' src='https://github.com/user-attachments/assets/c758d9c4-bdde-4ed9-b757-52aa2ce10cb0'> |  <img width='250' src='https://github.com/user-attachments/assets/89c5346d-0bea-4848-9549-f5e1a4034adb'> |
| :---------------------: | :---------------------: |
| 포인트 내역 보기 - 내역이 있을 경우 | 포인트 내역 보기 - 내역이 없을 경우 |

<br />


