### PR TITLE
#376 [MODIFY] PC 환경에서만 시험후기 다운로드 완료 토스트 노출

### DIFF
--- a/src/components/ReviewDownload/ReviewDownload.jsx
+++ b/src/components/ReviewDownload/ReviewDownload.jsx
@@ -9,6 +9,7 @@ import { useToast } from '@/hooks';
 import { DeleteModal } from '@/components/Modal';
 import { Icon } from '@/components/Icon';
 
+import { isPC } from '@/utils';
 import { TOAST } from '@/constants';
 
 import styles from './ReviewDownload.module.css';
@@ -48,7 +49,9 @@ export default function ReviewDownload({
         return { ...prev, isDownloaded: true };
       });
 
-      toast(TOAST.EXAM_REVIEW.download);
+      if (isPC()) {
+        toast(TOAST.EXAM_REVIEW.download);
+      }
     } catch ({ response }) {
       const text = await response.data.text();
       const { message } = JSON.parse(text);

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -7,3 +7,4 @@ export * from './getBoardTextId.js';
 export * from './pagination.js';
 export * from './timeAgo.js';
 export * from './validate.js';
+export * from './window.js';

--- a/src/utils/window.js
+++ b/src/utils/window.js
@@ -1,0 +1,22 @@
+const MOBBILE_DEVICES = Object.freeze([
+  'Android',
+  'iPhone',
+  'iPad',
+  'iPod',
+  'BlackBerry',
+  'Windows Phone',
+  'Mobile',
+]);
+
+export const isPC = () => {
+  if (navigator.userAgentData) {
+    return !navigator.userAgentData.mobile;
+  }
+
+  const userAgent = navigator.userAgent;
+  const isMobileDevice = MOBBILE_DEVICES.some((device) =>
+    userAgent.includes(device)
+  );
+
+  return !isMobileDevice && window.innerWidth > 1024;
+};


### PR DESCRIPTION
## 🎯 관련 이슈

close #376

<br />

## 🚀 작업 내용

- 모바일 환경에서는 브라우저에서 자체적으로 파일 다운로드 의사를 묻는 confirm과 완료 overlay를 띄우고 있습니다.
- 프론트에서 띄우는 토스트는 모바일 환경에서 제공하는 overlay 제어 흐름에서 벗어나기 때문에 사용자에게 혼란을 줄 여지가 있습니다.
  ```
  ex) 모바일에서는 다운로드 확인 의사를 묻는 confirm 창에서 확인을 눌러야만 실제 파일이 다운로드 됩니다. 
      만약 취소를 누를 경우 파일은 다운로드 되지 않고, 프론트 코드에 의해 다운로드 확인 토스트가 노출됩니다.
  ```

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
