### PR TITLE
#337 [FIX] 인증된 시험후기는 옵션 모달에서 수정 메뉴 숨김

### DIFF
--- a/src/components/PostBar/PostBar.jsx
+++ b/src/components/PostBar/PostBar.jsx
@@ -31,6 +31,14 @@ export default function PostBar({
         <p className={styles.dot}>·</p>
         <p>{agoTime}</p>
         {data.isEdited && <p className={styles.edited}>&nbsp;(수정됨)</p>}
+        {data.isConfirmed && (
+          <Icon
+            className={styles.checkCircleIcon}
+            id='check-circle'
+            width='12'
+            height='12'
+          />
+        )}
       </div>
       <div className={styles.post_center}>
         <p className={styles.title}>{data.title}</p>

--- a/src/components/PostBar/PostBar.module.css
+++ b/src/components/PostBar/PostBar.module.css
@@ -7,13 +7,13 @@
 }
 
 .post_top {
+  padding-bottom: 9px;
   display: flex;
   align-items: center;
   font-size: 11px;
   line-height: 150%;
   letter-spacing: -0.5px;
   color: #484848;
-  padding-bottom: 9px;
 }
 
 .name {
@@ -27,6 +27,10 @@
 .dot {
   font-weight: 800;
   padding: 0 3px;
+}
+
+.checkCircleIcon {
+  margin-left: 4px;
 }
 
 .post_center {

--- a/src/constants/modalOptions.js
+++ b/src/constants/modalOptions.js
@@ -122,7 +122,7 @@ export const MODAL_OPTIONS = [
     titleColor: '#000',
   },
   {
-    id: 'exam-review-edit',
+    id: 'exam-review-option',
     title: '내가 작성한 시험 후기',
     titleColor: '#000',
     children: [
@@ -133,6 +133,21 @@ export const MODAL_OPTIONS = [
         text: '수정하기',
         nav: '/post',
       },
+      {
+        iconId: 'trash',
+        IconWidth: 12,
+        IconHeight: 16,
+        text: '삭제하기',
+        color: '#FF4B6C',
+        nav: '/post-write',
+      },
+    ],
+  },
+  {
+    id: 'confirmed-exam-review-option',
+    title: '내가 작성한 시험 후기',
+    titleColor: '#000',
+    children: [
       {
         iconId: 'trash',
         IconWidth: 12,

--- a/src/pages/ExamReviewPage/ExamReviewDetailPage/ExamReviewDetailPage.jsx
+++ b/src/pages/ExamReviewPage/ExamReviewDetailPage/ExamReviewDetailPage.jsx
@@ -195,7 +195,7 @@ export default function ExamReviewDetailPage() {
       <CommentList commentCount={commentCount} />
       <InputBar />
       <OptionModal
-        id='exam-review-edit'
+        id={isConfirmed ? 'confirmed-exam-review-option' : 'exam-review-option'}
         isOpen={isOptionModalOpen}
         setIsOpen={setIsOptionModalOpen}
         closeFn={() => setIsOptionModalOpen(false)}

--- a/src/pages/ExamReviewPage/ExamReviewDetailPage/ExamReviewDetailPage.module.css
+++ b/src/pages/ExamReviewPage/ExamReviewDetailPage/ExamReviewDetailPage.module.css
@@ -28,7 +28,7 @@
 }
 
 .checkCircleIcon {
-  margin-left: 10px;
+  margin-left: 4px;
 }
 
 .dot {


### PR DESCRIPTION
## 🎯 관련 이슈

close #337

<br />

## 🚀 작업 내용

- 인증된 시험후기의 경우 옵션 모달에서 수정하기 메뉴 숨김

<br />

## 📸 스크린샷

| <img width="321" alt="image" src="https://github.com/user-attachments/assets/8710a30e-1016-4de3-92e0-6f21131965ae"> | <img width="321" alt="image" src="https://github.com/user-attachments/assets/364d5857-7234-4d03-b684-4c9ea454c1db"> |
| :---------------------: | :---------------------: |
| 인증된 시험후기 옵션 모달 | 인증된 시험후기 리스트 아이템에 인증 마크 부여 |

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
