### PR TITLE
#216 [FEAT] 댓글 포인트 API 

### DIFF
--- a/src/components/InputBar/InputBar.jsx
+++ b/src/components/InputBar/InputBar.jsx
@@ -1,6 +1,7 @@
-import { useCommentContext } from '../../contexts/CommentContext.jsx';
+import { useCommentContext } from '@/contexts/CommentContext.jsx';
 
-import useComment from '../../hooks/useComment.jsx';
+import { useComment, useToast } from '@/hooks';
+import { TOAST } from '@/constants';
 
 import { Icon } from '../../components/Icon';
 
@@ -8,6 +9,8 @@ import styles from './InputBar.module.css';
 
 const InputBar = () => {
   const { editComment, postComment } = useComment();
+  const { toast } = useToast();
+
   const {
     isEdit,
     setIsEdit,
@@ -17,12 +20,13 @@ const InputBar = () => {
     setContent,
     inputRef,
   } = useCommentContext();
+
   const handleInputChange = (e) => setContent(e.target.value);
 
   // 댓글 등록 or 수정
   const submitComment = () => {
     if (!content.trim()) {
-      alert('댓글을 입력하세요.');
+      toast(TOAST.EMPTY_COMMENT);
       return;
     }
 

--- a/src/constants/toast.js
+++ b/src/constants/toast.js
@@ -68,7 +68,7 @@ const TOAST = Object.freeze({
   COMMENT_EDIT_FAIL: { id: 'COMMENT_EDIT_FAIL', message: '댓글 수정 실패' },
   COMMENT_CREATE_SUCCESS: {
     id: 'COMMENT-CREATE-SUCCESS',
-    message: '댓글 등록 성공!',
+    message: '1P 적립이 완료되었어요',
   },
   COMMENT_CREATE_FAIL: {
     id: 'COMMENT_CREATE_FAIL',

--- a/src/constants/toast.js
+++ b/src/constants/toast.js
@@ -98,6 +98,10 @@ const TOAST = Object.freeze({
     id: 'COMMENT_DELETE_ERROR',
     message: '알 수 없는 오류가 발생했습니다.',
   },
+  EMPTY_COMMENT: {
+    id: 'EMPTY_COMMENT',
+    message:'댓글을 입력하세요.',
+  },
   EMPTY_TITLE: {
     id: 'EMPTY_TITLE_ERROR',
     message: '제목을 입력하세요.',

--- a/src/hooks/useComment.jsx
+++ b/src/hooks/useComment.jsx
@@ -23,43 +23,27 @@ export default function useComment() {
     staleTime: 1000 * 60,
   });
 
+  // 댓글 생성
   const postComment = useMutation({
     mutationFn: async ({ content, parentId }) => {
       const response = await post({ postId, parentId, content });
       const newCommentId = response.data.result.id;
-
       if (response.status === 201) {
-        try {
-          const pointResponse = await updatePoint({
-            userId: 35, // 실제 userId로 교체해야 합니다.
-            category: POINT_CATEGORY_ENUM.COMMENT_CREATE,
-            source: POINT_SOURCE_ENUM.COMMENT,
-            sourceId: newCommentId,
-          });
-
-          if (pointResponse.status !== 200) {
-            throw new Error('Point update failed');
-          }
-        } catch (error) {
-          console.error('Point update error:', error);
-          toast(TOAST.COMMENT_CREATE_FAIL);
-        }
-      } else {
-        toast(TOAST.COMMENT_CREATE_FAIL);
+        await updatePoint({
+          userId: 35, // 실제 userId로 교체해야 합니다.
+          category: POINT_CATEGORY_ENUM.COMMENT_CREATE,
+          source: POINT_SOURCE_ENUM.COMMENT,
+          sourceId: newCommentId,
+        });
       }
     },
     onSuccess: () => {
       queryClient.invalidateQueries(['comments', postId]);
     },
     onError: (error) => {
-      console.log('Mutation error:', error);
-      if (error.response) {
-        const errorStatus = error.response.status;
-        if (errorStatus === 404) {
-          toast(TOAST.COMMENT_NOT_FOUND);
-        } else {
-          toast(TOAST.COMMENT_CREATE_FAIL);
-        }
+      console.log('댓글 생성 에러:', error);
+      if (error.response.status === 404) {
+        toast(TOAST.COMMENT_NOT_FOUND);
       } else {
         toast(TOAST.COMMENT_CREATE_FAIL);
       }

--- a/src/hooks/useComment.jsx
+++ b/src/hooks/useComment.jsx
@@ -38,6 +38,7 @@ export default function useComment() {
       }
     },
     onSuccess: () => {
+      toast(TOAST.COMMENT_CREATE_SUCCESS);
       queryClient.invalidateQueries(['comments', postId]);
     },
     onError: (error) => {
@@ -60,7 +61,7 @@ export default function useComment() {
           userId: 35, // 실제 userId로 교체해야 합니다.
           category: POINT_CATEGORY_ENUM.COMMENT_DELETE,
           source: POINT_SOURCE_ENUM.COMMENT,
-          sourceId: undefined,
+          sourceId: commentId,
         });
       }
     },

--- a/src/hooks/useComment.jsx
+++ b/src/hooks/useComment.jsx
@@ -42,7 +42,6 @@ export default function useComment() {
       queryClient.invalidateQueries(['comments', postId]);
     },
     onError: (error) => {
-      console.log('댓글 생성 에러:', error);
       if (error.response.status === 404) {
         toast(TOAST.COMMENT_NOT_FOUND);
       } else {
@@ -55,7 +54,6 @@ export default function useComment() {
   const deleteComment = useMutation({
     mutationFn: async ({ commentId }) => {
       const response = await remove({ postId, commentId });
-      console.log('response:', response);
       if (response.status === 200) {
         await updatePoint({
           userId: 35, // 실제 userId로 교체해야 합니다.
@@ -70,7 +68,6 @@ export default function useComment() {
       queryClient.invalidateQueries(['comments', postId]);
     },
     onError: (error) => {
-      console.log('댓글 삭제 오류:', error);
       const errorStatus = error.response.status;
       const errorCode = error.response.data.code;
 


### PR DESCRIPTION
## 🎯 관련 이슈

close #216

<br />

## 🚀 작업 내용

- 댓글 생성 / 삭제 포인트 API 연결

<br />

## 📸 스크린샷

| <img width="615" alt="스크린샷 2024-08-30 오전 1 15 25" src="https://github.com/user-attachments/assets/5f66f90d-9174-4f52-8bc5-c2ef99c60e06"> | <img width="617" alt="스크린샷 2024-08-30 오전 1 16 45" src="https://github.com/user-attachments/assets/d9e203b3-e6ca-45de-ad3d-4ad8cff54a46"> |
| :---------------------: | :---------------------: |
| 댓글 생성 | 댓글 삭제 |

<br />

## 🔎 발견된 장애가 있었나요?

- 글 작성으로 포인트 받는 데에는 한계가 있는데 그 부분 백엔드 미구현인 것 같음
- 현재는 제한없이 글 쓰는대로 다 포인트 받음

<br />