### PR TITLE
#173 [FEAT] 시험후기 상세 페이지에 수정/삭제 모달 연결

### DIFF
--- a/src/constants/modalOptions.js
+++ b/src/constants/modalOptions.js
@@ -123,7 +123,7 @@ export const MODAL_OPTIONS = [
   },
   {
     id: 'exam-review-edit',
-    title: '내 게시글',
+    title: '내가 작성한 시험 후기',
     titleColor: '#000',
     children: [
       {
@@ -145,10 +145,10 @@ export const MODAL_OPTIONS = [
   },
   {
     id: 'exam-review-delete',
-    title: '게시글을 삭제할까요?',
+    title: '시험 후기를 삭제할까요?',
     titleColor: '#000',
     children: {
-      text: '',
+      text: '시험 후기 삭제 시 포인트가 차감돼요',
     },
     bottom: {
       redBtn: '삭제',

--- a/src/pages/ExamReviewPage/ExamReviewDetailPage/ExamReviewDetailPage.jsx
+++ b/src/pages/ExamReviewPage/ExamReviewDetailPage/ExamReviewDetailPage.jsx
@@ -9,6 +9,7 @@ import { useToast } from '@/hooks';
 
 import { BackAppBar } from '@/components/AppBar';
 import { CommentList } from '@/components/Comment';
+import { DeleteModal, OptionModal } from '@/components/Modal';
 import { Icon } from '@/components/Icon';
 import { InputBar } from '@/components/InputBar';
 import { ReviewContentItem } from '@/components/ReviewContentItem';
@@ -67,7 +68,17 @@ export default function ExamReviewDetailPage() {
   const { scrap, deleteScrap } = useScrap();
   const { toast } = useToast();
 
+  const [isOptionModalOpen, setIsOptionModalOpen] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
   if (data === undefined) return null;
+
+  const edit = () =>
+    navigate(`/board/exam-review/${postId}/edit`, {
+      state: data,
+      replace: true,
+    });
+  const remove = () => deleteReview.mutate();
 
   const {
     userDisplay,
@@ -123,30 +134,14 @@ export default function ExamReviewDetailPage() {
               fill='#5F86BF'
               onClick={() => (isScrap ? deleteScrap.mutate() : scrap.mutate())}
             />
-            <div className={styles.more}>
-              {isWriter && (
-                <>
-                  <Icon
-                    id='pencil'
-                    width='15'
-                    height='17'
-                    onClick={() =>
-                      navigate(`/board/exam-review/${postId}/edit`, {
-                        state: data,
-                        replace: true,
-                      })
-                    }
-                  />
-                  <Icon
-                    id='trash'
-                    width='12'
-                    height='16'
-                    onClick={() => deleteReview.mutate()}
-                  />
-                </>
-              )}
-              <Icon id='ellipsis-vertical' width='3' height='11' />
-            </div>
+            {isWriter && (
+              <Icon
+                onClick={() => setIsOptionModalOpen(true)}
+                id='ellipsis-vertical'
+                width='3'
+                height='11'
+              />
+            )}
           </div>
         </div>
         <div className={styles.title}>{title}</div>
@@ -182,6 +177,25 @@ export default function ExamReviewDetailPage() {
       </div>
       <CommentList />
       <InputBar />
+      <OptionModal
+        id='exam-review-edit'
+        isOpen={isOptionModalOpen}
+        setIsOpen={setIsOptionModalOpen}
+        closeFn={() => setIsOptionModalOpen(false)}
+        functions={{
+          pencil: edit,
+          trash: () => {
+            setIsOptionModalOpen(false);
+            setIsDeleteModalOpen(true);
+          },
+        }}
+      />
+      <DeleteModal
+        id='exam-review-delete'
+        isOpen={isDeleteModalOpen}
+        setIsOpen={setIsDeleteModalOpen}
+        redBtnFunction={remove}
+      />
     </main>
   );
 }

--- a/src/pages/ExamReviewPage/ExamReviewDetailPage/ExamReviewDetailPage.module.css
+++ b/src/pages/ExamReviewPage/ExamReviewDetailPage/ExamReviewDetailPage.module.css
@@ -46,15 +46,6 @@
   cursor: pointer;
 }
 
-.more {
-  /* width: 20px; */
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 15px;
-  cursor: pointer;
-}
-
 .title {
   margin: 0 var(--default-margin);
   font-weight: 700;


### PR DESCRIPTION
## 🎯 관련 이슈

close #173
<br />

## 🚀 작업 내용

- 시험후기 삭제/수정 모달 연결했습니다.

<br />

## 📸 스크린샷

| <img width="321" alt="image" src="https://github.com/user-attachments/assets/58440c91-4638-4052-9131-24f744d54c7b"> | <img width="321" alt="image" src="https://github.com/user-attachments/assets/9104ed73-2b0a-4801-8d70-e4963804ac7a"> |
| :---------------------: | :---------------------: |
| 옵션 모달 | 삭제 모달 |

<br />

## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

- 변경된 시험후기 상세 페이지의 라우트가 시험후기 수정 로직에 반영이 안 되어서 수정 완료 후 상세 페이지로 못 돌아가는 문제가 있습니다. 해당 문제는 따로 작업한 후 올리겠습니다.