### PR TITLE
#400 [FIX] 댓글 관련 오류 해결

### DIFF
--- a/src/components/Comment/Comment/Comment.jsx
+++ b/src/components/Comment/Comment/Comment.jsx
@@ -87,6 +87,9 @@ const Comment = forwardRef((props, ref) => {
         ref={ref}
         className={styles.comment}
         onClick={() => setCommentId(undefined)}
+        style={{
+          backgroundColor: commentId === data.id ? '#DDEBF6' : '#f8f8f8',
+        }}
       >
         <div className={styles.commentTop}>
           <div className={styles.commentTopLeft}>

--- a/src/components/InputBar/InputBar.jsx
+++ b/src/components/InputBar/InputBar.jsx
@@ -6,8 +6,6 @@ import { useComment, useToast } from '@/hooks';
 
 import { Icon } from '@/components/Icon';
 
-import { TOAST } from '@/constants';
-
 import styles from './InputBar.module.css';
 
 const InputBar = () => {
@@ -29,7 +27,7 @@ const InputBar = () => {
   // 댓글 등록 or 수정
   const submitComment = () => {
     if (!content.trim()) {
-      toast(TOAST.EMPTY_COMMENT);
+      toast('댓글 내용을 입력하세요.');
       return;
     }
 

--- a/src/components/InputBar/InputBar.jsx
+++ b/src/components/InputBar/InputBar.jsx
@@ -42,6 +42,7 @@ const InputBar = () => {
       setCommentId(undefined);
     } else {
       postComment.mutate({ parentId: commentId, content });
+      setCommentId(undefined);
     }
 
     setContent('');

--- a/src/contexts/CommentContext.jsx
+++ b/src/contexts/CommentContext.jsx
@@ -33,13 +33,17 @@ export function CommentContextProvider({ children }) {
     [isEdit, commentId, content]
   );
 
-  const onBlur = () => setCommentId(undefined);
+  const onBlur = () => {
+    if (!isEdit) {
+      setCommentId(undefined);
+    }
+  };
 
   useEffect(() => {
     window.addEventListener('click', onBlur);
 
     return () => window.removeEventListener('click', onBlur);
-  }, []);
+  }, [isEdit]);
 
   return (
     <CommentContext.Provider value={value}>{children}</CommentContext.Provider>

--- a/src/contexts/CommentContext.jsx
+++ b/src/contexts/CommentContext.jsx
@@ -33,15 +33,15 @@ export function CommentContextProvider({ children }) {
     [isEdit, commentId, content]
   );
 
-  const onBlur = () => {
-    if (!isEdit) {
+  const onBlur = (event) => {
+    // 클릭한 요소가 input이 아닐 경우에만 commentId를 undefined로 설정
+    if (!isEdit && !inputRef.current?.contains(event.target)) {
       setCommentId(undefined);
     }
   };
 
   useEffect(() => {
     window.addEventListener('click', onBlur);
-
     return () => window.removeEventListener('click', onBlur);
   }, [isEdit]);
 


### PR DESCRIPTION
## 🎯 관련 이슈

close #400

<br />

## 🚀 작업 내용

- 댓글 수정 시 빈 토스트만 뜨고 오류 발생하는 문제 해결 (focus가 input창에서 나갔을 때 isEdit 조건 확인하여 commentId를 undefined로 설정하지 않도록 수정)
- 대댓글 달 때 부모 댓글에 배경 파란색 주기
- 댓글 내용이 없을 경우 오류 토스트 띄우기 (TOAST constant가 수정되면서 생긴 오류였음)
<br />

## 📸 스크린샷

| <img width="618" alt="image" src="https://github.com/user-attachments/assets/0e447eee-f04f-463d-bd1b-7247e68f7ac2"> | <img width="619" alt="스크린샷 2024-09-18 오후 5 37 55" src="https://github.com/user-attachments/assets/f46db759-74e8-4563-9e08-2fba5d4f7d67"> |
| :---------------------: | :---------------------: |

