### PR TITLE
#342 [FIX] 시험후기 필터 유지되도록 수정

### DIFF
--- a/src/hooks/useSearch.jsx
+++ b/src/hooks/useSearch.jsx
@@ -26,10 +26,24 @@ export default function useSearch({ urlKeyword, filterOption }) {
         boardType === 'exam-review'
           ? navigate(`/board/${boardType}`)
           : navigate(`/board/${boardType}/search`);
-      } else {
-        setNewUrlKeyword(encodeURIComponent(keyword));
-        navigate(`/board/${boardType}/search/${encodeURIComponent(keyword)}`);
+        return;
       }
+
+      setNewUrlKeyword(encodeURIComponent(keyword));
+
+      if (boardType === 'exam-review') {
+        const param = Object.entries(filterOption).reduce(
+          (result, [key, value]) =>
+            value ? `${result}&${key}=${value}` : result,
+          ''
+        );
+
+        navigate(
+          `/board/${boardType}/search/${encodeURIComponent(keyword)}?${param}`
+        );
+        return;
+      }
+      navigate(`/board/${boardType}/search/${encodeURIComponent(keyword)}`);
     }
   };
 

--- a/src/pages/ExamReviewPage/ExamReviewPage/ExamReviewPage.jsx
+++ b/src/pages/ExamReviewPage/ExamReviewPage/ExamReviewPage.jsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { getReviewList } from '@/apis';
 
@@ -9,22 +9,39 @@ import { ExamReviewList, ExamReviewSearchList } from '@/pages/ExamReviewPage';
 
 import { AppBar, DropDownBlue, PTR, Search, WriteButton } from '@/components';
 
+import { convertToObject } from '@/utils';
 import { YEARS, SEMESTERS, EXAM_TYPES } from '@/constants';
 
 import styles from './ExamReviewPage.module.css';
 
+const LECTURE_YEAR_LEBEL = convertToObject(YEARS);
+const SEMESTER_LEBEL = convertToObject(SEMESTERS);
+const EXAM_TYPE_LEBEL = convertToObject(EXAM_TYPES);
+
 export default function ExamReviewPage() {
-  const { pathname } = useLocation();
+  const navigate = useNavigate();
+  const { pathname, search } = useLocation();
   const urlKeyword = decodeURIComponent(pathname.split('/')[4] || '');
+  const queryParams = new URLSearchParams(search);
 
   const [isOpen, setIsOpen] = useState({
     year: false,
     semester: false,
     examType: false,
   });
-  const [lectureYear, setLectureYear] = useState();
-  const [semester, setSemester] = useState();
-  const [examType, setExamType] = useState();
+
+  const [lectureYear, setLectureYear] = useState({
+    id: queryParams.get('lectureYear'),
+    name: LECTURE_YEAR_LEBEL[queryParams.get('lectureYear')],
+  });
+  const [semester, setSemester] = useState({
+    id: queryParams.get('semester'),
+    name: SEMESTER_LEBEL[queryParams.get('semester')],
+  });
+  const [examType, setExamType] = useState({
+    id: queryParams.get('examType'),
+    name: EXAM_TYPE_LEBEL[queryParams.get('examType')],
+  });
 
   const reviewResult = usePagination({
     queryKey: ['reviewList'],
@@ -42,6 +59,27 @@ export default function ExamReviewPage() {
   });
 
   const { handleChange, handleOnKeyDown, keyword } = searchResult;
+
+  useEffect(() => {
+    const filterOption = {
+      lectureYear: lectureYear?.id,
+      semester: semester?.id,
+      examType: examType?.id,
+    };
+    const param = Object.entries(filterOption).reduce(
+      (result, [key, value]) => (value ? `${result}&${key}=${value}` : result),
+      ''
+    );
+
+    if (keyword === '') {
+      navigate(`/board/exam-review`);
+      return;
+    }
+
+    navigate(
+      `/board/exam-review/search/${encodeURIComponent(keyword)}?${param}`
+    );
+  }, [lectureYear, semester, examType]);
 
   return (
     <main>


### PR DESCRIPTION
## 🎯 관련 이슈

close #342

<br />

## 🚀 작업 내용

- 시험후기 상세에서 리스트로 돌아올 때 필터 유지되도록 수정

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
