### PR TITLE
#200 [STYLE] 시험후기 상세 페이지의 댓글 아이콘 색상 회색으로 변경

### DIFF
--- a/src/pages/ExamReviewPage/ExamReviewDetailPage/ExamReviewDetailPage.jsx
+++ b/src/pages/ExamReviewPage/ExamReviewDetailPage/ExamReviewDetailPage.jsx
@@ -157,7 +157,7 @@ export default function ExamReviewDetailPage() {
               id='comment'
               width='15'
               height='14'
-              fill='#5F86BF'
+              fill='#D9D9D9'
             />
             <span>{commentCount.toLocaleString()}</span>
           </div>


### PR DESCRIPTION
## 🎯 관련 이슈

close #200

<br />

## 🚀 작업 내용

- 시험후기 상세 페이지 하단 댓글 아이콘 색상을 #D9D9D9으로 변경

<br />

## 📸 스크린샷

| <img width="323" alt="image" src="https://github.com/user-attachments/assets/c97f6ea7-2514-4163-87c3-c81331b83e01"> |
| :---------------------: |
| 시험후기 하단 댓글 아이콘 색상 변경 |

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
