### PR TITLE
#352 [FIX] 사이드바에 누락된 공지사항 메뉴 추가

### DIFF
--- a/src/constants/menus.js
+++ b/src/constants/menus.js
@@ -42,7 +42,7 @@ export const SIDEBAR_MENUS = Object.freeze([
     title: '스노로즈',
     items: [
       { to: '/about', name: 'About 스노로즈' },
-      // { to: '/notice', name: '공지사항' },
+      { to: '/notice', name: '공지사항' },
     ],
   },
   {


### PR DESCRIPTION
## 🎯 관련 이슈

close #352

<br />

## 🚀 작업 내용

- 사이드바에 누락된 공지사항 메뉴 추가

<br />

## 📸 스크린샷

| <img width="321" alt="image" src="https://github.com/user-attachments/assets/47ec8947-d23d-4351-a27c-b402b8099491"> |
| :---------------------: |
| 공지사항 메뉴 추가 |

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
