### PR TITLE
#181 [REFACTOR] 좋아요 로직 수정

### DIFF
--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -5,6 +5,7 @@ export * from './notice';
 export * from './point';
 export * from './post';
 export * from './scrap';
+export * from './like';
 export * from './search.js';
 export * from './signup';
 export * from './userInfo';

--- a/src/components/Comment/Comment/Comment.jsx
+++ b/src/components/Comment/Comment/Comment.jsx
@@ -1,8 +1,8 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 import { useCommentContext } from '@/contexts/CommentContext.jsx';
 
-import { useToast, useLike, useComment } from '@/hooks';
+import { useLike, useComment } from '@/hooks';
 
 import { DeleteModal, OptionModal } from '@/components/Modal';
 import { Icon } from '@/components/Icon';
@@ -10,31 +10,16 @@ import { NestedComment } from '@/components/Comment';
 
 import timeAgo from '@/utils/timeAgo.js';
 
-import { TOAST } from '@/constants';
-
 import styles from './Comment.module.css';
 
 export default function Comment({ data }) {
   const { setIsEdit, commentId, setCommentId, setContent, inputFocus } =
     useCommentContext();
-  const { deleteComment, refetch } = useComment();
-  const { toast } = useToast();
+  const { deleteComment } = useComment();
   const [isOptionModalOpen, setIsOptionModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
-  // 좋아요 훅 사용
-  const {
-    isLiked,
-    toggleLike,
-    error: likeError,
-  } = useLike('comments', data.id, data?.isLiked, refetch);
-
-  // 좋아요 처리 시 에러 메시지 표시
-  useEffect(() => {
-    if (likeError?.response?.status === 403) {
-      toast(TOAST.LIKE_SELF_ERROR);
-    }
-  }, [likeError]);
+  const { like, deleteLike } = useLike({ type: 'comments', typeId: data.id });
 
   const onCommentOptionClick = (data) => {
     console.log('Comment option clicked', data);
@@ -61,6 +46,7 @@ export default function Comment({ data }) {
     isWriter,
     isWriterWithdrawn,
     content,
+    isLiked,
     likeCount,
     createdAt,
     updatedAt,
@@ -110,7 +96,10 @@ export default function Comment({ data }) {
             <Icon id='comment' width='15' height='13' fill='#D9D9D9' />
             <p>{children.length}</p>
           </button>
-          <button className={styles.likedCount} onClick={toggleLike}>
+          <button
+            className={styles.likedCount}
+            onClick={() => (isLiked ? deleteLike.mutate() : like.mutate())}
+          >
             <Icon
               id='like'
               width='13'

--- a/src/components/Comment/NestedComment/NestedComment.jsx
+++ b/src/components/Comment/NestedComment/NestedComment.jsx
@@ -92,13 +92,15 @@ export default function NestedComment({
           </div>
         </div>
         <div className={styles.commentBottom}>
-          <button className={styles.likedCount}>
+          <button
+            className={styles.likedCount}
+            onClick={() => (isLiked ? deleteLike.mutate() : like.mutate())}
+          >
             <Icon
               id='like'
               width='13'
               height='12'
               fill={isLiked ? '#5F86BF' : '#D9D9D9'}
-              onClick={() => (isLiked ? deleteLike.mutate() : like.mutate())}
             />
             <span>{data.likeCount.toLocaleString()}</span>
           </button>

--- a/src/components/Comment/NestedComment/NestedComment.jsx
+++ b/src/components/Comment/NestedComment/NestedComment.jsx
@@ -2,14 +2,12 @@ import { useState, useEffect } from 'react';
 
 import { useCommentContext } from '@/contexts/CommentContext.jsx';
 
-import { useToast, useLike, useComment } from '@/hooks';
+import { useLike, useComment } from '@/hooks';
 
 import { DeleteModal, OptionModal } from '@/components/Modal';
 import { Icon } from '@/components/Icon';
 
 import timeAgo from '@/utils/timeAgo.js';
-
-import { TOAST } from '@/constants';
 
 import styles from '../Comment/Comment.module.css';
 
@@ -21,29 +19,16 @@ export default function NestedComment({
 }) {
   const { setIsEdit, commentId, setCommentId, setContent, inputFocus } =
     useCommentContext();
-  const { deleteComment, refetch } = useComment();
-  const { toast } = useToast();
+  const { deleteComment } = useComment();
   const [isOptionModalOpen, setIsOptionModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
+  const { like, deleteLike } = useLike({ type: 'comments', typeId: data.id });
 
   const onCloseClick = () => {
     setCommentId(undefined);
     setContent('');
   };
-
-  // 좋아요 훅 사용
-  const {
-    isLiked,
-    toggleLike,
-    error: likeError,
-  } = useLike('comments', data.id, data?.isLiked, refetch);
-
-  // 좋아요 처리 시 에러 메시지 표시
-  useEffect(() => {
-    if (likeError?.response?.status === 403) {
-      toast(TOAST.LIKE_SELF_ERROR);
-    }
-  }, [likeError]);
 
   const {
     id,
@@ -52,6 +37,7 @@ export default function NestedComment({
     isWriter,
     isWriterWithdrawn,
     content,
+    isLiked,
     likeCount,
     createdAt,
     updatedAt,
@@ -112,7 +98,7 @@ export default function NestedComment({
               width='13'
               height='12'
               fill={isLiked ? '#5F86BF' : '#D9D9D9'}
-              onClick={toggleLike}
+              onClick={() => (isLiked ? deleteLike.mutate() : like.mutate())}
             />
             <span>{data.likeCount.toLocaleString()}</span>
           </button>

--- a/src/components/Loading/FetchLoading.module.css
+++ b/src/components/Loading/FetchLoading.module.css
@@ -17,7 +17,7 @@
 }
 
 .icon {
-  animation: rotateAndPause 3s linear infinite;
+  animation: rotateAndPause 2s linear infinite;
 }
 
 @keyframes rotateAndPause {

--- a/src/components/Loading/FetchLoading.module.css
+++ b/src/components/Loading/FetchLoading.module.css
@@ -17,7 +17,7 @@
 }
 
 .icon {
-  animation: rotateAndPause 2s linear infinite;
+  animation: rotateAndPause 3s linear infinite;
 }
 
 @keyframes rotateAndPause {

--- a/src/components/PostBar/PostBar.jsx
+++ b/src/components/PostBar/PostBar.jsx
@@ -68,7 +68,7 @@ export default function PostBar({
                 id='like'
                 width='12'
                 height='11'
-                fill={data.liked ? '#5F86BF' : '#D9D9D9'}
+                fill={data.isLiked ? '#5F86BF' : '#D9D9D9'}
               />
               <span>{data.likeCount.toLocaleString()}</span>
             </>
@@ -80,7 +80,7 @@ export default function PostBar({
                 id='bookmark-fill'
                 width='9'
                 height='11'
-                fill={data.liked ? '#5F86BF' : '#D9D9D9'}
+                fill={data.isScrapped ? '#5F86BF' : '#D9D9D9'}
               />
               <span>{data.scrapCount.toLocaleString()}</span>
             </>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -7,6 +7,7 @@ export * from './Carousel';
 // export * from './CategoryBoard';
 export * from './Comment';
 export * from './DropDownBlue';
+export * from './DropDownMenu';
 export * from './Fieldset';
 export * from './Flex';
 export * from './Footer';

--- a/src/constants/boardMenus.js
+++ b/src/constants/boardMenus.js
@@ -25,13 +25,14 @@ export const BOARD_MENUS = [
     desc: '졸업생 전용 게시판',
     image: permanentSnow,
   },
-  {
-    id: 20,
-    textId: 'besookt',
-    title: '베숙트',
-    desc: '추천을 가장 많이\n받은 게시물 모아보기',
-    image: besookt,
-  },
+  // 2차 개발 시 추가 예정
+  // {
+  //   id: 20,
+  //   textId: 'besookt',
+  //   title: '베숙트',
+  //   desc: '추천을 가장 많이\n받은 게시물 모아보기',
+  //   image: besookt,
+  // },
   {
     id: 32,
     textId: 'exam-review',

--- a/src/constants/toast.js
+++ b/src/constants/toast.js
@@ -45,6 +45,44 @@ const TOAST = Object.freeze({
     id: 'POST_DELETE_ERROR',
     message: '알 수 없는 오류가 발생했습니다.',
   },
+  COMMENT_EDIT_SUCCESS: {
+    id: 'COMMENT_EDIT_SUCCESS',
+    message: '댓글 수정 완료',
+  },
+  COMMENT_EDIT_FAIL: { id: 'COMMENT_EDIT_FAIL', message: '댓글 수정 실패' },
+  COMMENT_CREATE_SUCCESS: {
+    id: 'COMMENT-CREATE-SUCCESS',
+    message: '댓글 등록 성공!',
+  },
+  COMMENT_CREATE_FAIL: {
+    id: 'COMMENT_CREATE_FAIL',
+    message: '댓글 등록에 실패했습니다.',
+  },
+  COMMENT_DELETE_SUCCESS: {
+    id: 'COMMENT_DELETE_SUCCESS',
+    message: '댓글이 삭제되었습니다.',
+  },
+  COMMENT_DELETE_FAIL: {
+    id: 'COMMENT_DELETE_FAIL',
+    message: '댓글 삭제에 실패했습니다.',
+  },
+  COMMENT_NOT_FOUND: {
+    id: 'COMMENT_NOT_FOUND',
+    message: '댓글을 찾을 수 없습니다.',
+  },
+  COMMENT_EDIT_ERROR: {
+    id: 'COMMENT_EDIT_ERROR',
+    message: '알 수 없는 오류가 발생했습니다.',
+  },
+  COMMENT_CREATE_ERROR: {
+    id: 'COMMENT_CREATE_ERROR',
+    message: '알 수 없는 오류가 발생했습니다.',
+  },
+  COMMENT_DELETE_ERROR: {
+    id: 'COMMENT_DELETE_ERROR',
+    message: '알 수 없는 오류가 발생했습니다.',
+  },
+
   EMPTY_TITLE: {
     id: 'EMPTY_TITLE_ERROR',
     message: '제목을 입력하세요.',

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -5,5 +5,4 @@ export { default as useIntersect } from './useIntersect';
 export { default as useScrap } from './useScrap';
 export { default as useToast } from './useToast';
 export { default as useLike } from './useLike';
-
 export { default as useModal } from './useModal';

--- a/src/hooks/useComment.jsx
+++ b/src/hooks/useComment.jsx
@@ -1,6 +1,9 @@
 import { useParams } from 'react-router-dom';
 import { useQueryClient, useQuery, useMutation } from '@tanstack/react-query';
 
+import { useToast } from '@/hooks';
+import { TOAST } from '@/constants';
+
 import {
   deleteComment as remove,
   getCommentList,
@@ -11,6 +14,7 @@ import {
 export default function useComment() {
   const { postId } = useParams();
   const queryClient = useQueryClient();
+  const { toast } = useToast();
 
   const { data: commentList, refetch } = useQuery({
     queryKey: ['comments', postId],
@@ -28,9 +32,9 @@ export default function useComment() {
       const errorStatus = error.response.status;
 
       if (errorStatus === 400) {
-        alert('댓글 등록에 실패했습니다.');
+        toast(TOAST.COMMENT_CREATE_FAIL);
       } else if (errorStatus === 404) {
-        alert('찾을 수 없는 댓글입니다.');
+        toast(TOAST.COMMENT_NOT_FOUND);
       }
     },
   });
@@ -46,11 +50,11 @@ export default function useComment() {
       const errorCode = error.response.data.code;
 
       if (errorStatus === 400) {
-        alert('댓글 삭제에 실패했습니다.');
+        toast(TOAST.COMMENT_DELETE_FAIL);
       } else if (errorCode === 404 && errorCode === 3031) {
-        alert('사라진 게시글입니다.');
+        toast(TOAST.POST_NOT_FOUND);
       } else if (errorCode === 404 && errorCode === 3020) {
-        alert('사라진 댓글입니다.');
+        toast(TOAST.COMMENT_NOT_FOUND);
       }
     },
   });
@@ -67,11 +71,11 @@ export default function useComment() {
       const errorCode = error.response.data.code;
 
       if (errorStatus === 400) {
-        alert('댓글 수정에 실패했습니다.');
+        toast(TOAST.COMMENT_EDIT_FAIL);
       } else if (errorCode === 404 && errorCode === 3031) {
-        alert('사라진 게시글입니다.');
+        toast(TOAST.POST_NOT_FOUND);
       } else if (errorCode === 404 && errorCode === 3020) {
-        alert('사라진 댓글입니다.');
+        toast(TOAST.COMMENT_NOT_FOUND);
       }
     },
   });

--- a/src/hooks/useComment.jsx
+++ b/src/hooks/useComment.jsx
@@ -18,7 +18,7 @@ export default function useComment() {
     staleTime: 1000 * 60,
   });
 
-  // 게시글 작성
+  // 댓글 작성
   const postComment = useMutation({
     mutationFn: ({ content, parentId }) => post({ postId, parentId, content }),
     onSuccess: () => {
@@ -35,7 +35,7 @@ export default function useComment() {
     },
   });
 
-  // 게시글 삭제
+  // 댓글 삭제
   const deleteComment = useMutation({
     mutationFn: ({ commentId }) => remove({ postId, commentId }),
     onSuccess: () => {
@@ -55,7 +55,7 @@ export default function useComment() {
     },
   });
 
-  // 게시글 수정
+  // 댓글 수정
   const editComment = useMutation({
     mutationFn: ({ commentId, content, parentId }) =>
       edit({ postId, commentId, content, parentId }),

--- a/src/hooks/useLike.jsx
+++ b/src/hooks/useLike.jsx
@@ -1,29 +1,47 @@
-import { useState, useEffect } from 'react';
-import { postLike, deleteLike } from '@/apis/like';
+import { useLocation } from 'react-router-dom';
+import { useQueryClient, useMutation } from '@tanstack/react-query';
+import { useToast } from '@/hooks';
+import { TOAST } from '@/constants';
 
-// 좋아요 훅
-const useLike = (type, typeId, initialState, refetch = () => {}) => {
-  const [isLiked, setIsLiked] = useState(initialState);
-  const [error, setError] = useState(null);
+import { postLike as LikeApi, deleteLike as DeleteLikeApi } from '@/apis';
 
-  const toggleLike = async () => {
-    try {
-      const action = isLiked ? deleteLike : postLike;
-      await action(type, typeId);
-      setIsLiked((prev) => !prev);
-      refetch();
-      setError(null);
-    } catch (err) {
-      setError(err);
-      console.error('좋아요 에러:', err);
-    }
-  };
+export default function useLike({ type, typeId }) {
+  const { pathname } = useLocation();
+  const currentBoard = pathname.split('/')[2];
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
 
-  useEffect(() => {
-    setIsLiked(initialState);
-  }, [initialState]);
+  const like = useMutation({
+    mutationFn: () => LikeApi(type, typeId),
+    onSuccess: () => {
+      if (currentBoard === 'exam-review') {
+        queryClient.invalidateQueries(['reviewDetail', typeId]);
+      } else {
+        queryClient.invalidateQueries(['postContent', typeId]);
+      }
+    },
+    onError: (error) => {
+      if (error?.response?.status === 403) {
+        toast(TOAST.LIKE_SELF_ERROR);
+      }
+    },
+  });
 
-  return { isLiked, toggleLike, error };
-};
+  const deleteLike = useMutation({
+    mutationFn: () => DeleteLikeApi(type, typeId),
+    onSuccess: () => {
+      if (currentBoard === 'exam-review') {
+        queryClient.invalidateQueries(['reviewDetail', typeId]);
+      } else {
+        queryClient.invalidateQueries(['postContent', typeId]);
+      }
+    },
+    onError: (error) => {
+      if (error?.response?.status === 403) {
+        toast(TOAST.LIKE_SELF_ERROR);
+      }
+    },
+  });
 
-export default useLike;
+  return { like, deleteLike };
+}

--- a/src/hooks/useLike.jsx
+++ b/src/hooks/useLike.jsx
@@ -1,4 +1,3 @@
-import { useLocation } from 'react-router-dom';
 import { useQueryClient, useMutation } from '@tanstack/react-query';
 import { useToast } from '@/hooks';
 import { TOAST } from '@/constants';
@@ -6,19 +5,13 @@ import { TOAST } from '@/constants';
 import { postLike as LikeApi, deleteLike as DeleteLikeApi } from '@/apis';
 
 export default function useLike({ type, typeId }) {
-  const { pathname } = useLocation();
-  const currentBoard = pathname.split('/')[2];
   const queryClient = useQueryClient();
   const { toast } = useToast();
 
   const like = useMutation({
     mutationFn: () => LikeApi(type, typeId),
     onSuccess: () => {
-      if (currentBoard === 'exam-review') {
-        queryClient.invalidateQueries(['reviewDetail', typeId]);
-      } else {
-        queryClient.invalidateQueries(['postContent', typeId]);
-      }
+      queryClient.invalidateQueries(['comments', typeId]);
     },
     onError: (error) => {
       if (error?.response?.status === 403) {
@@ -30,11 +23,7 @@ export default function useLike({ type, typeId }) {
   const deleteLike = useMutation({
     mutationFn: () => DeleteLikeApi(type, typeId),
     onSuccess: () => {
-      if (currentBoard === 'exam-review') {
-        queryClient.invalidateQueries(['reviewDetail', typeId]);
-      } else {
-        queryClient.invalidateQueries(['postContent', typeId]);
-      }
+      queryClient.invalidateQueries(['comments', typeId]);
     },
     onError: (error) => {
       if (error?.response?.status === 403) {

--- a/src/hooks/useScrap.jsx
+++ b/src/hooks/useScrap.jsx
@@ -1,14 +1,15 @@
 import { useParams, useLocation } from 'react-router-dom';
 import { useQueryClient, useMutation } from '@tanstack/react-query';
+import { useToast } from '@/hooks';
+import { TOAST } from '@/constants';
 
 import { scrap as ScrapApi, deleteScrap as deleteScrapApi } from '../apis';
 
 export default function useScrap() {
+  const { toast } = useToast();
   const { postId } = useParams();
   const { pathname } = useLocation();
-
   const currentBoard = pathname.split('/')[2];
-
   const queryClient = useQueryClient();
 
   const scrap = useMutation({
@@ -20,6 +21,11 @@ export default function useScrap() {
         queryClient.invalidateQueries(['postContent', postId]);
       }
     },
+    onError: (error) => {
+      if (error?.response?.status === 403) {
+        toast(TOAST.SCRAP_SELF_ERROR);
+      }
+    },
   });
 
   const deleteScrap = useMutation({
@@ -29,6 +35,11 @@ export default function useScrap() {
         queryClient.invalidateQueries(['reviewDetail', postId]);
       } else {
         queryClient.invalidateQueries(['postContent', postId]);
+      }
+    },
+    onError: (error) => {
+      if (error?.response?.status === 403) {
+        toast(TOAST.SCRAP_SELF_ERROR);
       }
     },
   });

--- a/src/pages/PostPage/PostWritePage/PostWritePage.jsx
+++ b/src/pages/PostPage/PostWritePage/PostWritePage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import TextareaAutosize from 'react-textarea-autosize';
 
@@ -161,12 +161,6 @@ export default function PostWritePage() {
           />
         </div>
       </div>
-      <div
-        className={styles.bottom}
-        onClick={() => {
-          setDropDownOpen(false);
-        }}
-      ></div>
     </div>
   );
 }

--- a/src/pages/PostPage/PostWritePage/PostWritePage.jsx
+++ b/src/pages/PostPage/PostWritePage/PostWritePage.jsx
@@ -4,14 +4,11 @@ import TextareaAutosize from 'react-textarea-autosize';
 
 import { postPost } from '@/apis/post';
 
-import { useToast } from '@/hooks';
+import { useToast, useAuth } from '@/hooks';
 
-import { Icon } from '@/components/Icon';
-import { CloseAppBar } from '@/components/AppBar';
-import { DropDownMenu } from '@/components/DropDownMenu';
+import { Icon, CloseAppBar, DropDownMenu, FetchLoading } from '@/components';
 
-import { TOAST } from '@/constants';
-import { BOARD_MENUS } from '@/constants';
+import { TOAST, BOARD_MENUS } from '@/constants';
 
 import formattedNowTime from '@/utils/formattedNowTime';
 
@@ -23,6 +20,7 @@ export default function PostWritePage() {
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const { toast } = useToast();
+  const { userInfo, status } = useAuth();
   const [isNotice, setIsNotice] = useState(false);
   const [dropDownOpen, setDropDownOpen] = useState(false);
   const [title, setTitle] = useState('');
@@ -102,6 +100,10 @@ export default function PostWritePage() {
     }
   };
 
+  if (status === 'loading') {
+    return <FetchLoading>로딩 중...</FetchLoading>;
+  }
+
   return (
     <div className={styles.container}>
       <div className={styles.top}>
@@ -126,7 +128,7 @@ export default function PostWritePage() {
         <div className={styles.profileBox}>
           <div className={styles.profileBoxLeft}>
             <Icon id='cloud' width='25' height='16' />
-            <p>김준희</p>
+            <p>{userInfo.nickname}</p>
             <p className={styles.dot}></p>
             <p>{formattedNowTime()}</p>
           </div>

--- a/src/pages/PostPage/PostWritePage/PostWritePage.module.css
+++ b/src/pages/PostPage/PostWritePage/PostWritePage.module.css
@@ -10,6 +10,7 @@
 
 .center {
   padding: 0 20px;
+  background-color: #eaf5fd;
 }
 
 .categorySelect {
@@ -73,6 +74,7 @@
   display: flex;
   flex-direction: column;
   row-gap: 36px;
+  padding-bottom: 110px;
 }
 
 .title {


### PR DESCRIPTION
## 🎯 관련 이슈

close #181

<br />

## 🚀 작업 내용

- 좋아요 로직을 스크랩과 일치시키도록 수정
- 수정된 로직을 게시글, 댓글, 대댓글에 적용함 (시험후기 쪽은 별도 적용 필요)
- useScrap에도 자기글 스크랩 못하도록 토스트 설정
- PostPage 'views' 글자 크게 뜨던 거 span태그로 처리해서 다시 작게 수정
- useComment에 alert를 Toast로 수정
- PostBar에 좋아요와 스크랩 여부에 따라 아이콘 색 채움 
- 게시판 리스트에서 '베숙트' 제외 (주석 처리)
- 게시글 작성 페이지의 바닥 흰 배경 오류 수정
- 게시글 작성 페이지 유저 이름 데이터 받아와 띄우기

<br />

## 📸 스크린샷
| <img width="609" alt="image" src="https://github.com/user-attachments/assets/5693b10a-3a55-4f13-834d-ce00a538fdf1"> | <img width="608" alt="스크린샷 2024-08-26 오후 3 09 55" src="https://github.com/user-attachments/assets/9f4164ef-e16d-4395-9ec1-b768a2f0f2c7">  |  
| :---------------------: | :---------------------: | 
| 베숙트 제외  | 좋아요 스크랩 여부에 따라 아이콘 색 |

| <img width="611" alt="image" src="https://github.com/user-attachments/assets/4abcae40-da44-425f-8e11-d6caa53b1f67"> | <img width="615" alt="스크린샷 2024-08-26 오후 3 10 45" src="https://github.com/user-attachments/assets/ee10df2b-5a00-4758-b5d7-d651862a99e3"> |
| :---------------------: | :---------------------: | 
| 게시글 작성 페이지에 닉네임 받아와 띄우기  | 좋아요, 스크랩 훅 적용 | 


<br />

## 🔎 발견된 장애가 있었나요?

- 스크랩 api 백엔드에서 수정해주셔서 잘 작동하는데 한 가지 오류 남음
- postScrap을 했을 때 scrapCount가 안 올라가서 deleteScrap을 하면 scrapCount가 음수값이 되어버림
- 이 부분은 백엔드에서 고쳐주면 해결될 문제라 그대로 놔두고 Pr 올림

<br />

## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

- 좋아요 로직 수정과 어제 회의 때 나온 여러 수정사항들 중 일부 고쳤습니다

<br />
