### PR TITLE
#326 [FIX] views 클래스로 따로 스타일 지정

### DIFF
--- a/src/pages/PostPage/PostPage/PostPage.jsx
+++ b/src/pages/PostPage/PostPage/PostPage.jsx
@@ -140,7 +140,9 @@ export default function PostPage() {
         <div className={styles.title}>
           <p>
             {postData.title}
-            <span>&nbsp;&nbsp;{postData.viewCount.toLocaleString()} views</span>
+            <span className={styles.views}>
+              &nbsp;&nbsp;{postData.viewCount.toLocaleString()} views
+            </span>
           </p>
         </div>
         <p className={styles.text}>{postData.content}</p>

--- a/src/pages/PostPage/PostPage/PostPage.module.css
+++ b/src/pages/PostPage/PostPage/PostPage.module.css
@@ -59,15 +59,16 @@
     letter-spacing: -0.5px;
     color: #484848;
   }
-  span {
-    white-space: nowrap;
-    color: #5f86bf;
-    font-size: 11px;
-    font-weight: 400;
-    line-height: 150%;
-    letter-spacing: -0.5px;
-    padding-left: 2px;
-  }
+}
+
+.views {
+  white-space: nowrap;
+  color: #5f86bf;
+  font-size: 11px;
+  font-weight: 400;
+  line-height: 150%;
+  letter-spacing: -0.5px;
+  padding-left: 2px;
 }
 
 .text {


### PR DESCRIPTION
## 🎯 관련 이슈
close #326

<br />

## 🚀 작업 내용

- 배포버전에서 span에 대한 스타일이 안 먹어, 따로 클래스 빼서 지정해주었음

<br />

## 📸 스크린샷
<img width="384" alt="스크린샷 2024-09-12 오후 9 37 48" src="https://github.com/user-attachments/assets/97799248-fa62-4933-a2f5-ef28c18576bf">
