### PR TITLE
#387 [FEAT] 시험후기 공지 게시판 추가

### DIFF
--- a/src/pages/ExamReviewPage/ExamReviewPage/ExamReviewPage.jsx
+++ b/src/pages/ExamReviewPage/ExamReviewPage/ExamReviewPage.jsx
@@ -1,13 +1,21 @@
 import { useEffect, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 
-import { getReviewList } from '@/apis';
+import { getReviewList, getNoticeLine } from '@/apis';
 
 import { usePagination, useSearch } from '@/hooks';
 
 import { ExamReviewList, ExamReviewSearchList } from '@/pages/ExamReviewPage';
 
-import { AppBar, DropDownBlue, PTR, Search, WriteButton } from '@/components';
+import {
+  AppBar,
+  DropDownBlue,
+  PTR,
+  Search,
+  WriteButton,
+  Icon,
+} from '@/components';
 
 import { convertToObject } from '@/utils';
 import { YEARS, SEMESTERS, EXAM_TYPES } from '@/constants';
@@ -60,6 +68,11 @@ export default function ExamReviewPage() {
 
   const { handleChange, handleOnKeyDown, keyword } = searchResult;
 
+  const { data: noticeLineData } = useQuery({
+    queryKey: ['noticeLine', 32],
+    queryFn: () => getNoticeLine(32),
+  });
+
   useEffect(() => {
     const filterOption = {
       lectureYear: lectureYear?.id,
@@ -84,6 +97,16 @@ export default function ExamReviewPage() {
   return (
     <main>
       <AppBar title='시험후기' />
+      <div className={styles.notification}>
+        <Link
+          className={styles.notification_bar}
+          to={`/board/exam-review/notice`}
+        >
+          <Icon id='notice-bell' width={11} height={13} />
+          <p>[필독]&nbsp;&nbsp;{noticeLineData?.title}</p>
+        </Link>
+      </div>
+
       <Search
         className={styles.search}
         placeholder='시험후기 검색'

--- a/src/pages/ExamReviewPage/ExamReviewPage/ExamReviewPage.module.css
+++ b/src/pages/ExamReviewPage/ExamReviewPage/ExamReviewPage.module.css
@@ -1,3 +1,28 @@
+.notification {
+  width: 100%;
+  padding: 10px var(--default-margin);
+}
+
+.notification_bar {
+  width: 100%;
+  padding: 0.688rem 0.938rem;
+  display: flex;
+  align-items: center;
+  gap: 0.861rem;
+  border-radius: 5px;
+  background-color: #fee9eb;
+  font-size: 0.688rem;
+  color: #ff4b6c;
+  box-sizing: border-box;
+  cursor: pointer;
+}
+
+.notification_icon {
+  width: 0.663rem;
+  height: 0.791rem;
+  display: flex;
+}
+
 .search {
   width: calc(100% - 1.25rem * 2);
   margin: 0 1.25rem 0.625rem 1.25rem;

--- a/src/pages/NoticeListPage/NoticeListPage.jsx
+++ b/src/pages/NoticeListPage/NoticeListPage.jsx
@@ -70,7 +70,11 @@ export default function NoticeListPage() {
             : `${currentBoard.title} 공지`
         }
         hasNotice={true}
-        backNavTo={currentBoardTextId === 'notice' ? '/home' : '/board'}
+        backNavTo={
+          currentBoardTextId === 'notice'
+            ? '/home'
+            : `/board/${currentBoardTextId}`
+        }
       />
       <div className={styles.content}>
         {Array.isArray(noticeList) &&

--- a/src/route.js
+++ b/src/route.js
@@ -243,6 +243,20 @@ export const routeList = [
         ),
       },
       {
+        path: `/board/exam-review/notice`,
+        element: (
+          <ProtectedRoute
+            roles={[ROLE.user, ROLE.admin]}
+            message={'시험후기 게시판 접근 권한이 없습니다.'}
+          >
+            <NoticeListPage />
+          </ProtectedRoute>
+        ),
+        meta: {
+          hideNav: true,
+        },
+      },
+      {
         path: '/board/exam-review/search/:keyword',
         element: (
           <ProtectedRoute


### PR DESCRIPTION
## 🎯 관련 이슈

close #397

<br />

## 🚀 작업 내용

- 시험후기 공지 게시판 추가

<br />

## 📸 스크린샷

| <img width="615" alt="스크린샷 2024-09-15 오후 6 04 01" src="https://github.com/user-attachments/assets/f9b63723-bf2a-41f1-a8f3-ae8e43dc36d6"> | <img width="617" alt="image" src="https://github.com/user-attachments/assets/8231236b-33a9-4eb6-8c21-5d9d28aace3c"> |
| :---------------------: | :---------------------: |

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
