### PR TITLE
#299 [FEAT] Fetch 중일 때 FetchLoading 컴포넌트 보여주기

### DIFF
--- a/src/components/Calendar/Calendar.jsx
+++ b/src/components/Calendar/Calendar.jsx
@@ -3,7 +3,6 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getMonthlyAttendanceHistory } from '@/apis';
 
-import { FetchLoading } from '@/components/Loading';
 import { Icon } from '@/components/Icon';
 import { Tile } from '@/components/Calendar';
 

--- a/src/components/Calendar/Calendar.jsx
+++ b/src/components/Calendar/Calendar.jsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getMonthlyAttendanceHistory } from '@/apis';
 
+import { FetchLoading } from '@/components/Loading';
 import { Icon } from '@/components/Icon';
 import { Tile } from '@/components/Calendar';
 
@@ -23,10 +24,6 @@ export default function Calendar({ callback }) {
   useEffect(() => {
     callback(data);
   }, [data]);
-
-  if (!data) {
-    return null;
-  }
 
   return (
     <StyledCalendar

--- a/src/components/Calendar/Tile/Tile.jsx
+++ b/src/components/Calendar/Tile/Tile.jsx
@@ -4,7 +4,7 @@ import { isToday } from '@/utils/date.js';
 
 import styles from './Tile.module.css';
 
-export default function Tile({ date, data }) {
+export default function Tile({ date, data = [] }) {
   const currentDate = new Date(date);
   const checked = data.find(({ createdAt }) => {
     const checkedDate = new Date(createdAt);

--- a/src/components/Loading/FetchLoading.module.css
+++ b/src/components/Loading/FetchLoading.module.css
@@ -1,5 +1,5 @@
-/* 기본 로딩 스타일 */
 .loading {
+  flex: 1;
   width: 100%;
   height: calc(100% - 56px - 86px);
   display: flex;

--- a/src/pages/AttendancePage/AttendancePage.jsx
+++ b/src/pages/AttendancePage/AttendancePage.jsx
@@ -23,6 +23,7 @@ export default function AttendancePage() {
   const queryClient = useQueryClient();
   const { toast } = useToast();
   const [attendanceHistoryByMonth, setAttendanceHistoryByMonth] = useState([]);
+  const [disabled, setDisabled] = useState(false);
   const { title, content } =
     attendanceHistoryByMonth?.length > 0
       ? ATTENDANCE_MESSAGE.CONSECUTIVE
@@ -38,7 +39,9 @@ export default function AttendancePage() {
         </div>
         <button
           className={styles.attendanceButton}
+          disabled={disabled}
           onClick={() => {
+            setDisabled(true);
             updatePoint({
               userId: USER.userId, // userId 교체 필요함
               category: POINT_CATEGORY_ENUM.ATTENDANCE,
@@ -57,6 +60,9 @@ export default function AttendancePage() {
               })
               .catch(({ response }) => {
                 toast(response.data.message);
+              })
+              .finally(() => {
+                setDisabled(false);
               });
           }}
         >

--- a/src/pages/AttendancePage/AttendancePage.module.css
+++ b/src/pages/AttendancePage/AttendancePage.module.css
@@ -40,6 +40,11 @@
   filter: brightness(0.9);
 }
 
+.attendanceButton:disabled {
+  cursor: not-allowed;
+  filter: brightness(0.5);
+}
+
 /* bottom */
 
 .bottom {

--- a/src/pages/BoardPage/BoardListPage/BoardListPage.jsx
+++ b/src/pages/BoardPage/BoardListPage/BoardListPage.jsx
@@ -87,7 +87,12 @@ export default function BoardListPage() {
 
   return (
     <div className={styles.container}>
-      <BackAppBar title={currentBoard.title} hasMenu hasSearch backNavTo={'/board'}/>
+      <BackAppBar
+        title={currentBoard.title}
+        hasMenu
+        hasSearch
+        backNavTo={'/board'}
+      />
       <div className={styles.top}>
         <div
           className={styles.notification_bar}

--- a/src/pages/ExamReviewPage/ExamReviewDetailPage/ExamReviewDetailPage.jsx
+++ b/src/pages/ExamReviewPage/ExamReviewDetailPage/ExamReviewDetailPage.jsx
@@ -12,6 +12,7 @@ import { NotFoundPage } from '@/pages/NotFoundPage';
 import { BackAppBar } from '@/components/AppBar';
 import { CommentList } from '@/components/Comment';
 import { DeleteModal, OptionModal } from '@/components/Modal';
+import { FetchLoading } from '@/components/Loading';
 import { Icon } from '@/components/Icon';
 import { InputBar } from '@/components/InputBar';
 import { ReviewContentItem } from '@/components/ReviewContentItem';
@@ -33,7 +34,7 @@ export default function ExamReviewDetailPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  const { data, error } = useQuery({
+  const { data, error, isError, isLoading } = useQuery({
     queryKey: ['reviewDetail', postId],
     queryFn: () => getReviewDetail(postId),
     staleTime: 1000 * 60 * 5,
@@ -100,6 +101,30 @@ export default function ExamReviewDetailPage() {
     title,
     userDisplay,
   } = data;
+
+  if (isLoading) {
+    return (
+      <>
+        <BackAppBar />
+        <FetchLoading>게시글 불러오는 중...</FetchLoading>
+      </>
+    );
+  }
+
+  if (error?.response.status === 404) {
+    return <NotFoundPage />;
+  }
+
+  if (isError) {
+    return (
+      <>
+        <BackAppBar />
+        <FetchLoading animation={false}>
+          게시글을 불러오지 못했습니다.
+        </FetchLoading>
+      </>
+    );
+  }
 
   return (
     <main>

--- a/src/pages/ExamReviewPage/ExamReviewDetailPage/ExamReviewDetailPage.jsx
+++ b/src/pages/ExamReviewPage/ExamReviewDetailPage/ExamReviewDetailPage.jsx
@@ -69,17 +69,41 @@ export default function ExamReviewDetailPage() {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isReportModalOpen, setIsReportModalOpen] = useState(false);
 
-  if (error?.response.status === 404) {
-    return <NotFoundPage />;
-  }
-
-  if (data === undefined) return null;
-
   const edit = () =>
     navigate(`/board/exam-review/${postId}/edit`, {
       state: data,
       replace: true,
     });
+
+  console.log(isLoading);
+
+  if (isLoading) {
+    return (
+      <>
+        <BackAppBar />
+        <FetchLoading>게시글 불러오는 중...</FetchLoading>
+      </>
+    );
+  }
+
+  if (error?.response.status === 404) {
+    return <NotFoundPage />;
+  }
+
+  if (error?.response.status === 404) {
+    return <NotFoundPage />;
+  }
+
+  if (isError) {
+    return (
+      <>
+        <BackAppBar />
+        <FetchLoading animation={false}>
+          게시글을 불러오지 못했습니다.
+        </FetchLoading>
+      </>
+    );
+  }
 
   const {
     commentCount,
@@ -100,31 +124,7 @@ export default function ExamReviewDetailPage() {
     semester,
     title,
     userDisplay,
-  } = data;
-
-  if (isLoading) {
-    return (
-      <>
-        <BackAppBar />
-        <FetchLoading>게시글 불러오는 중...</FetchLoading>
-      </>
-    );
-  }
-
-  if (error?.response.status === 404) {
-    return <NotFoundPage />;
-  }
-
-  if (isError) {
-    return (
-      <>
-        <BackAppBar />
-        <FetchLoading animation={false}>
-          게시글을 불러오지 못했습니다.
-        </FetchLoading>
-      </>
-    );
-  }
+  } = data ?? {};
 
   return (
     <main>

--- a/src/pages/ExamReviewPage/ExamReviewList/ExamReviewList.jsx
+++ b/src/pages/ExamReviewPage/ExamReviewList/ExamReviewList.jsx
@@ -20,7 +20,7 @@ export default function ExamReviewList({ result }) {
 
   if (isError) {
     if (error.response.status === 404) {
-      return <div className={styles.error}>검색 결과가 없습니다</div>;
+      return;
     }
 
     return <div className={styles.error}>잠시 후 다시 시도해 주세요</div>;

--- a/src/pages/ExamReviewPage/ExamReviewPage/ExamReviewPage.jsx
+++ b/src/pages/ExamReviewPage/ExamReviewPage/ExamReviewPage.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 
 import { getReviewList } from '@/apis';
 
@@ -38,14 +38,7 @@ export default function ExamReviewPage() {
     queryFn: ({ pageParam }) => getReviewList(pageParam),
   });
 
-  const {
-    data: searchData,
-    ref,
-    isLoading,
-    handleChange,
-    handleOnKeyDown,
-    keyword,
-  } = useSearch({
+  const searchResult = useSearch({
     urlKeyword,
     filterOption: {
       lectureYear: lectureYear?.id,
@@ -54,8 +47,10 @@ export default function ExamReviewPage() {
     },
   });
 
+  const { isLoading, handleChange, handleOnKeyDown, keyword } = searchResult;
+
   return (
-    <main>
+    <main className={styles.main}>
       <AppBar title='시험후기' />
       <Search
         className={styles.search}
@@ -98,13 +93,12 @@ export default function ExamReviewPage() {
       ) : (
         <PTR>
           {urlKeyword !== '' ? (
-            <ExamReviewSearchList result={searchData || []} />
+            <ExamReviewSearchList result={searchResult} />
           ) : (
             <ExamReviewList result={reviewResult || []} />
           )}
         </PTR>
       )}
-
       <WriteButton to='/board/exam-review-write' />
     </main>
   );

--- a/src/pages/ExamReviewPage/ExamReviewPage/ExamReviewPage.module.css
+++ b/src/pages/ExamReviewPage/ExamReviewPage/ExamReviewPage.module.css
@@ -1,3 +1,9 @@
+.main {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
 .search {
   width: calc(100% - 1.25rem * 2);
   margin: 0 1.25rem 0.625rem 1.25rem;

--- a/src/pages/ExamReviewPage/ExamReviewSearchList/ExamReviewSearchList.jsx
+++ b/src/pages/ExamReviewPage/ExamReviewSearchList/ExamReviewSearchList.jsx
@@ -7,8 +7,8 @@ import { Target } from '@/components/Target';
 import styles from '@/pages/ExamReviewPage/ExamReviewPage/ExamReviewPage.module.css';
 
 export default function ExamReviewSearchList({ result }) {
-  const { ref, isLoading, isError, error } = result || {};
-  const pages = result?.pages || [];
+  const { data, ref, isLoading, isError, error } = result || {};
+  const pages = data?.pages || [];
   const searchList = pages.flatMap((page) => page);
 
   if (isLoading) {

--- a/src/pages/PostPage/PostPage/PostPage.jsx
+++ b/src/pages/PostPage/PostPage/PostPage.jsx
@@ -36,7 +36,7 @@ export default function PostPage() {
   const [isReportModalOpen, setIsReportModalOpen] = useState(false);
 
   // 게시글 데이터 받아오기
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, error, isError } = useQuery({
     queryKey: ['postContent', postId],
     queryFn: () => getPostContent(currentBoard?.id, postId),
     enabled: !!currentBoard?.id && !!postId,
@@ -82,7 +82,7 @@ export default function PostPage() {
     return <NotFoundPage />;
   }
 
-  if (error) {
+  if (isError) {
     return (
       <>
         <BackAppBar />

--- a/src/route.js
+++ b/src/route.js
@@ -231,7 +231,7 @@ export const routeList = [
         ),
       },
       {
-        path: '/board/exam-review/search/:keyword?',
+        path: '/board/exam-review/search/:keyword',
         element: (
           <ProtectedRoute
             roles={[ROLE.user, ROLE.admin]}

--- a/src/utils/findRoute.js
+++ b/src/utils/findRoute.js
@@ -5,7 +5,7 @@ export const findRouteByPath = (path, routeList) => {
     }
 
     const routePathRegex = new RegExp(
-      '^' + route.path?.replace(/:\w+/g, '\\w+') + '$'
+      '^' + route.path?.replace(/:\w+/g, '[^/]+') + '$'
     );
 
     if (routePathRegex.test(path)) {


### PR DESCRIPTION
## 🎯 관련 이슈

close #299

<br />

## 🚀 작업 내용

- 출석체크 페이지에서 출석체크 버튼 클릭 후 응답 완료될 때까지 버튼 비활성화
- 시험후기 상세에서 로딩 상태일 때 FetchLoading 컴포넌트가 보이게 수정했습니다.


<br />

## 📸 스크린샷

| <img width="321" alt="image" src="https://github.com/user-attachments/assets/91e148b8-e332-42f7-8c8a-7cff6c1c5fa6"> | <img width="321" alt="image" src="https://github.com/user-attachments/assets/1a751c18-124e-4bab-93c5-b81a6cd8ecd8"> |
| :---------------------: | :---------------------: |
| 출석체크 버튼 클릭 시 버튼 비활성화 | 시험후기 상세 페이지 로딩 중 |

<br />


## 🔎 발견된 장애가 있었나요?

- 시험후기 검색 페이지에서 Navbar 보이지 않는 문제 수정
  - 시험후기 페이지에서 검색 상태일 경우 라우트에 /search/:keyword가 추가됨에 따라 Navbar 렌더링을 결정하는 함수인 `findRouteByPath`에서 시험후기 검색에 대한 라우트를 제대로 찾지 못하는 문제 때문에 발생한 문제였습니다.
  - `findRouteByPath`함수에서 영어뿐만 아니라 다른 문자도 매치할 수 있도록 정규표현식을 수정했습니다.

<br />


## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

- 현재 서버쪽 pagination 응답이 바뀜에 따라 pagination 이 적용된 페이지는 오류가 발생합니다.
- 해당 이슈를 해결한 코드는 PR(#304) 올려뒀습니다.

<br />

