### PR TITLE
#210 [MODIFY] 포인트 내역 보기 내 '시험후기 삭제' enum 추가

### DIFF
--- a/src/constants/point.js
+++ b/src/constants/point.js
@@ -41,6 +41,7 @@ export const POINT_CATEGORY_KOREAN_ENUM = Object.freeze({
   COMMENT_DELETE: '댓글 삭제',
   EXAM_REVIEW_CREATE: '시험후기 작성',
   EXAM_REVIEW_DOWNLOAD: '시험후기 다운로드',
+  EXAM_REVIEW_DELETE: '시험후기 삭제',
   LECTURE_REVIEW_CREATE: '강의후기 작성',
   POINT_REWARD_10_LIKES: '좋아요 10개 게시글',
   POINT_REWARD_100_LIKES: '좋아요 100개 게시글',


### PR DESCRIPTION
## 🎯 관련 이슈

close #210

<br />

## 🚀 작업 내용

- `포인트 내역 보기` 페이지 내 `시험후기 삭제` enum 추가

<br />

## 📸 스크린샷

| <img width='250' src='https://github.com/user-attachments/assets/959165fe-75b2-4640-8d5b-3fb11a7bf87c'> |  <img width='250' src='https://github.com/user-attachments/assets/b06c3b00-33fd-429e-9d63-2b50e7db0a95'> |  
| :---------------------: |  :---------------------: | 
| 수정 전 | 수정 후 |

<br />
