### PR TITLE
#275 [MODIFY] 해당 월의 첫 출석인지 아닌지에 따라 다른 메시지 노출

### DIFF
--- a/src/components/Calendar/Calendar.jsx
+++ b/src/components/Calendar/Calendar.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import { getMonthlyAttendanceHistory } from '@/apis';
@@ -8,8 +8,9 @@ import { Tile } from '@/components/Calendar';
 
 import { StyledCalendar } from '@/components/Calendar/Calendar.style.jsx';
 
-export default function Calendar() {
+export default function Calendar({ callback }) {
   const today = new Date();
+  const [activeStartDate, setActiveStartDate] = useState(new Date());
   const [year, setYear] = useState(today.getFullYear());
   const [month, setMonth] = useState(today.getMonth() + 1);
 
@@ -18,6 +19,10 @@ export default function Calendar() {
     queryFn: () => getMonthlyAttendanceHistory({ year, month }),
     staleTime: 1000 * 60 * 7,
   });
+
+  useEffect(() => {
+    callback(data);
+  }, [data]);
 
   if (!data) {
     return null;
@@ -41,8 +46,10 @@ export default function Calendar() {
       showNeighboringMonth={false}
       tileContent={({ date }) => <Tile date={date} data={data} />}
       formatDay={() => {}}
+      activeStartDate={activeStartDate}
       onActiveStartDateChange={({ activeStartDate }) => {
         const active = new Date(activeStartDate);
+        setActiveStartDate(activeStartDate);
         setYear(() => active.getFullYear());
         setMonth(() => active.getMonth() + 1);
       }}

--- a/src/constants/attendance.js
+++ b/src/constants/attendance.js
@@ -1,0 +1,10 @@
+export const ATTENDANCE_MESSAGE = Object.freeze({
+  FIRST: {
+    title: '첫 출석체크',
+    content: '첫 출석을 완료하고 포인트를 받아요',
+  },
+  CONSECUTIVE: {
+    title: '연속 출석 포인트',
+    content: '연속으로 출석하고 25 포인트를 받아요',
+  },
+});

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,3 +1,4 @@
+export * from './attendance.js';
 export * from './board.js';
 export * from './boardMenus.js';
 export * from './dropDown.js';

--- a/src/pages/AttendancePage/AttendancePage.jsx
+++ b/src/pages/AttendancePage/AttendancePage.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 
 import { updatePoint } from '@/apis';
@@ -8,7 +9,12 @@ import { BackAppBar } from '@/components/AppBar';
 import { Calendar } from '@/components/Calendar';
 import { Icon } from '@/components/Icon';
 
-import { POINT_CATEGORY_ENUM, POINT_SOURCE_ENUM, TOAST } from '@/constants';
+import {
+  ATTENDANCE_MESSAGE,
+  POINT_CATEGORY_ENUM,
+  POINT_SOURCE_ENUM,
+  TOAST,
+} from '@/constants';
 import { USER } from '@/dummy/data';
 
 import styles from './AttendancePage.module.css';
@@ -16,6 +22,11 @@ import styles from './AttendancePage.module.css';
 export default function AttendancePage() {
   const queryClient = useQueryClient();
   const { toast } = useToast();
+  const [attendanceHistoryByMonth, setAttendanceHistoryByMonth] = useState([]);
+  const { title, content } =
+    attendanceHistoryByMonth?.length > 0
+      ? ATTENDANCE_MESSAGE.CONSECUTIVE
+      : ATTENDANCE_MESSAGE.FIRST;
 
   return (
     <main>
@@ -23,7 +34,7 @@ export default function AttendancePage() {
         <BackAppBar isDark />
         <h2 className={styles.title}>{`매일 출석체크하고 \n 포인트 모아요`}</h2>
         <div className={styles.calendar}>
-          <Calendar />
+          <Calendar callback={setAttendanceHistoryByMonth} />
         </div>
         <button
           className={styles.attendanceButton}
@@ -55,14 +66,12 @@ export default function AttendancePage() {
       <div className={styles.bottom}>
         <div className={styles.item}>
           <div className={styles.itemLeft}>
-            <span className={styles.label}>첫 출석체크</span>
-            <p className={styles.description}>
-              첫 출석을 완료하고 포인트를 받아요
-            </p>
+            <span className={styles.label}>{title}</span>
+            <p className={styles.description}>{content}</p>
           </div>
           <Icon id='point-circle' width='32' height='32' />
         </div>
-        <div className={styles.item}>
+        {/* <div className={styles.item}>
           <div className={styles.itemLeft}>
             <span className={styles.label}>알림 설정</span>
             <p className={styles.description}>
@@ -70,7 +79,7 @@ export default function AttendancePage() {
             </p>
           </div>
           <Icon id='point-circle' width='32' height='32' />
-        </div>
+        </div> */}
       </div>
     </main>
   );


### PR DESCRIPTION
## 🎯 관련 이슈

close #275

<br />

## 🚀 작업 내용

- 알림 토글 주석 처리
- 해당 월 출석 여부에 따라 하단 메시지 다르게 보여주기
- 달력의 prev, next을 클릭했을 때 month와 view가 일치하지 않는 문제 수정

<br />

## 📸 스크린샷

| <img width="321" alt="image" src="https://github.com/user-attachments/assets/799f30fb-f446-4d85-8d84-f6b568371716"> | <img width="321" alt="image" src="https://github.com/user-attachments/assets/007c45b2-8d5c-452e-af29-04f342e2b352"> |
| :---------------------: | :---------------------: |
| 첫 출석인 경우 | 이미 출석 이력이 있는 경우 |

<br />


## 🔎 발견된 장애가 있었나요?

- 달력의 next, prev navigation 버튼을 클릭했을 때 가끔씩 month와 view가 일치하지 않는 문제가 있었습니다.
- `activeStartDate`를 핸들링하는 로직을 추가해서 month가 변경되었을 때 일치하는 view가 보여지도록 했습니다.

<br />


<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
