### PR TITLE
#323 [FIX] 로그아웃 시 유저 정보 캐시를 삭제

### DIFF
--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { getMyPageUserInfo, withdrawAccount } from '@/apis';
 
@@ -10,6 +10,7 @@ import { TOAST } from '@/constants';
 
 const useAuth = ({ isRequiredAuth = false } = {}) => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { toast } = useToast();
 
   const hasToken = !!localStorage.getItem('accessToken');
@@ -41,6 +42,7 @@ const useAuth = ({ isRequiredAuth = false } = {}) => {
 
   const logout = () => {
     localStorage.removeItem('accessToken');
+    queryClient.removeQueries(['myPageUserInfo']);
     navigate('/');
     refetch();
   };


### PR DESCRIPTION
## 🎯 관련 이슈

close #323

<br />

## 🚀 작업 내용

- 로그아웃 시 캐시된 유저 정보를 삭제

<br />

## 🔎 발견된 장애가 있었나요?

- 로그아웃 후 곧바로 로그인 했을 때 로그인 권한을 얻지 못 하는 문제가 있었습니다.
  - 다시 로그인 했을 때 유저 정보를 새로 가져오는 게 아니라 로그아웃 후 캐시된 유저 정보를 가져와서 발생한 문제였습니다.
  - 로그아웃 시 캐시된 유저 정보를 삭제하는 코드를 추가하여 해결했습니다.

<br />

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
