### PR TITLE
#371 [STYLE] 시험 유형 및 문항 수 라벨이 안 찌그러지게 정렬 수정

### DIFF
--- a/src/components/ReviewContentItem/ReviewContentItem.jsx
+++ b/src/components/ReviewContentItem/ReviewContentItem.jsx
@@ -1,9 +1,19 @@
+import { FLEX_ALIGN } from '@/constants';
+
 import styles from './ReviewContentItem.module.css';
 
-export default function ReviewContentItem({ tag, value }) {
+export default function ReviewContentItem({
+  tag,
+  value,
+  align = FLEX_ALIGN.center,
+}) {
   return (
     <div className={styles.item}>
-      <span className={styles.tag}>{tag}</span>
+      <span
+        className={`${styles.tag} ${align === FLEX_ALIGN.flexStart && styles.flexStart}`}
+      >
+        {tag}
+      </span>
       <span className={styles.value}>{value}</span>
     </div>
   );

--- a/src/components/ReviewContentItem/ReviewContentItem.module.css
+++ b/src/components/ReviewContentItem/ReviewContentItem.module.css
@@ -14,6 +14,8 @@
 }
 
 .tag {
+  margin-right: 14px;
+  flex-shrink: 0;
   font-size: 12px;
   letter-spacing: -0.5px;
   color: #898989;
@@ -22,4 +24,8 @@
 .value {
   font-size: 14px;
   color: #484848;
+}
+
+.flexStart {
+  align-self: flex-start;
 }

--- a/src/constants/align.js
+++ b/src/constants/align.js
@@ -1,0 +1,4 @@
+export const FLEX_ALIGN = Object.freeze({
+  center: 'center',
+  flexStart: 'flex-start',
+});

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,3 +1,4 @@
+export * from './align.js';
 export * from './attendance.js';
 export * from './board.js';
 export * from './boardMenus.js';

--- a/src/pages/ExamReviewPage/ExamReviewDetailPage/ExamReviewDetailPage.jsx
+++ b/src/pages/ExamReviewPage/ExamReviewDetailPage/ExamReviewDetailPage.jsx
@@ -19,7 +19,13 @@ import { ReviewDownload } from '@/components/ReviewDownload';
 
 import { dateFormat, convertToObject } from '@/utils';
 
-import { LECTURE_TYPES, SEMESTERS, EXAM_TYPES, TOAST } from '@/constants';
+import {
+  LECTURE_TYPES,
+  SEMESTERS,
+  EXAM_TYPES,
+  TOAST,
+  FLEX_ALIGN,
+} from '@/constants';
 
 import styles from './ExamReviewDetailPage.module.css';
 
@@ -165,7 +171,11 @@ export default function ExamReviewDetailPage() {
           />
           <ReviewContentItem tag='시험 종류' value={EXAM_TYPE[examType]} />
           <ReviewContentItem tag='P/F 여부' value={isPF ? 'O' : 'X'} />
-          <ReviewContentItem tag='시험 유형 및 문항수' value={questionDetail} />
+          <ReviewContentItem
+            tag='시험 유형 및 문항수'
+            value={questionDetail}
+            align={FLEX_ALIGN.flexStart}
+          />
         </div>
         <ReviewDownload
           className={styles.fileDownload}


### PR DESCRIPTION
## 🎯 관련 이슈

close #

<br />

## 🚀 작업 내용

- `tag`에 flex-shrink: 0으로 설정, margin-right 추가
- 시험 유형 및 문항 수 영역에 align을 flex-start로 지정

<br />

## 📸 스크린샷

| <img width="321" alt="image" src="https://github.com/user-attachments/assets/617cc8ea-19ce-406d-a896-4726d71aa1c7"> |
| :---------------------: |
| 시험후기 상세 |

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
