### PR TITLE
#166 [MODIFY] isWriterWithdrawn, isDeleted, isVisible에 따라 대체 텍스트 표시 i…

### DIFF
--- a/src/components/Comment/Comment/Comment.jsx
+++ b/src/components/Comment/Comment/Comment.jsx
@@ -36,6 +36,23 @@ export default function Comment({ data }) {
     inputFocus();
   };
 
+  const {
+    id,
+    postId,
+    userDisplay,
+    isWriter,
+    isWriterWithdrawn,
+    content,
+    likeCount,
+    createdAt,
+    updatedAt,
+    isVisible,
+    isUpdated,
+    isDeleted,
+    isLiked,
+    children,
+  } = data;
+
   return (
     <>
       <div className={styles.comment} onClick={() => setCommentId(undefined)}>
@@ -44,10 +61,12 @@ export default function Comment({ data }) {
             <div className={styles.cloud}>
               <Icon id='cloud' width='19' height='13' />
             </div>
-            <p>{data.userDisplay}</p>
+            <p className={`${isWriterWithdrawn && styles.isWriterWithdrawn}`}>
+              {isWriterWithdrawn ? '(알 수 없음)' : userDisplay}
+            </p>
             <p className={styles.dot}>·</p>
             <p>
-              {timeAgo(data.createdAt)} {data.isUpdated ? ' (수정됨)' : null}
+              {timeAgo(createdAt)} {isUpdated ? ' (수정됨)' : null}
             </p>
           </div>
           <p
@@ -57,28 +76,34 @@ export default function Comment({ data }) {
               onCommentOptionClick(data);
             }}
           >
-            {data.isWriter && (
+            {isWriter && !isDeleted && (
               <Icon id='ellipsis-vertical' width='3' height='11' />
             )}
           </p>
         </div>
-        <div className={styles.commentCenter}>{data.content}</div>
+        <div
+          className={`${styles.commentCenter} ${(isDeleted || !isVisible) && styles.hide}`}
+        >
+          {!isDeleted &&
+            (isVisible ? content : '(관리자에 의해 차단된 댓글입니다)')}
+          {isDeleted && '(삭제된 댓글입니다)'}
+        </div>
         <div className={styles.commentBottom}>
           <button className={styles.commentCount} onClick={handleReply}>
             <Icon id='comment' width='15' height='13' fill='#D9D9D9' />
-            <p>{data.children.length}</p>
+            <p>{children.length}</p>
           </button>
           <button className={styles.likedCount}>
             <Icon id='like' width='13' height='12' fill='#D9D9D9' />
-            <p>{data.likeCount}</p>
+            <p>{likeCount}</p>
           </button>
         </div>
-        {data.children.length > 0 &&
-          data.children.map((childComment, index) => (
+        {children.length > 0 &&
+          children.map((childComment, index) => (
             <NestedComment
               key={childComment.id}
               data={childComment}
-              isLast={index === data.children.length - 1}
+              isLast={index === children.length - 1}
               isFirst={index === 0}
               onCommentOptionClick={onCommentOptionClick}
             />

--- a/src/components/Comment/Comment/Comment.module.css
+++ b/src/components/Comment/Comment/Comment.module.css
@@ -30,6 +30,10 @@
   align-items: center;
 }
 
+.isWriterWithdrawn {
+  color: #a7a7a7;
+}
+
 .dot {
   width: 3px;
   height: 3px;
@@ -47,6 +51,10 @@
   line-height: 150%;
   letter-spacing: -0.5px;
   padding: 0 14px;
+}
+
+.commentCenter.hide {
+  color: #a7a7a7;
 }
 
 .commentBottom {
@@ -124,6 +132,10 @@
   padding-left: 22px;
 }
 
+.nestedPadding.hide {
+  color: #a7a7a7;
+}
+
 .deletedComment {
   width: 100%;
   padding: 15px 14px;
@@ -133,5 +145,4 @@
   font-size: 14px;
   line-height: 150%;
   letter-spacing: -0.5px;
-
 }

--- a/src/components/Comment/CommentList/CommentList.jsx
+++ b/src/components/Comment/CommentList/CommentList.jsx
@@ -11,19 +11,19 @@ import styles from './CommentList.module.css';
 export default function CommentList() {
   const { commentList } = useComment();
 
-  console.log(commentList);
-
   if (!commentList) {
     return <FetchLoading>댓글을 불러오는 중...</FetchLoading>;
   }
 
-  const dataList = filterDeletedComments(commentList);
+  console.log(commentList);
 
   return (
     <div className={styles.comments}>
       <p className={styles.commentsTitle}>댓글 {commentList?.length}개</p>
-      {dataList ? (
-        dataList.map((comment) => <Comment key={comment.id} data={comment} />)
+      {commentList ? (
+        commentList.map((comment) => (
+          <Comment key={comment.id} data={comment} />
+        ))
       ) : (
         <div className={styles.failComment}>댓글을 불러올 수 없습니다.</div>
       )}

--- a/src/components/Comment/NestedComment/NestedComment.jsx
+++ b/src/components/Comment/NestedComment/NestedComment.jsx
@@ -34,6 +34,23 @@ export default function NestedComment({
     console.log('API로 liked 데이터 수정');
   };
 
+  const {
+    id,
+    postId,
+    userDisplay,
+    isWriter,
+    isWriterWithdrawn,
+    content,
+    likeCount,
+    createdAt,
+    updatedAt,
+    isVisible,
+    isUpdated,
+    isDeleted,
+    // isLiked,
+    children,
+  } = data;
+
   return (
     <>
       <div
@@ -53,21 +70,29 @@ export default function NestedComment({
             <div className={styles.cloud}>
               <Icon id='cloud' width='19' heigth='13' />
             </div>
-            <p>{data.userDisplay}</p>
+            <p className={`${isWriterWithdrawn && styles.isWriterWithdrawn}`}>
+              {isWriterWithdrawn ? '(알 수 없음)' : userDisplay}
+            </p>
             <p className={styles.dot}>·</p>
             <p>
-              {timeAgo(data.createdAt)} {data.isUpdated ? ' (수정됨)' : null}
+              {timeAgo(createdAt)} {isUpdated ? ' (수정됨)' : null}
             </p>
           </div>
 
           <p className={styles.dot3} onClick={() => onCommentOptionClick(data)}>
-            {data.isWriter && (
+            {isWriter && !isDeleted && (
               <Icon id='ellipsis-vertical' width='3' height='11' />
             )}
           </p>
         </div>
         <div className={styles.commentCenter}>
-          <div className={styles.nestedPadding}>{data.content}</div>
+          <div
+            className={`${styles.nestedPadding} ${(isDeleted || !isVisible) && styles.hide}`}
+          >
+            {!isDeleted &&
+              (isVisible ? content : '(관리자에 의해 차단된 댓글입니다)')}
+            {isDeleted && '(삭제된 댓글입니다)'}
+          </div>
         </div>
         <div className={styles.commentBottom}>
           <button className={styles.likedCount}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8295,6 +8295,11 @@ react-error-overlay@^6.0.11:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
+react-intersection-observer@^9.13.0:
+  version "9.13.0"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-9.13.0.tgz#ee10827954cf6ccc204d027f8400a6ddb8df163a"
+  integrity sha512-y0UvBfjDiXqC8h0EWccyaj4dVBWMxgEx0t5RGNzQsvkfvZwugnKwxpu70StY4ivzYuMajavwUDjH4LJyIki9Lw==
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
## 🎯 관련 이슈

close #166

<br />

## 🚀 작업 내용

- 부모 댓글을 삭제해도 자식 댓글을 보여주기 위해 isDeleted에 대한 필터 삭제
- 대체 텍스트 표시를 위해 isWriterWithdrawn, isDeleted, isVisible에 대한 조건문 추가

<br />

## 📸 스크린샷

| <img width="321" alt="image" src="https://github.com/user-attachments/assets/a5fff8ea-66e5-455e-8994-a3109b5e2211"> | <img width="321" alt="image" src="https://github.com/user-attachments/assets/a19c7387-35d3-491f-9de3-efa854467c4d"> | <img width="321" alt="image" src="https://github.com/user-attachments/assets/63d85f31-a555-4683-af6b-4c14638ca5e9"> |
| :---------------------: | :---------------------: | :---------------------: |
| isWriterWithdrawn이 `true`인 경우 | isDeleted가 `true`인 경우 | isVisible이 `false`인 경우 |

<br />

## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

- isDeleted가 isVisible보다 더 우선으로 처리됩니다.
  ```
  ex) isDeleted = true, isVisible = false인 경우 (삭제된 댓글입니다)를 표시합니다.
  ```