### PR TITLE
#253 [STYLE] InputBar에 textAreaAutosize 설정 (5줄까지 보여주고 그 후론 스크롤 생김)

### DIFF
--- a/src/components/InputBar/InputBar.jsx
+++ b/src/components/InputBar/InputBar.jsx
@@ -1,3 +1,4 @@
+import TextareaAutosize from 'react-textarea-autosize';
 import { useCommentContext } from '@/contexts/CommentContext.jsx';
 
 import { useComment, useToast } from '@/hooks';
@@ -58,13 +59,14 @@ const InputBar = () => {
     <div className={styles.container}>
       <div className={styles.input_bar}>
         <Icon id='cloud' width='25' height='16' />
-        <input
+        <TextareaAutosize
           ref={inputRef}
           className={styles.input_zone}
           placeholder='댓글을 입력하세요'
           value={content}
           onChange={handleInputChange}
           onKeyPress={handleKeyPress}
+          maxRows={5}
         />
       </div>
       <Icon

--- a/src/components/InputBar/InputBar.module.css
+++ b/src/components/InputBar/InputBar.module.css
@@ -1,7 +1,7 @@
 .container {
   max-width: var(--default-width);
   width: 100%;
-  height: 83px;
+  min-height: 83px;
   padding: 15px 15px 30px 15px;
   display: flex;
   justify-content: space-between;
@@ -18,7 +18,7 @@
 .input_bar {
   background-color: #f4f4f4;
   width: 100%;
-  height: 40px;
+  min-height: 40px;
   display: flex;
   align-items: center;
   gap: 7px;
@@ -28,12 +28,13 @@
 
 .input_zone {
   width: 100%;
-  height: 20px;
+  min-height: 20px;
   outline: none;
   border: none;
   background-color: transparent;
   font-weight: 400;
   font-size: 12px;
+  resize: none;
 }
 
 .input_zone::placeholder {


### PR DESCRIPTION
## 🎯 관련 이슈

close #253

<br />

## 🚀 작업 내용

- InputBar에 textAreaAutosize 설정
- 5줄까지 보여주고 그 후론 스크롤 생김 (에타 참고)

<br />

## 📸 스크린샷

| <img width="350" alt="스크린샷 2024-09-01 오후 2 55 02" src="https://github.com/user-attachments/assets/732217ce-9405-4c6a-a798-eec1ff40970a"> |
| :---------------------: |
| 5줄 제한 textareaAutosize 설정 |

<br />
