### PR TITLE
#174 [STYLE] Toast 위치를 정중앙으로 수정

### DIFF
--- a/src/components/Toast/Toast.module.css
+++ b/src/components/Toast/Toast.module.css
@@ -1,6 +1,6 @@
 .toast {
   padding: 0.75rem 1rem;
-  background: rgba(72, 72, 72, 0.6);
+  background: rgba(72, 72, 72, 0.8);
   border-radius: 0.375rem;
   transition: 500ms opacity ease-in-out;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -128,9 +128,9 @@ code {
   align-items: center;
   gap: 4px;
   position: fixed;
-  bottom: 6.25rem;
+  top: 50%;
   left: 50%;
-  transform: translateX(-50%);
+  transform: translate(-50%, -50%);
   z-index: 2;
 }
 


### PR DESCRIPTION
## 🎯 관련 이슈

close #174

<br />

## 🚀 작업 내용

- 기존 Toast가 눈에 잘 띄지 않아 위치를 정중앙으로 이동시켰습니다.

<br />

## 📸 스크린샷

| <img width="323" alt="image" src="https://github.com/user-attachments/assets/95157bdc-ffb2-40aa-b8d7-e3e415a0b14c"> | <img width="323" alt="image" src="https://github.com/user-attachments/assets/1b0c924d-ed40-46cb-b890-6b2fdb0131e4"> |
| :---------------------: | :---------------------: |
| 기존 | 변경 후 |

<br />

그리고 배경색이 너무 투명해서 메시지가 잘 보이지 않아 투명도를 변경하려고 합니다.
어느 것이 더 나은 지 의견주시면 반영하겠습니다 :)

| <img width="323" alt="image" src="https://github.com/user-attachments/assets/1b0c924d-ed40-46cb-b890-6b2fdb0131e4"> | <img width="323" alt="image" src="https://github.com/user-attachments/assets/8a5d3707-1603-40ac-a547-8bc4d1cb1707"> | <img width="323" alt="image" src="https://github.com/user-attachments/assets/259549b2-929e-4589-9b98-4f722b9af825"> |
| :---------------------: | :---------------------: | :---------------------: |
| 기존(alpha = `0.6`) | alpha = `0.7` | alpha = `0.8` |

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
