### PR TITLE
#329 [FIX] 메인 화면에서 공지글 & 게시글 검색 - 접근 권한 설정

### DIFF
--- a/src/ProtectedRoute.jsx
+++ b/src/ProtectedRoute.jsx
@@ -14,7 +14,7 @@ export default function ProtectedRoute({ roles, children, to = '/', message }) {
 
   if (status === USER_STATUS.isLogout) {
     alert('로그인이 필요합니다.');
-    return <Navigate to={to} replace={true} />;
+    return <Navigate to={'/login'} replace={true} />;
   }
 
   if (roles && !roles.includes(userInfo?.userRoleId)) {

--- a/src/route.js
+++ b/src/route.js
@@ -57,6 +57,8 @@ const getRolesForReadBoard = (boardPath) => {
       return [ROLE.user, ROLE.admin, ROLE.official];
     case 'permanent-snow':
       return [ROLE.user, ROLE.admin, ROLE.official];
+    case 'all':
+      return [ROLE.preUser, ROLE.user, ROLE.admin, ROLE.official]; // 또는 모든 권한 부여
     default:
       return [];
   }
@@ -75,7 +77,13 @@ const getRolesForWriteBoard = (boardPath) => {
   }
 };
 
-const boardPaths = ['first-snow', 'large-snow', 'permanent-snow', 'besookt'];
+const boardPaths = [
+  'first-snow',
+  'large-snow',
+  'permanent-snow',
+  'besookt',
+  'all',
+];
 
 const boardRoutes = boardPaths.flatMap((boardPath) => [
   {

--- a/src/route.js
+++ b/src/route.js
@@ -58,7 +58,7 @@ const getRolesForReadBoard = (boardPath) => {
     case 'permanent-snow':
       return [ROLE.user, ROLE.admin, ROLE.official];
     case 'all':
-      return [ROLE.preUser, ROLE.user, ROLE.admin, ROLE.official]; // 또는 모든 권한 부여
+      return [ROLE.preUser, ROLE.user, ROLE.admin, ROLE.official];
     default:
       return [];
   }

--- a/src/route.js
+++ b/src/route.js
@@ -395,7 +395,15 @@ export const routeList = [
       },
       {
         path: '/notice',
-        element: <NoticeListPage />,
+        element: (
+          <ProtectedRoute
+            roles={[ROLE.user, ROLE.admin, ROLE.official]}
+            message={'등업 후 이용 가능합니다'}
+          >
+            <NoticeListPage />
+          </ProtectedRoute>
+        ),
+
         meta: {
           hideNav: true,
         },


### PR DESCRIPTION
## 🎯 관련 이슈

close #329 

<br />

## 🚀 작업 내용

- 로그인 필요한 메뉴 클릭 시 로그인 페이지로 이동
- 게시판 검색 권한에 따른 접근 제한 안 됐던 거 수정 (boardlist에 'all' 추가)
- 권한에 따른 공지 페이지 접근 제한 (router.js에서 공지 부분에 ProtectedRoute 추가)

<br />

## 📸 스크린샷

| <img width="1512" alt="스크린샷 2024-09-12 오후 10 43 33" src="https://github.com/user-attachments/assets/0557d2fd-9dbc-469c-a0f0-dd4599e1b1f8"> | <img width="1512" alt="스크린샷 2024-09-12 오후 10 43 05" src="https://github.com/user-attachments/assets/ac4e814a-71c1-4bbc-873d-e315c098d3c5"> |
| :---------------------: | :---------------------: |
| 로그인 안 했을 때 공지 클릭 시 | 준회원이 공지 클릭 시 |

