### PR TITLE
#194 [MODIFY] 메인페이지 보드 카드에 게시판 링크 연결 및 베숙트 숨기기

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -1,4 +1,5 @@
-import { Icon } from '../Icon';
+import { Icon } from '@/components/Icon';
+
 import styles from './Footer.module.css';
 
 export default function Footer() {

--- a/src/components/Footer/Footer.module.css
+++ b/src/components/Footer/Footer.module.css
@@ -1,5 +1,5 @@
 .footer {
-  padding: 1.75rem 0 7rem 0;
+  padding-top: 1.75rem;
   margin-top: 2.75rem;
   display: flex;
   flex-direction: column;
@@ -15,7 +15,6 @@
   text-align: center;
   letter-spacing: -0.5px;
   color: #6a6a6a;
-  background: linear-gradient(180deg, #f9f9f9 0%, #ffffff 100%);
 }
 
 .contact {

--- a/src/constants/boardMenus.js
+++ b/src/constants/boardMenus.js
@@ -6,6 +6,7 @@ import besookt from '../assets/images/besookt-board-page.svg';
 export const BOARD_MENUS = [
   {
     id: 21,
+    to: '/board/first-snow',
     textId: 'first-snow',
     title: '첫눈온방',
     desc: '새내기 전용 커뮤니티',
@@ -13,6 +14,7 @@ export const BOARD_MENUS = [
   },
   {
     id: 22,
+    to: '/board/first-snow',
     textId: 'large-snow',
     title: '함박눈방',
     desc: '눈송이 모두가\n이용하는 커뮤니티',
@@ -20,6 +22,7 @@ export const BOARD_MENUS = [
   },
   {
     id: 23,
+    to: '/board/first-snow',
     textId: 'permanent-snow',
     title: '만년설방',
     desc: '졸업생 전용 게시판',
@@ -28,6 +31,7 @@ export const BOARD_MENUS = [
   // 2차 개발 시 추가 예정
   // {
   //   id: 20,
+  //   to: '/board/besookt',
   //   textId: 'besookt',
   //   title: '베숙트',
   //   desc: '추천을 가장 많이\n받은 게시물 모아보기',
@@ -35,6 +39,7 @@ export const BOARD_MENUS = [
   // },
   {
     id: 32,
+    to: '/board/exam-review',
     textId: 'exam-review',
     title: '시험후기',
     desc: '시험 정보를 조회할 수\n있는 게시판입니다.',

--- a/src/pages/MainPage/MainPage.jsx
+++ b/src/pages/MainPage/MainPage.jsx
@@ -66,7 +66,7 @@ export default function MainPage() {
           ))}
         </Flex>
       </Margin>
-      {BESOOKTS.length > 0 && (
+      {/* {BESOOKTS.length > 0 && (
         <Margin className={styles.besookt}>
           <ListHeader to='/board/besookt' title='베숙트' />
           <Flex direction='column' gap='0.375rem'>
@@ -95,7 +95,7 @@ export default function MainPage() {
             )}
           </Flex>
         </Margin>
-      )}
+      )} */}
       <Footer />
     </main>
   );


### PR DESCRIPTION
## 🎯 관련 이슈

close #194
<br />

## 🚀 작업 내용

- 메인페이지 보드 카드에 게시판 링크 연결
- 베숙트 3개 글 미리보기 숨기기

<br />

## 📸 스크린샷

| <img width="323" alt="image" src="https://github.com/user-attachments/assets/a96ad925-994c-435d-ade7-10f69e032d7b"> | <img width="323" alt="image" src="https://github.com/user-attachments/assets/a095663b-b07d-43cc-916d-e5c4b653a900"> |
| :---------------------: | :---------------------: |
| 수정 전 메인 페이지| 수정 후 메인 페이지 |

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
