### PR TITLE
#367 [FIX] 댓글 페이지네이션 버그 수정

### DIFF
--- a/src/components/Comment/CommentList/CommentList.jsx
+++ b/src/components/Comment/CommentList/CommentList.jsx
@@ -1,14 +1,23 @@
-import { useComment } from '@/hooks';
+import { useParams } from 'react-router-dom';
+
+import { getCommentList } from '@/apis';
+
+import { usePagination } from '@/hooks';
 
 import { Comment } from '@/components/Comment';
 import { FetchLoading } from '@/components/Loading';
 
-import { filterVisibleComments } from '@/utils';
+import { filterVisibleComments, flatPaginationCache } from '@/utils';
 
 import styles from './CommentList.module.css';
 
 export default function CommentList({ commentCount }) {
-  const { commentList, ref, isLoading, isError } = useComment();
+  const { postId } = useParams();
+
+  const { data, isLoading, isError, ref } = usePagination({
+    queryKey: ['comments', postId],
+    queryFn: ({ pageParam }) => getCommentList({ postId, page: pageParam }),
+  });
 
   if (isLoading) {
     return <FetchLoading>댓글을 불러오는 중...</FetchLoading>;
@@ -20,6 +29,7 @@ export default function CommentList({ commentCount }) {
     );
   }
 
+  const commentList = flatPaginationCache(data);
   const filteredCommentList = filterVisibleComments(commentList);
 
   return (
@@ -27,17 +37,13 @@ export default function CommentList({ commentCount }) {
       <p className={styles.commentsTitle}>
         댓글 {commentCount.toLocaleString()}개
       </p>
-      {commentList ? (
-        filteredCommentList.map((comment, index) => (
-          <Comment
-            ref={index === filteredCommentList.length - 1 ? ref : undefined}
-            key={comment.id}
-            data={comment}
-          />
-        ))
-      ) : (
-        <div className={styles.failComment}>댓글을 불러올 수 없습니다.</div>
-      )}
+      {filteredCommentList.map((comment, index) => (
+        <Comment
+          ref={index === filteredCommentList.length - 1 ? ref : undefined}
+          key={comment.id}
+          data={comment}
+        />
+      ))}
     </div>
   );
 }

--- a/src/components/Loading/FetchLoading.module.css
+++ b/src/components/Loading/FetchLoading.module.css
@@ -5,7 +5,6 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 9999;
 }
 
 .centerBox {

--- a/src/hooks/useComment.jsx
+++ b/src/hooks/useComment.jsx
@@ -3,27 +3,19 @@ import { useQueryClient, useMutation } from '@tanstack/react-query';
 
 import {
   deleteComment as remove,
-  getCommentList,
   postComment as post,
   editComment as edit,
 } from '@/apis';
 
-import { usePagination, useToast } from '@/hooks';
+import { useToast } from '@/hooks';
 
 import { flatPaginationCache, toPaginationCacheFormat } from '@/utils';
 import { TOAST } from '@/constants';
 
 export default function useComment() {
   const { postId } = useParams();
-  const queryClient = useQueryClient();
   const { toast } = useToast();
-
-  const { data, isLoading, isError, ref } = usePagination({
-    queryKey: ['comments', postId],
-    queryFn: ({ pageParam }) => getCommentList({ postId, page: pageParam }),
-  });
-
-  const commentList = flatPaginationCache(data);
+  const queryClient = useQueryClient();
 
   const postComment = useMutation({
     mutationFn: async ({ content, parentId }) => {
@@ -144,12 +136,8 @@ export default function useComment() {
   });
 
   return {
-    commentList,
-    isLoading,
-    isError,
     postComment,
     deleteComment,
     editComment,
-    ref,
   };
 }

--- a/src/hooks/usePagination.jsx
+++ b/src/hooks/usePagination.jsx
@@ -22,10 +22,6 @@ export default function usePagination({ queryKey, queryFn, enabled }) {
         return null;
       }
 
-      if (lastPage?.length === 0) {
-        return null;
-      }
-
       return lastPageParam + 1;
     },
     enabled,


### PR DESCRIPTION
## 🎯 관련 이슈

close #367

<br />

## 🚀 작업 내용

- useComment에서 pagination 로직을 분리했습니다.

<br />

## 🔎 발견된 장애가 있었나요?

- 댓글 페이지네이션에서 0부터 n 페이지까지를 한 번에 호출하는 문제
  - useComment에 pagination 로직이 포함되어 있는데, CommentList와 Comment 컴포넌트가 useComment에 대한 의존성을 가지면서 pagination 로직이 중복으로 실행이 된 것 같습니다.
  - useComment에서 pagination 로직을 분리해서 해결했습니다.

<br />

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
