### PR TITLE
#268 [MODIFY] 시험후기 페이지 questionDetail 필수 입력으로 변경

### DIFF
--- a/src/components/AppBar/CloseAppBar/CloseAppBar.jsx
+++ b/src/components/AppBar/CloseAppBar/CloseAppBar.jsx
@@ -4,7 +4,12 @@ import { Icon } from '@/components/Icon';
 
 import styles from './CloseAppBar.module.css';
 
-export default function CloseAppBar({ alignRight, children, stroke, onClick }) {
+export default function CloseAppBar({
+  alignRight,
+  children,
+  stroke = 'black',
+  onClick,
+}) {
   const navigate = useNavigate();
 
   return (
@@ -15,8 +20,8 @@ export default function CloseAppBar({ alignRight, children, stroke, onClick }) {
       <Icon
         className={styles.close}
         id='x'
-        width={22}
-        height={22}
+        width='22'
+        height='22'
         onClick={() => navigate(-1)}
         stroke={stroke}
       />

--- a/src/components/Toast/Toast.jsx
+++ b/src/components/Toast/Toast.jsx
@@ -15,7 +15,7 @@ export default function Toast({ toast }) {
     }, 3000);
 
     const unmount = setTimeout(() => {
-      removeToast(toast);
+      removeToast(toast.message);
     }, 3500);
 
     return () => {

--- a/src/constants/toast.js
+++ b/src/constants/toast.js
@@ -6,6 +6,7 @@ const TOAST = Object.freeze({
     validate: '필수 입력을 모두 작성해주세요',
     create: '100P 적립이 완료되었어요',
     delete: '100P 차감되었어요',
+    edit: '시험후기 수정 완료',
     download: '50P 차감되었어요',
   },
   POST: {

--- a/src/pages/ExamReviewEditPage/ExamReviewEditPage.jsx
+++ b/src/pages/ExamReviewEditPage/ExamReviewEditPage.jsx
@@ -4,6 +4,8 @@ import { useQueryClient, useMutation } from '@tanstack/react-query';
 
 import { editReviewDetail } from '@/apis';
 
+import { useToast } from '@/hooks';
+
 import { ActionButton, CloseAppBar } from '@/components/AppBar';
 import {
   CategoryButton,
@@ -19,22 +21,28 @@ import {
   LECTURE_TYPES,
   ROUTE,
   SEMESTERS,
+  TOAST,
   YEARS,
 } from '@/constants';
 
 export default function ExamReviewEditPage() {
   const { postId } = useParams();
-  const queryClient = useQueryClient();
+  const { state } = useLocation();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
   const editReview = useMutation({
     mutationFn: (edit) => editReviewDetail(postId, edit),
     onSuccess: () => {
       queryClient.invalidateQueries(['reviewDetail', postId]);
       navigate(ROUTE.examReviewDetail(postId), { replace: true });
+      toast(TOAST.EXAM_REVIEW.edit);
     },
-    onError: (error) => console.error(error),
+    onError: ({ response }) => {
+      toast(response.data.message);
+    },
   });
-  const { state } = useLocation();
 
   const [lectureName, setLectureName] = useState(state.lectureName);
   const [professor, setProfessor] = useState(state.professor);
@@ -150,20 +158,6 @@ export default function ExamReviewEditPage() {
           placeholder='선택하세요'
         />
       </CategoryFieldset>
-      <CategoryFieldset
-        title='P/F 여부'
-        required
-        hasCheckbox
-        value={isPF}
-        setFn={setIsPF}
-      />
-      <CategoryFieldset
-        title='온라인(비대면 수업) 여부'
-        required
-        hasCheckbox
-        value={isOnline}
-        setFn={setIsOnline}
-      />
       <CategoryFieldset title='수강 분반' required>
         <Dropdown
           options={CLASS_NUMBERS}
@@ -172,7 +166,21 @@ export default function ExamReviewEditPage() {
           placeholder='선택하세요'
         />
       </CategoryFieldset>
-      <CategoryFieldset title='시험 유형 및 설명'>
+      <CategoryFieldset
+        title='P/F 수업입니다'
+        required
+        hasCheckbox
+        value={isPF}
+        setFn={setIsPF}
+      />
+      <CategoryFieldset
+        title='온라인 수업입니다'
+        required
+        hasCheckbox
+        value={isOnline}
+        setFn={setIsOnline}
+      />
+      <CategoryFieldset title='시험 유형 및 설명' required>
         <Textarea
           value={questionDetail}
           setFn={setQuestionDetail}

--- a/src/pages/ExamReviewWritePage/ExamReviewWritePage.jsx
+++ b/src/pages/ExamReviewWritePage/ExamReviewWritePage.jsx
@@ -98,6 +98,7 @@ export default function ExamReviewWritePage() {
     lectureYear &&
     semester &&
     classNumber &&
+    questionDetail &&
     file;
 
   const handleFile = (event) => {
@@ -244,7 +245,7 @@ export default function ExamReviewWritePage() {
         value={isOnline}
         setFn={setIsOnline}
       />
-      <CategoryFieldset title='시험 유형 및 설명'>
+      <CategoryFieldset title='시험 유형 및 설명' required>
         <Textarea
           value={questionDetail}
           setFn={setQuestionDetail}

--- a/src/pages/ExamReviewWritePage/ExamReviewWritePage.jsx
+++ b/src/pages/ExamReviewWritePage/ExamReviewWritePage.jsx
@@ -222,20 +222,6 @@ export default function ExamReviewWritePage() {
           placeholder='선택하세요'
         />
       </CategoryFieldset>
-      <CategoryFieldset
-        title='P/F 여부'
-        required
-        hasCheckbox
-        value={isPF}
-        setFn={setIsPF}
-      />
-      <CategoryFieldset
-        title='온라인(비대면 수업) 여부'
-        required
-        hasCheckbox
-        value={isOnline}
-        setFn={setIsOnline}
-      />
       <CategoryFieldset title='수강 분반' required>
         <Dropdown
           options={CLASS_NUMBERS}
@@ -244,6 +230,20 @@ export default function ExamReviewWritePage() {
           placeholder='선택하세요'
         />
       </CategoryFieldset>
+      <CategoryFieldset
+        title='P/F 수업입니다'
+        required
+        hasCheckbox
+        value={isPF}
+        setFn={setIsPF}
+      />
+      <CategoryFieldset
+        title='온라인 수업입니다'
+        required
+        hasCheckbox
+        value={isOnline}
+        setFn={setIsOnline}
+      />
       <CategoryFieldset title='시험 유형 및 설명'>
         <Textarea
           value={questionDetail}

--- a/src/pages/ExamReviewWritePage/ExamReviewWritePage.jsx
+++ b/src/pages/ExamReviewWritePage/ExamReviewWritePage.jsx
@@ -16,7 +16,7 @@ import {
   CategoryFieldset,
   Dropdown,
 } from '@/components/Fieldset';
-import { ConfirmModal } from '@/components';
+import { ConfirmModal } from '@/components/Modal';
 import { Icon } from '@/components/Icon';
 import { InputItem, InputList } from '@/components/Input';
 import { Textarea } from '@/components/Fieldset';


### PR DESCRIPTION
## 🎯 관련 이슈

close #268

<br />

## 🚀 작업 내용

- 체크박스 필드의 라벨을 명확하게 수정
- questionDetail을 필수 입력으로 변경

<br />

## 📸 스크린샷

| <img width="321" alt="image" src="https://github.com/user-attachments/assets/a56ff0ca-e49c-445b-bfd1-72397ad89ce4"> | <img width="321" alt="image" src="https://github.com/user-attachments/assets/f5e8359a-72ad-43d3-8403-9e946db46798"> |
| :---------------------: | :---------------------: |
| 수정 전 화면 | 수정 후 화면 |

<br />

## 🔎 발견된 장애가 있었나요?

- Toast가 3초 뒤에도 언마운트 되지 않는 문제가 발생했습니다.
  - 언마운트하는 로직에서 파라미터를 잘못 전달하는 문제가 있어 수정했습니다.

- 시험후기 작성 페이지의 CloseAppBar에서 X 아이콘이 안 보이는 문제가 있었습니다.
  - CloseAppBar의 stroke prop을 default parameter로 두어서 아무 값도 지정하지 않으면 검은색으로 설정되게 수정했습니다.
