### PR TITLE
#209 [MODIFY] 마이페이지 내 alert > toast message로 수정

### DIFF
--- a/src/components/Toast/Toast.module.css
+++ b/src/components/Toast/Toast.module.css
@@ -12,5 +12,6 @@
   font-size: 0.75rem;
   line-height: 130%;
   letter-spacing: -0.5px;
+  white-space: pre-wrap;
   color: #ffffff;
 }

--- a/src/constants/toast.js
+++ b/src/constants/toast.js
@@ -121,6 +121,10 @@ const TOAST = Object.freeze({
     id: 'UPDATE_PASSWORD_SUCCESS',
     message: '비밀번호 수정이 완료되었습니다.',
   },
+  UPDATE_USER_INFO_SUCCESS: {
+    id: 'UPDATE_USER_INFO_SUCCESS',
+    message: '회원 정보 수정이 완료되었습니다.',
+  },
 });
 
 export { TOAST };

--- a/src/constants/toast.js
+++ b/src/constants/toast.js
@@ -15,8 +15,14 @@ const TOAST = Object.freeze({
     id: 'NO_SELF_SCROP',
     message: '내 게시글은 스크랩할 수 없어요',
   },
-  POST_EDIT_SUCCESS: { id: 'POST_EDIT_SUCCESS', message: '게시글 수정 완료' },
-  POST_EDIT_FAIL: { id: 'POST_EDIT_FAIL', message: '게시글 수정 실패' },
+  POST_EDIT_SUCCESS: {
+    id: 'POST_EDIT_SUCCESS',
+    message: '게시글 수정 완료',
+  },
+  POST_EDIT_FAIL: {
+    id: 'POST_EDIT_FAIL',
+    message: '게시글 수정 실패',
+  },
   POST_CREATE_SUCCESS: {
     id: 'POST-CREATE-SUCCESS',
     message: '게시글 등록 성공!',
@@ -53,7 +59,10 @@ const TOAST = Object.freeze({
     id: 'COMMENT_EDIT_SUCCESS',
     message: '댓글 수정 완료',
   },
-  COMMENT_EDIT_FAIL: { id: 'COMMENT_EDIT_FAIL', message: '댓글 수정 실패' },
+  COMMENT_EDIT_FAIL: {
+    id: 'COMMENT_EDIT_FAIL',
+    message: '댓글 수정 실패',
+  },
   COMMENT_CREATE_SUCCESS: {
     id: 'COMMENT-CREATE-SUCCESS',
     message: '댓글 등록 성공!',
@@ -106,6 +115,11 @@ const TOAST = Object.freeze({
   SCRAP_SELF_ERROR: {
     id: 'SCRAP_SELF_ERROR',
     message: '자신의 글은 스크랩할 수 없습니다.',
+  },
+
+  UPDATE_PASSWORD_SUCCESS: {
+    id: 'UPDATE_PASSWORD_SUCCESS',
+    message: '비밀번호 수정이 완료되었습니다.',
   },
 });
 

--- a/src/constants/toast.js
+++ b/src/constants/toast.js
@@ -125,6 +125,14 @@ const TOAST = Object.freeze({
     id: 'UPDATE_USER_INFO_SUCCESS',
     message: '회원 정보 수정이 완료되었습니다.',
   },
+  WITHDRAW_ACCOUNT_SUCCESS: {
+    id: 'UPDATE_USER_INFO_SUCCESS',
+    message: '회원 탈퇴가 완료되었습니다.',
+  },
+  WITHDRAW_ACCOUNT_ERROR: {
+    id: 'WITHDRAW_ACCOUNT_ERROR',
+    message: '회원 탈퇴에 실패했습니다.\n다시 시도해주세요.',
+  },
 });
 
 export { TOAST };

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -2,9 +2,12 @@ import { useNavigate } from 'react-router-dom';
 import { useEffect, useMemo } from 'react';
 import { getMyPageUserInfo, withdrawAccount } from '@/apis';
 import { useQuery } from '@tanstack/react-query';
+import { useToast } from '.';
+import { TOAST } from '@/constants';
 
 const useAuth = ({ isRequiredAuth = false } = {}) => {
   const navigate = useNavigate();
+  const { toast } = useToast();
 
   const hasToken = !!localStorage.getItem('token');
 
@@ -42,14 +45,14 @@ const useAuth = ({ isRequiredAuth = false } = {}) => {
       await withdrawAccount({
         currentPassword,
       });
-      alert('회원 탈퇴가 완료되었습니다.');
+      toast(TOAST.WITHDRAW_ACCOUNT_SUCCESS);
       logout();
 
       if (onSuccess !== undefined) {
         onSuccess();
       }
     } catch {
-      alert('회원 탈퇴에 실패했습니다. 다시 시도해주세요.');
+      toast(TOAST.WITHDRAW_ACCOUNT_ERROR);
 
       if (onError !== undefined) {
         onError();

--- a/src/pages/MyPage/ChangePasswordPage/ChangePasswordPage.jsx
+++ b/src/pages/MyPage/ChangePasswordPage/ChangePasswordPage.jsx
@@ -4,6 +4,8 @@ import { BackAppBar, ActionButton, InputPassword } from '@/components';
 import { useMutation } from '@tanstack/react-query';
 import { updatePassword } from '@/apis';
 import { useNavigate } from 'react-router-dom';
+import { useToast } from '@/hooks';
+import { TOAST } from '@/constants';
 
 export default function ChangePasswordPage() {
   const [currentPassword, setCurrentPassword] = useState('');
@@ -13,17 +15,21 @@ export default function ChangePasswordPage() {
   const [newPasswordCheckError, setNewPasswordCheckError] = useState('');
 
   const navigate = useNavigate();
+  const { toast } = useToast();
 
   const { mutate: updatePasswordMutate, isPending: isUpdatePasswordPending } =
     useMutation({
       mutationKey: ['updatePassword'],
       mutationFn: (body) => updatePassword(body),
       onSuccess: () => {
-        alert('비밀번호 수정이 완료되었습니다.');
+        toast(TOAST.UPDATE_PASSWORD_SUCCESS);
         navigate('/my-page');
       },
       onError: ({ response }) => {
-        alert(response.data.message);
+        toast({
+          id: 'UPDATE_PASSWORD_ERROR',
+          message: response.data.message,
+        });
       },
     });
 

--- a/src/pages/MyPage/ChangePasswordPage/ChangePasswordPage.jsx
+++ b/src/pages/MyPage/ChangePasswordPage/ChangePasswordPage.jsx
@@ -62,7 +62,6 @@ export default function ChangePasswordPage() {
 
   const handleSubmitButtonClick = () => {
     if (newPassword !== newPasswordCheck) {
-      alert('비밀번호가 일치하지 않습니다.');
       return;
     }
 

--- a/src/pages/MyPage/EditInfoPage/EditInfoPage.jsx
+++ b/src/pages/MyPage/EditInfoPage/EditInfoPage.jsx
@@ -7,10 +7,10 @@ import {
   CategoryFieldset,
   Dropdown,
 } from '@/components';
-import { MAJORS } from '@/constants';
+import { MAJORS, TOAST } from '@/constants';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { updateUserInfo } from '@/apis';
-import { useAuth } from '@/hooks';
+import { useAuth, useToast } from '@/hooks';
 import { useNavigate } from 'react-router-dom';
 
 const VALIDATIONS = Object.freeze({
@@ -36,6 +36,7 @@ export default function EditInfoPage() {
 
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const { toast } = useToast();
 
   const { mutate: updateUserInfoMutate, isPending: isUpdateUserInfoPending } =
     useMutation({
@@ -46,20 +47,22 @@ export default function EditInfoPage() {
           queryKey: ['myPageUserInfo'],
         });
 
-        alert('회원 정보 수정이 완료되었습니다.');
+        toast(TOAST.UPDATE_USER_INFO_SUCCESS);
         navigate('/my-page');
       },
       onError: ({ response }) => {
         const { data } = response;
 
-        alert(
-          data.userProfile ||
+        toast({
+          id: 'UPDATE_USER_INFO_ERROR',
+          message:
+            data.userProfile ||
             data.userName ||
             data.birthday ||
             data.nickname ||
             data.major ||
-            data.message
-        );
+            data.message,
+        });
       },
     });
 


### PR DESCRIPTION
## 🎯 관련 이슈

close #209

<br />

## 🚀 작업 내용

- 마이페이지 내 alert > toast 로 수정
  - `비밀번호 변경` 페이지
  - `내 정보 수정` 페이지
  - `회원탈퇴` 페이지
- `비밀번호 변경` 페이지 내에서 비밀번호가 일치하지 않을 경우 early return 되도록 수정
  - 비밀번호가 일치하지 않을 경우, `완료` 버튼이 비활성화 되기 때문에 toast를 띄울 필요 없음
  (#145 참고)
  <img width='250' src='https://github.com/user-attachments/assets/ad2bd1a7-41a2-4d5e-847e-c874bc935962'>


<br />

## 📸 스크린샷

| <img height='550' src='https://github.com/user-attachments/assets/79a55bbb-7af1-4acd-841c-58aaa7a30908'> | <img height='550' src='https://github.com/user-attachments/assets/dfd5b75c-03bf-4034-b7d8-b2c4c3e3ea60'> |
| :---------------------: | :---------------------: |
| `비밀번호  변경` - 성공 | `비밀번호  변경` - 실패 |

| <img height='550' src='https://github.com/user-attachments/assets/201d625e-07ba-4883-b7e7-a18c8d0a0b6e'> | <img height='550' src='https://github.com/user-attachments/assets/fd3b1656-6fea-479b-ad5b-a7aa7db63739'> |
| :---------------------: | :---------------------: |
| `내 정보 수정` - 실패 | `내 정보 수정` - 실패2 |

| <img height='550' src='https://github.com/user-attachments/assets/eee2c214-aef1-40a5-8859-9dcdbe50e631'> | <img height='550' src='https://github.com/user-attachments/assets/eabe75af-831c-42e8-8fb7-fa92efb70537'> |
| :---------------------: | :---------------------: |
| `회원탈퇴` - 성공 | `회원탈퇴` - 실패 |

<br />

## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

- toast 메세지가 사라지는 중에 화면 캡쳐를 해서, toast 배경색은 스크린샷마다 다를수 있어요 :)

- `내 정보 수정`페이지에서 아래와 같은 이유로 성공 케이스 스크린샷은 없지만, 동일한 로직으로 코드 수정하였습니다.
  - 이름을 수정하려고 하면 → 유저에게 권한이 없다 (이름, 생년월일은 수정 불가하기 때문)
  - 닉네임을 수정하려고 하면 → 이름이 유효하지 않아서 수정 불가하다

<br />
