### PR TITLE
#208 [MODIFY] 글이 없을 경우 나타나는 일러스트 이미지 변경

### DIFF
--- a/src/pages/MyPage/ActivityPage/ActivityPage.module.css
+++ b/src/pages/MyPage/ActivityPage/ActivityPage.module.css
@@ -57,7 +57,7 @@
 }
 
 .noContentMessage {
-  color: var(--Grey-4, var(--grey-3, #484848));
+  color: #484848;
   font-size: 16px;
   font-weight: 500;
   line-height: 150%;
@@ -66,13 +66,15 @@
 
 .imageWrapper {
   display: flex;
+  justify-content: flex-end;
   position: relative;
-  justify-content: center;
+  width: auto;
+  height: auto;
+  min-height: 580px;
 }
 
 .image {
   position: absolute;
-  transform: translateY(100%);
-  width: 220px;
-  height: 182px;
+  right: 0px;
+  bottom: 0px;
 }

--- a/src/pages/MyPage/ActivityPage/CommentPage.jsx
+++ b/src/pages/MyPage/ActivityPage/CommentPage.jsx
@@ -6,6 +6,7 @@ import { getMyCommentList } from '@/apis';
 import { useInView } from 'react-intersection-observer';
 import { Link } from 'react-router-dom';
 import { getBoardTextId } from '@/utils';
+import frustratedWomanIllustration from '@/assets/images/frustratedWoman.svg';
 
 export default function CommentPage() {
   const { ref, inView } = useInView();
@@ -66,7 +67,11 @@ export default function CommentPage() {
                 아직 작성한 댓글이 없어요
               </p>
               <div className={styles.imageWrapper}>
-                <Icon id='no-comment-star' className={styles.image} />
+                <img
+                  src={frustratedWomanIllustration}
+                  alt='frustrated woman image'
+                  className={styles.image}
+                />
               </div>
             </div>
           )}

--- a/src/pages/MyPage/ActivityPage/DownloadExamReviewPage.jsx
+++ b/src/pages/MyPage/ActivityPage/DownloadExamReviewPage.jsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo } from 'react';
 import styles from './ActivityPage.module.css';
-import { BackAppBar, Icon, PostBar, Sponsor } from '@/components';
+import { BackAppBar, PostBar, Sponsor } from '@/components';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useInView } from 'react-intersection-observer';
 import { getMyReviewFileList } from '@/apis';
 import { Link } from 'react-router-dom';
+import frustratedWomanIllustration from '@/assets/images/frustratedWoman.svg';
 
 export default function DownloadExamReviewPage() {
   const { ref, inView } = useInView();
@@ -65,7 +66,11 @@ export default function DownloadExamReviewPage() {
                 아직 다운받은 후기가 없어요
               </p>
               <div className={styles.imageWrapper}>
-                <Icon id='no-review-star' className={styles.image} />
+                <img
+                  src={frustratedWomanIllustration}
+                  alt='frustrated woman image'
+                  className={styles.image}
+                />
               </div>
             </div>
           )}

--- a/src/pages/MyPage/ActivityPage/MyPostPage.jsx
+++ b/src/pages/MyPage/ActivityPage/MyPostPage.jsx
@@ -1,11 +1,12 @@
 import { useEffect, useMemo } from 'react';
 import styles from './ActivityPage.module.css';
-import { BackAppBar, Icon, PostBar, Sponsor } from '@/components';
+import { BackAppBar, PostBar, Sponsor } from '@/components';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { getMyPostList } from '@/apis';
 import { Link } from 'react-router-dom';
 import { useInView } from 'react-intersection-observer';
 import { getBoardTextId } from '@/utils';
+import frustratedWomanIllustration from '@/assets/images/frustratedWoman.svg';
 
 export default function MyPostPage() {
   const { ref, inView } = useInView();
@@ -64,7 +65,11 @@ export default function MyPostPage() {
             <div className={styles.noContentWrapper}>
               <p className={styles.noContentMessage}>아직 작성한 글이 없어요</p>
               <div className={styles.imageWrapper}>
-                <Icon id='no-post-star' className={styles.image} />
+                <img
+                  src={frustratedWomanIllustration}
+                  alt='frustrated woman image'
+                  className={styles.image}
+                />
               </div>
             </div>
           )}

--- a/src/pages/MyPage/ActivityPage/ScrapExamReviewPage.jsx
+++ b/src/pages/MyPage/ActivityPage/ScrapExamReviewPage.jsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo } from 'react';
 import styles from './ActivityPage.module.css';
-import { BackAppBar, Icon, PostBar, Sponsor } from '@/components';
+import { BackAppBar, PostBar, Sponsor } from '@/components';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { getMyScrapReviewList } from '@/apis';
 import { useInView } from 'react-intersection-observer';
 import { Link } from 'react-router-dom';
+import frustratedWomanIllustration from '@/assets/images/frustratedWoman.svg';
 
 export default function ScrapExamReviewPage() {
   const { ref, inView } = useInView();
@@ -65,7 +66,11 @@ export default function ScrapExamReviewPage() {
                 아직 스크랩한 시험 후기가 없어요
               </p>
               <div className={styles.imageWrapper}>
-                <Icon id='no-review-star' className={styles.image} />
+                <img
+                  src={frustratedWomanIllustration}
+                  alt='frustrated woman image'
+                  className={styles.image}
+                />
               </div>
             </div>
           )}

--- a/src/pages/MyPage/ActivityPage/ScrapPage.jsx
+++ b/src/pages/MyPage/ActivityPage/ScrapPage.jsx
@@ -1,11 +1,12 @@
 import { useEffect, useMemo } from 'react';
 import styles from './ActivityPage.module.css';
-import { BackAppBar, Icon, PostBar, Sponsor } from '@/components';
+import { BackAppBar, PostBar, Sponsor } from '@/components';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { getMyScrapPostList } from '@/apis';
 import { useInView } from 'react-intersection-observer';
 import { getBoardTitleToTextId } from '@/utils';
 import { Link } from 'react-router-dom';
+import frustratedWomanIllustration from '@/assets/images/frustratedWoman.svg';
 
 export default function ScrapPage() {
   const { ref, inView } = useInView();
@@ -66,7 +67,11 @@ export default function ScrapPage() {
                 아직 스크랩 한 글이 없어요
               </p>
               <div className={styles.imageWrapper}>
-                <Icon id='no-review-star' className={styles.image} />
+                <img
+                  src={frustratedWomanIllustration}
+                  alt='frustrated woman image'
+                  className={styles.image}
+                />
               </div>
             </div>
           )}


### PR DESCRIPTION
## 🎯 관련 이슈

close #208

<br />

## 🚀 작업 내용

- 글이 없을 경우 나타나는 일러스트 이미지 변경
  - [마이페이지] - [내 활동] 탭 내 모든 페이지 변경 

<br />

## 📸 스크린샷

|<img width='250' src='https://github.com/user-attachments/assets/1df536ad-2bc0-41fe-b248-fac2458d4902'> |<img width='250' src='https://github.com/user-attachments/assets/84b508e2-ff33-4a1e-9732-1e6d68d9098a'> |
| :---------------------: |:---------------------: |
|작성한 글이 없는 경우 |작성한 댓글이 없는 경우 | 

|<img width='250' src='https://github.com/user-attachments/assets/a8f20676-6007-496f-b420-1e7247f56013'> |<img width='250' src='https://github.com/user-attachments/assets/3d57369d-545f-442e-ae0d-edc35e869755'> |
| :---------------------: |:---------------------: |
|작성한 글이 없는 경우 |작성한 댓글이 없는 경우 | 

<br />
