### PR TITLE
#321 [FIX] ProtectedRoute에서 유저 정보 status가 loading일 경우 undefined를 반환하도록 수정

### DIFF
--- a/src/ProtectedRoute.jsx
+++ b/src/ProtectedRoute.jsx
@@ -8,6 +8,10 @@ import { USER_STATUS } from './constants';
 export default function ProtectedRoute({ roles, children, to = '/', message }) {
   const { status, userInfo } = useAuth();
 
+  if (status === USER_STATUS.loading) {
+    return;
+  }
+
   if (status === USER_STATUS.isLogout) {
     alert('로그인이 필요합니다.');
     return <Navigate to={to} replace={true} />;


### PR DESCRIPTION
## 🎯 관련 이슈

close #321

<br />

## 🚀 작업 내용

- ProtectedRoute에서 유저 정보의 `status`가 loading 상태인 경우 fetch가 끝날 때까지 기다리기 위해 `undefined`를 반환하도록 수정했습니다.

<br />

## 🔎 발견된 장애가 있었나요?

- 권한이 필요한 페이지에서 새로고침 시 권한 없음으로 메인 페이지로 돌아가는 문제
- ProtectedRoute에서 유저 정보를 fetch할 때까지 기다리기 위해 `status`가 loading일 때 `undefined`를 반환

<br />

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
