### PR TITLE
#183 [STYLE] NoticeBar UI 수정 & FetchLoading 적용

### DIFF
--- a/src/components/Loading/FetchLoading.jsx
+++ b/src/components/Loading/FetchLoading.jsx
@@ -1,11 +1,11 @@
 import styles from './FetchLoading.module.css';
 import { Icon } from '../Icon';
 
-export default function FetchLoading({ children }) {
+export default function FetchLoading({ children, animation = true }) {
   return (
     <div className={styles.loading}>
       <div className={styles.centerBox}>
-        <div className={styles.icon}>
+        <div className={animation ? styles.icon : styles.icon_static}>
           <Icon id='cloud' width='25' height='16' />
         </div>
         <p>{children}</p>

--- a/src/components/Loading/FetchLoading.module.css
+++ b/src/components/Loading/FetchLoading.module.css
@@ -1,6 +1,7 @@
+/* 기본 로딩 스타일 */
 .loading {
   width: 100%;
-  height: 100%;
+  height: calc(100% - 56px - 86px);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -20,14 +21,18 @@
   animation: rotateAndPause 2s linear infinite;
 }
 
+.icon_static {
+  animation: none;
+}
+
 @keyframes rotateAndPause {
   0% {
-    transform: rotate(0deg); /* 시작 상태 */
+    transform: rotate(0deg);
   }
   15% {
-    transform: rotate(180deg); /* 반 바퀴 회전 */
+    transform: rotate(180deg);
   }
   100% {
-    transform: rotate(180deg); /* 반 바퀴 회전 후 멈춤 */
+    transform: rotate(180deg);
   }
 }

--- a/src/components/NoticeBar/NoticeBar.jsx
+++ b/src/components/NoticeBar/NoticeBar.jsx
@@ -9,26 +9,18 @@ export default function NoticeBar({ data, onClick }) {
     <div className={styles.post} onClick={onClick}>
       <div className={styles.post_top}>
         <p className={styles.title}>{data.title}</p>
-        <div className={styles.more_option}>
-          <Icon id='ellipsis-vertical' width={3} height={11} fill='#484848' />
-        </div>
       </div>
       <div className={styles.post_center}>
         <p className={styles.text}>{data.content}</p>
       </div>
       <div className={styles.postBottom}>
-        <div className={styles.postBottomLeft}>{formattedDate}</div>
+        <span>{formattedDate}</span>
         <div className={styles.postBottomRight}>
           <Icon id='comment' width={13} height={11} fill='#D9D9D9' />
           <span className={styles.comment_cnt}>
             {data.commentCount.toLocaleString()}
           </span>
-          <Icon
-            id='like'
-            width={12}
-            height={11}
-            fill={data.liked ? '#5F86BF' : '#D9D9D9'}
-          />
+          <Icon id='like' width={12} height={11} fill='#D9D9D9' />
           <span className={styles.like_cnt}>
             {data.likeCount.toLocaleString()}
           </span>

--- a/src/components/NoticeBar/NoticeBar.module.css
+++ b/src/components/NoticeBar/NoticeBar.module.css
@@ -11,8 +11,8 @@
 }
 
 .title {
-  font-size: 12px;
-  line-height: 130%;
+  font-size: 14px;
+  line-height: 150%;
   font-weight: 500;
   letter-spacing: -0.5px;
   display: -webkit-box;
@@ -22,21 +22,17 @@
   text-overflow: ellipsis;
 }
 
-.more_option {
-  margin-left: auto;
-}
-
 .post_center {
   padding-top: 6px;
 }
 
 .text {
-  font-size: 11px;
-  line-height: 140%;
+  font-size: 13px;
+  line-height: 150%;
   letter-spacing: -0.5px;
   color: #484848;
   display: -webkit-box;
-  -webkit-line-clamp: 4;
+  -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -45,18 +41,17 @@
 .postBottom {
   display: flex;
   justify-content: space-between;
-  padding: 6px 0 0 0;
+  align-items: center;
+  padding: 8px 0 0 0;
   color: #898989;
-}
-
-.postBottomLeft {
-  font-size: 9px;
+  font-weight: 400;
+  font-size: 11px;
   line-height: 150%;
   letter-spacing: -0.5px;
 }
 
 .postBottomRight {
-  gap: 5px;
+  gap: 6px;
   display: flex;
   align-items: center;
 

--- a/src/pages/BoardPage/BoardListPage/BoardListPage.jsx
+++ b/src/pages/BoardPage/BoardListPage/BoardListPage.jsx
@@ -16,6 +16,7 @@ import {
   PTR,
   Target,
   WriteButton,
+  FetchLoading,
 } from '@/components';
 
 import timeAgo from '@/utils/timeAgo';
@@ -30,18 +31,26 @@ export default function BoardListPage() {
   const currentBoard =
     BOARD_MENUS.find((menu) => menu.textId === currentBoardTextId) || {};
 
-  const { data, hasNextPage, isFetching, status, fetchNextPage, refetch } =
-    useInfiniteQuery({
-      queryKey: ['postList', currentBoard.id],
-      queryFn: ({ pageParam }) => getPostList(currentBoard.id, pageParam),
-      getNextPageParam: (lastPage, allPages, lastPageParam) => {
-        if (lastPage.length === 0) {
-          return undefined;
-        }
-        return lastPage.length > 0 ? (lastPageParam || 0) + 1 : undefined;
-      },
-      refetchInterval: false,
-    });
+  const {
+    data,
+    hasNextPage,
+    isFetching,
+    isLoading,
+    isError,
+    status,
+    fetchNextPage,
+    refetch,
+  } = useInfiniteQuery({
+    queryKey: ['postList', currentBoard.id],
+    queryFn: ({ pageParam }) => getPostList(currentBoard.id, pageParam),
+    getNextPageParam: (lastPage, allPages, lastPageParam) => {
+      if (lastPage.length === 0) {
+        return undefined;
+      }
+      return lastPage.length > 0 ? (lastPageParam || 0) + 1 : undefined;
+    },
+    refetchInterval: false,
+  });
 
   const ref = useIntersect(
     async (entry, observer) => {
@@ -79,6 +88,26 @@ export default function BoardListPage() {
       navigate(to);
     };
   };
+
+  if (isLoading) {
+    return (
+      <>
+        <BackAppBar />
+        <FetchLoading>게시글 불러오는 중...</FetchLoading>
+      </>
+    );
+  }
+
+  if (isError) {
+    return (
+      <>
+        <BackAppBar />
+        <FetchLoading animation={false}>
+          게시글을 불러오지 못했습니다.
+        </FetchLoading>
+      </>
+    );
+  }
 
   return (
     <div className={styles.container}>

--- a/src/pages/NoticeListPage/NoticeListPage.jsx
+++ b/src/pages/NoticeListPage/NoticeListPage.jsx
@@ -2,8 +2,7 @@ import { useState, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 
-import { BackAppBar } from '@/components/AppBar';
-import NoticeBar from '@/components/NoticeBar/NoticeBar.jsx';
+import { BackAppBar, NoticeBar, FetchLoading } from '@/components';
 
 import { getNoticeList } from '@/apis/notice';
 import { BOARD_MENUS } from '../../constants';
@@ -19,7 +18,7 @@ export default function NoticeListPage() {
     BOARD_MENUS.find((menu) => menu.textId === currentBoardTextId) || {};
 
   // 게시글 데이터 받아오기
-  const { data } = useQuery({
+  const { data, isLoading, isError } = useQuery({
     queryKey: ['noticeList', currentBoard?.id],
     queryFn: () => getNoticeList(currentBoard?.id),
     enabled: !!currentBoard?.id,
@@ -37,6 +36,26 @@ export default function NoticeListPage() {
       navigate(to);
     };
   };
+
+  if (isLoading) {
+    return (
+      <>
+        <BackAppBar />
+        <FetchLoading>공지글 불러오는 중...</FetchLoading>
+      </>
+    );
+  }
+
+  if (isError) {
+    return (
+      <>
+        <BackAppBar />;
+        <FetchLoading animation={false}>
+          게시글을 불러오지 못했습니다.
+        </FetchLoading>
+      </>
+    );
+  }
 
   return (
     <div className={styles.container}>


### PR DESCRIPTION
## 🎯 관련 이슈

close #183

<br />

## 🚀 작업 내용

- NoticeBar에 PostBar와 같은 폰트 사이즈 적용 & vertical-bar 제거
- FetchLoading 컴포넌트 수정 - (animation=true) 옵션 선택 가능
- 게시글 리스트 페이지와 공지글 페이지에 FetchLoading 추가

<br />

## 📸 스크린샷
| <img width="610" alt="스크린샷 2024-08-26 오후 6 31 18" src="https://github.com/user-attachments/assets/e29a196c-4b6a-47b5-b2e3-7cc8835d3a64"> | <img width="617" alt="스크린샷 2024-08-26 오후 6 33 18" src="https://github.com/user-attachments/assets/ba1e3c98-a2ab-4c10-aa52-0821bcb79ac8">  |  
| :---------------------: | :---------------------: | 
| isLoading=true  | isError=true |

* 서버 에러로 공지글 리스트 관련 스크린샷은 미첨부