### PR TITLE
#392 [FIX] 새 비밀번호와 확인을 동일하게 입력하여도, 유효성 검사를 통과하지 못하면 submit 버튼 비활성화되도록 수정

### DIFF
--- a/src/pages/MyPage/ChangePasswordPage/ChangePasswordPage.jsx
+++ b/src/pages/MyPage/ChangePasswordPage/ChangePasswordPage.jsx
@@ -18,6 +18,7 @@ export default function ChangePasswordPage() {
   const [newPasswordCheck, setNewPasswordCheck] = useState('');
   const [newPasswordError, setNewPasswordError] = useState('');
   const [newPasswordCheckError, setNewPasswordCheckError] = useState('');
+  const [isPasswordValid, setIsPasswordValid] = useState(false);
 
   const navigate = useNavigate();
   const { toast } = useToast();
@@ -49,8 +50,10 @@ export default function ChangePasswordPage() {
       setNewPasswordError(
         '영어, 숫자, 특수문자를 포함해 8자 이상으로 작성해주세요'
       );
+      setIsPasswordValid(false);
     } else {
       setNewPasswordError('');
+      setIsPasswordValid(true);
     }
   };
 
@@ -90,6 +93,7 @@ export default function ChangePasswordPage() {
       validatePasswordStrength(newPassword);
     } else {
       setNewPasswordError('');
+      setIsPasswordValid(false);
     }
   }, [newPassword]);
 
@@ -111,7 +115,9 @@ export default function ChangePasswordPage() {
           <ActionButton
             type='button'
             disabled={
-              isUpdatePasswordPending || newPassword !== newPasswordCheck
+              isUpdatePasswordPending ||
+              newPassword !== newPasswordCheck ||
+              !isPasswordValid
             }
             onClick={handleSubmitButtonClick}
           >

--- a/src/pages/MyPage/EditInfoPage/EditInfoPage.jsx
+++ b/src/pages/MyPage/EditInfoPage/EditInfoPage.jsx
@@ -270,7 +270,7 @@ export default function EditInfoPage() {
               maxLength={12}
               value={birthDate.replaceAll('-', '')}
               pattern='\d{4}\.\d{2}\.\d{2}'
-              title='형식: YYYYMMDD (예: 20020101)'
+              title='형식: YYYYMMDD (예: 19060522)'
               disabled={disabledPrivateUserInfoInput}
               onChange={handleBirthDateChange}
             />


### PR DESCRIPTION
## 🎯 관련 이슈

close #392

<br />

## 🚀 작업 내용

- 변경전) `새 비밀번호`와 `새 비밀번호 확인`이 동일하게 입력되면, 조건에 맞지 않는 비밀번호 형식을 입력해도 submit 버튼이 활성화 됨
- 변경후) `새 비밀번호`와 `새 비밀번호 확인`을 동일하게 입력하여도, 유효성 검사를 통과하지 못하면 submit 버튼 비활성화되도록 수정

<br />

## 📸 스크린샷

| <img height='500' src='https://github.com/user-attachments/assets/5bd3c79e-08f3-4281-a927-ca79097d5daa'> |  <img height='500'  src='https://github.com/user-attachments/assets/40961b74-42a2-40fb-8878-8746798470a1'> |  
| :-----:|:------:|
| 수정 전 | 수정 후 |


<br />


## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?
- `새 비밀번호`와 `새 비밀번호 확인` 모두 유효성 검사를 통과하지 않으면 submit 버튼이 비활성화 되므로, 빈 토스트가 노출되는 문제도 함께 해결됨

<br />
