### PR TITLE
#186 [FEAT] 스크랩 에러 핸들링 및 시험후기 페이지 스크랩 아이콘 수정

### DIFF
--- a/src/components/Comment/Comment/Comment.module.css
+++ b/src/components/Comment/Comment/Comment.module.css
@@ -80,7 +80,7 @@
 }
 
 .commentCount:hover {
-  background-color: #e8e8e8;
+  background-color: #e9e9e9;
 }
 
 .likedCount {
@@ -98,7 +98,7 @@
 }
 
 .likedCount:hover {
-  background-color: #e8e8e8;
+  background-color: #e9e9e9;
 }
 
 .nestedComment {

--- a/src/constants/toast.js
+++ b/src/constants/toast.js
@@ -11,6 +11,10 @@ const TOAST = Object.freeze({
     id: 'EXAM_REVIEW_DOWNLOAD',
     message: '50P 차감되었어요',
   },
+  NO_SELF_SCRAP: {
+    id: 'NO_SELF_SCROP',
+    message: '내 게시글은 스크랩할 수 없어요',
+  },
   POST_EDIT_SUCCESS: { id: 'POST_EDIT_SUCCESS', message: '게시글 수정 완료' },
   POST_EDIT_FAIL: { id: 'POST_EDIT_FAIL', message: '게시글 수정 실패' },
   POST_CREATE_SUCCESS: {

--- a/src/hooks/useScrap.jsx
+++ b/src/hooks/useScrap.jsx
@@ -3,7 +3,11 @@ import { useQueryClient, useMutation } from '@tanstack/react-query';
 
 import { scrap as ScrapApi, deleteScrap as deleteScrapApi } from '../apis';
 
+import { useToast } from '@/hooks';
+import { TOAST } from '@/constants/toast.js';
+
 export default function useScrap() {
+  const { toast } = useToast();
   const { postId } = useParams();
   const { pathname } = useLocation();
 
@@ -18,6 +22,11 @@ export default function useScrap() {
         queryClient.invalidateQueries(['reviewDetail', postId]);
       } else {
         queryClient.invalidateQueries(['postContent', postId]);
+      }
+    },
+    onError: (error) => {
+      if (error.response.data.code === 3801) {
+        toast(TOAST.NO_SELF_SCRAP);
       }
     },
   });

--- a/src/pages/ExamReviewPage/ExamReviewDetailPage/ExamReviewDetailPage.jsx
+++ b/src/pages/ExamReviewPage/ExamReviewDetailPage/ExamReviewDetailPage.jsx
@@ -81,24 +81,24 @@ export default function ExamReviewDetailPage() {
   const remove = () => deleteReview.mutate();
 
   const {
-    userDisplay,
-    isWriter,
-    title,
     commentCount,
-    scrapCount,
-    isScrap,
     createdAt,
-    lectureName,
-    professor,
-    lectureYear,
-    semester,
-    lectureType,
-    isPF,
     examType,
-    isConfirmed,
     fileName,
+    isConfirmed,
     isEdited,
+    isPF,
+    isScrapped,
+    isWriter,
+    lectureName,
+    lectureType,
+    lectureYear,
+    professor,
     questionDetail,
+    scrapCount,
+    semester,
+    title,
+    userDisplay,
   } = data;
 
   return (
@@ -126,23 +126,15 @@ export default function ExamReviewDetailPage() {
               />
             )}
           </div>
-          <div className={styles.actions}>
+          {isWriter && (
             <Icon
-              id={isScrap ? 'bookmark-fill' : 'bookmark-line'}
-              width='14'
-              height='18'
-              fill='#5F86BF'
-              onClick={() => (isScrap ? deleteScrap.mutate() : scrap.mutate())}
+              onClick={() => setIsOptionModalOpen(true)}
+              id='ellipsis-vertical'
+              width='3'
+              height='11'
+              style={{ padding: '0 4px', cursor: 'pointer' }}
             />
-            {isWriter && (
-              <Icon
-                onClick={() => setIsOptionModalOpen(true)}
-                id='ellipsis-vertical'
-                width='3'
-                height='11'
-              />
-            )}
-          </div>
+          )}
         </div>
         <div className={styles.title}>{title}</div>
         <div className={styles.content}>
@@ -158,8 +150,8 @@ export default function ExamReviewDetailPage() {
           <ReviewContentItem tag='시험 유형 및 문항수' value={questionDetail} />
         </div>
         <ReviewDownload className={styles.fileDownload} fileName={fileName} />
-        <div className={styles.counts}>
-          <div className={styles.count}>
+        <div className={styles.actions}>
+          <div className={styles.action}>
             <Icon
               className={styles.comment}
               id='comment'
@@ -169,8 +161,16 @@ export default function ExamReviewDetailPage() {
             />
             <span>{commentCount.toLocaleString()}</span>
           </div>
-          <div className={styles.count}>
-            <Icon id='bookmark-fill' width='10' height='13' fill='#5F86BF' />
+          <div
+            className={styles.action}
+            onClick={() => (isScrapped ? deleteScrap.mutate() : scrap.mutate())}
+          >
+            <Icon
+              id='bookmark-fill'
+              width='10'
+              height='13'
+              fill={isScrapped ? '#5F86BF' : '#D9D9D9'}
+            />
             <span>{scrapCount.toLocaleString()}</span>
           </div>
         </div>

--- a/src/pages/ExamReviewPage/ExamReviewDetailPage/ExamReviewDetailPage.module.css
+++ b/src/pages/ExamReviewPage/ExamReviewDetailPage/ExamReviewDetailPage.module.css
@@ -39,13 +39,6 @@
   border-radius: 100%;
 }
 
-.actions {
-  display: flex;
-  align-items: center;
-  gap: 15px;
-  cursor: pointer;
-}
-
 .title {
   margin: 0 var(--default-margin);
   font-weight: 700;
@@ -65,22 +58,28 @@
   margin: 0 var(--default-margin) 0 auto;
 }
 
-.counts {
+.actions {
   margin: 15px var(--default-margin) 0 0;
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  gap: 12px;
   font-size: 11px;
   line-height: 150%;
   letter-spacing: -0.5px;
   color: #898989;
 }
 
-.count {
+.action {
+  padding: 4px 8px;
   display: flex;
   align-items: center;
   gap: 6px;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.action:hover {
+  background-color: #ffffffcc;
 }
 
 .comment {


### PR DESCRIPTION
## 🎯 관련 이슈

close #186 

<br />

## 🚀 작업 내용

- 스크랩 api 응답 멤버 변수 중 isScrap => isScrapped으로 변경된 것 반영
- 내 게시글 스크랩 시 토스트로 경고 띄우기
- 스크랩 기능을 기존 상단 북마크 아이콘에서 하단 액션 아이콘으로 이동(상단 북마크 아이콘은 삭제)

<br />

## 📸 스크린샷

| <img width="323" alt="image" src="https://github.com/user-attachments/assets/ac05733b-4739-44fb-ba37-8463cef268fe"> |
| :---------------------: |
| 내 게시글 스크랩한 경우 |

<br />


## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

- 내 게시글 스크랩  시 발생하는 에러 핸들링 로직은 `useScrap`에 추가했습니다.
  - toast 띄우는 로직