### PR TITLE
#332 [FEAT] 메인페이지 전체공지 게시판 연결

### DIFF
--- a/src/constants/boardMenus.js
+++ b/src/constants/boardMenus.js
@@ -5,6 +5,14 @@ import besookt from '@/assets/images/besookt-board-page.svg';
 
 export const BOARD_MENUS = [
   {
+    id: 12,
+    to: '/board/notice',
+    textId: 'notice',
+    title: '전체',
+    desc: '',
+    image: '',
+  },
+  {
     id: 21,
     to: '/board/first-snow',
     textId: 'first-snow',

--- a/src/pages/MainPage/MainPage.jsx
+++ b/src/pages/MainPage/MainPage.jsx
@@ -45,7 +45,7 @@ export default function MainPage() {
         <Flex gap='0.45rem'>
           <Card
             className={styles.notice}
-            to='/notice'
+            to='/board/notice'
             title={data.title}
             tag='공지'
             imgPath='megaphone.svg'

--- a/src/route.js
+++ b/src/route.js
@@ -394,7 +394,7 @@ export const routeList = [
         },
       },
       {
-        path: '/notice',
+        path: '/board/notice',
         element: (
           <ProtectedRoute
             roles={[ROLE.user, ROLE.admin, ROLE.official]}
@@ -403,7 +403,20 @@ export const routeList = [
             <NoticeListPage />
           </ProtectedRoute>
         ),
-
+        meta: {
+          hideNav: true,
+        },
+      },
+      {
+        path: '/board/notice/post/:postId',
+        element: (
+          <ProtectedRoute
+            roles={[ROLE.user, ROLE.admin, ROLE.official]}
+            message={'등업 후 이용 가능합니다'}
+          >
+            <PostPage />
+          </ProtectedRoute>
+        ),
         meta: {
           hideNav: true,
         },


### PR DESCRIPTION
## 🎯 관련 이슈

close #332

<br />

## 🚀 작업 내용

- (코드, 테스트 등 변경 사항과 변경 이유를 작성해주세요.)

<br />

## 📸 스크린샷
| <img width="369" alt="스크린샷 2024-09-13 오전 12 31 25" src="https://github.com/user-attachments/assets/9f765c8c-40db-4427-b3bd-e54c45cac779"> | <img width="369" alt="스크린샷 2024-09-13 오전 12 31 36" src="https://github.com/user-attachments/assets/3c9eb0f9-0328-4c4d-96c9-7ada429e2049"> |
| :---------------------: | :---------------------: |
| 전체공지 게시판 | 공지 상세 보기 |

<br />

## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

- 전체공지 작성 페이지는 다음 PR에서 작업할 예정

<br />
