### PR TITLE
#212 [MODIFY] 이름, 생년월일 변경 불가를 보여주도록 UI 수정

### DIFF
--- a/src/constants/role.js
+++ b/src/constants/role.js
@@ -13,3 +13,5 @@ export const ROLE_NAME = Object.freeze({
   4: '리자',
   5: '공식계정',
 });
+
+export const PRIVATE_USER_INFO_UPDATE_PERMISSION_ROLE_ID_LIST = [1];

--- a/src/pages/MyPage/EditInfoPage/EditInfoPage.jsx
+++ b/src/pages/MyPage/EditInfoPage/EditInfoPage.jsx
@@ -1,5 +1,5 @@
 import styles from './EditInfoPage.module.css';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   Icon,
   BackAppBar,
@@ -7,7 +7,11 @@ import {
   CategoryFieldset,
   Dropdown,
 } from '@/components';
-import { MAJORS, TOAST } from '@/constants';
+import {
+  MAJORS,
+  TOAST,
+  PRIVATE_USER_INFO_UPDATE_PERMISSION_ROLE_ID_LIST,
+} from '@/constants';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { updateUserInfo } from '@/apis';
 import { useAuth, useToast } from '@/hooks';
@@ -65,6 +69,16 @@ export default function EditInfoPage() {
         });
       },
     });
+
+  const disabledPrivateUserInfoInput = useMemo(() => {
+    if (userInfo === undefined) {
+      return true;
+    }
+
+    return !PRIVATE_USER_INFO_UPDATE_PERMISSION_ROLE_ID_LIST.includes(
+      userInfo.userRoleId
+    );
+  }, [userInfo]);
 
   const handleNameChange = (e) => {
     const value = e.target.value;
@@ -233,58 +247,51 @@ export default function EditInfoPage() {
         <div className={styles.contentContainer}>
           <div className={styles.infoWrapper}>
             <h3 className={styles.title}>이름</h3>
-            <div
-              className={`${styles.inputWrapper} ${nameError ? styles.errorInputWrapper : ''}`}
-            >
-              <input
-                type='text'
-                className={`${styles.inputText} ${nameError ? styles.errorInputText : ''}`}
-                placeholder='이름을 입력하세요'
-                value={name}
-                onChange={handleNameChange}
-              />
-            </div>
+            <input
+              type='text'
+              className={`${styles.inputText} ${nameError ? styles.errorInputText : ''}`}
+              placeholder='이름을 입력하세요'
+              value={name}
+              disabled={disabledPrivateUserInfoInput}
+              onChange={handleNameChange}
+            />
             {nameError && <p className={styles.errorMessage}>{nameError}</p>}
           </div>
+
           <div className={styles.infoWrapper}>
             <h3 className={styles.title}>생년월일</h3>
-            <div
-              className={`${styles.inputWrapper} ${birthDateError ? styles.errorInputWrapper : ''}`}
-            >
-              <input
-                type='text'
-                className={styles.inputText}
-                placeholder='20020101'
-                maxLength={12}
-                value={birthDate.replaceAll('-', '')}
-                onChange={handleBirthDateChange}
-                pattern='\d{4}\.\d{2}\.\d{2}'
-                title='형식: YYYYMMDD (예: 20020101)'
-              />
-            </div>
+            <input
+              type='text'
+              className={`${styles.inputText} ${birthDateError ? styles.errorInputText : ''}`}
+              placeholder='20020101'
+              maxLength={12}
+              value={birthDate.replaceAll('-', '')}
+              pattern='\d{4}\.\d{2}\.\d{2}'
+              title='형식: YYYYMMDD (예: 20020101)'
+              disabled={disabledPrivateUserInfoInput}
+              onChange={handleBirthDateChange}
+            />
             {birthDateError && (
               <p className={styles.errorMessage}>{birthDateError}</p>
             )}
           </div>
+
           <div className={styles.infoWrapper}>
             <h3 className={styles.title}>닉네임</h3>
-            <div
-              className={`${styles.inputWrapper} ${nicknameError ? styles.errorInputWrapper : ''}`}
-            >
-              <input
-                type='text'
-                className={`${styles.inputText} ${nicknameError ? styles.errorInputText : ''}`}
-                placeholder='닉네임을 입력하세요'
-                value={nickname}
-                onChange={handleNicknameChange}
-              />
-            </div>
+            <input
+              type='text'
+              className={`${styles.inputText} ${nicknameError ? styles.errorInputText : ''}`}
+              placeholder='닉네임을 입력하세요'
+              value={nickname}
+              onChange={handleNicknameChange}
+            />
             {nicknameError && (
               <p className={styles.errorMessage}>{nicknameError}</p>
             )}
           </div>
         </div>
       </section>
+
       <CategoryFieldset title='전공' required>
         <Dropdown
           options={MAJORS}

--- a/src/pages/MyPage/EditInfoPage/EditInfoPage.module.css
+++ b/src/pages/MyPage/EditInfoPage/EditInfoPage.module.css
@@ -70,23 +70,23 @@
   letter-spacing: -0.5px;
 }
 
-.inputWrapper {
+.inputText {
   display: flex;
+  width: 100%;
   height: 40px;
   border-radius: 5px;
-  background: var(--Miscellaneous-_Kit-Section-Fill, #f5f5f5);
-  padding-left: 12px;
-}
-
-.inputText {
-  width: 100%;
+  padding: 0 12px;
   border: none;
-  background-color: transparent;
+  background: #f5f5f5;
   outline: none;
   line-height: 150%;
   letter-spacing: -0.5px;
-  color: var(--Black, #000);
+  color: #000000;
   font-size: 12px;
+
+  &:disabled {
+    background: #d9d9d9;
+  }
 }
 
 .errorMessage {
@@ -96,10 +96,6 @@
   line-height: 150%;
   letter-spacing: -0.5px;
   top: 71px;
-}
-
-.errorInputWrapper {
-  background: var(--Pink-1, #fee9eb);
 }
 
 .errorInputText {


### PR DESCRIPTION
## 🎯 관련 이슈

close #212

<br />

## 🚀 작업 내용

- `준회원` 이외의 등급에서는 이름, 생년월일 변경 불가를 보여주도록 UI 수정

<br />

## 📸 스크린샷

| <img width='250' src='https://github.com/user-attachments/assets/104d5c66-12da-4316-b05a-32e54dad84b6'> |  <img width='250' src='https://github.com/user-attachments/assets/db317cc8-8056-4be9-8766-eb654351f69d'> |  
| :---------------------: |  :---------------------: | 
| 준회원 - 수정 가능 | 그 외 - 수정 불가 |

<br />

## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

- 이전에 준희가 approve 했는데, 코드 충돌 과정에서 문제가 생겨 다시 PR 올립니다. 
  (#217 코드 내용 동일)


<br />