### PR TITLE
#396 [FEAT] 마이페이지 내 계정정보 항목에 이름 추가 및 생년월일 형식 변경

### DIFF
--- a/src/pages/MyPage/MyPage/AccountTab.jsx
+++ b/src/pages/MyPage/MyPage/AccountTab.jsx
@@ -6,6 +6,7 @@ import styles from './MyPage.module.css';
 
 const USER_INFO_ITEM_LABEL = Object.freeze({
   loginId: '아이디',
+  userName: '이름',
   email: '이메일',
   studentNumber: '학번',
   major: '전공',

--- a/src/pages/MyPage/MyPage/AccountTab.jsx
+++ b/src/pages/MyPage/MyPage/AccountTab.jsx
@@ -26,8 +26,9 @@ const AccountTab = () => {
 
   const userInfoValue = {
     ...userInfo,
-    birthday: userInfo.birthday.replaceAll('-', ''),
+    birthday: `${userInfo.birthday.slice(0, 4)}.${userInfo.birthday.slice(5, 7)}.${userInfo.birthday.slice(8, 10)}`,
   };
+
   const userInfoList = Object.entries(USER_INFO_ITEM_LABEL).map(
     ([key, label]) => ({
       label,


### PR DESCRIPTION
## 🎯 관련 이슈

close #396

<br />

## 🚀 작업 내용

- 마이페이지 내 계정정보 항목에 이름 추가 및 생년월일 형식 변경

<br />

## 📸 스크린샷

| <img height='500' src='https://github.com/user-attachments/assets/8c7571b2-9951-4ffd-986b-2c5a19e4645c'> | 
|:---------------:|
| [마이페이지] - [계정 정보] 탭 | 


<br />

