### PR TITLE
#408 [FIX] 댓글 수정, 삭제 버그 해결

### DIFF
--- a/src/components/Comment/Comment/Comment.jsx
+++ b/src/components/Comment/Comment/Comment.jsx
@@ -15,8 +15,14 @@ import { reportComment } from '@/apis';
 
 const Comment = forwardRef((props, ref) => {
   const { data } = props;
-  const { setIsEdit, commentId, setCommentId, setContent, inputFocus } =
-    useCommentContext();
+  const {
+    setIsEdit,
+    commentId,
+    setCommentId,
+    setContent,
+    inputFocus,
+    resetCommentState,
+  } = useCommentContext();
   const { deleteComment } = useComment();
   const { like, deleteLike } = useLike({ type: 'comments', typeId: data.id });
   const { toast } = useToast();
@@ -62,8 +68,8 @@ const Comment = forwardRef((props, ref) => {
     setContent('');
   };
 
-  const handleReply = (e) => {
-    e.stopPropagation();
+  const handleReply = () => {
+    resetCommentState();
     setCommentId(data.id);
     inputFocus();
   };
@@ -86,7 +92,7 @@ const Comment = forwardRef((props, ref) => {
       <div
         ref={ref}
         className={styles.comment}
-        onClick={() => setCommentId(undefined)}
+        onClick={(event) => event.stopPropagation()}
         style={{
           backgroundColor: commentId === data.id ? '#DDEBF6' : '#f8f8f8',
         }}
@@ -106,10 +112,7 @@ const Comment = forwardRef((props, ref) => {
           </div>
           <p
             className={styles.dot3}
-            onClick={(e) => {
-              e.stopPropagation();
-              onCommentOptionClick(data);
-            }}
+            onClick={(e) => onCommentOptionClick(data)}
           >
             {!isDeleted && isVisible && (
               <Icon id='ellipsis-vertical' width='3' height='11' />
@@ -181,12 +184,11 @@ const Comment = forwardRef((props, ref) => {
       <DeleteModal
         id='comment-delete'
         isOpen={isDeleteModalOpen}
-        setIsOpen={setIsDeleteModalOpen}
-        redBtnFunction={() => {
-          deleteComment.mutate({ commentId });
-          setCommentId(undefined);
-          setContent('');
+        closeFunction={() => {
+          resetCommentState();
+          setIsDeleteModalOpen(false);
         }}
+        redBtnFunction={() => deleteComment.mutate({ commentId })}
       />
       <OptionModal
         id='comment-report'

--- a/src/components/Comment/NestedComment/NestedComment.jsx
+++ b/src/components/Comment/NestedComment/NestedComment.jsx
@@ -14,8 +14,7 @@ export default function NestedComment({
   isFirst,
   onCommentOptionClick,
 }) {
-  const { setCommentId } = useCommentContext();
-
+  const { commentId } = useCommentContext();
   const { like, deleteLike } = useLike({ type: 'comments', typeId: data.id });
 
   const {
@@ -28,15 +27,14 @@ export default function NestedComment({
     isVisible,
     isUpdated,
     isDeleted,
-    // isLiked,
   } = data;
 
   return (
     <div
       className={`${styles.nestedComment} ${isLast && styles.isLast}`}
-      onClick={(e) => {
-        e.stopPropagation();
-        setCommentId(undefined);
+      onClick={(event) => event.stopPropagation()}
+      style={{
+        backgroundColor: commentId === data.id ? '#DDEBF6' : '#f0f0f0',
       }}
     >
       <div className={styles.nestedCommentTop}>

--- a/src/components/Modal/DeleteModal.jsx
+++ b/src/components/Modal/DeleteModal.jsx
@@ -2,13 +2,18 @@ import { MODAL_OPTIONS } from '@/constants';
 
 import styles from './Modal.module.css';
 
-export default function DeleteModal({ id, isOpen, setIsOpen, redBtnFunction }) {
+export default function DeleteModal({
+  id,
+  isOpen,
+  closeFunction,
+  redBtnFunction,
+}) {
   const modalOption = MODAL_OPTIONS.find((option) => option.id === id);
 
   if (!isOpen || !modalOption) return null;
 
   return (
-    <div className={styles.dim}>
+    <div className={styles.dim} onClick={(event) => event.stopPropagation()}>
       <div className={styles.container}>
         <div className={styles.noBottomLineTop}>
           <div
@@ -22,15 +27,14 @@ export default function DeleteModal({ id, isOpen, setIsOpen, redBtnFunction }) {
         <div className={styles.deleteOrBack}>
           <div
             className={styles.redBtn}
-            onClick={(event) => {
-              event.stopPropagation();
+            onClick={() => {
               redBtnFunction();
-              setIsOpen(false);
+              closeFunction();
             }}
           >
             {modalOption.bottom.redBtn}
           </div>
-          <div className={styles.greyBtn} onClick={() => setIsOpen(false)}>
+          <div className={styles.greyBtn} onClick={closeFunction}>
             {modalOption.bottom.greyBtn}
           </div>
         </div>

--- a/src/components/Modal/OptionModal.jsx
+++ b/src/components/Modal/OptionModal.jsx
@@ -17,7 +17,7 @@ export default function OptionModal({
   if (!isOpen || !modalOption) return null;
 
   return (
-    <div className={styles.dim}>
+    <div className={styles.dim} onClick={(event) => event.stopPropagation()}>
       <div className={styles.container}>
         <div className={styles.top}>
           <div

--- a/src/contexts/CommentContext.jsx
+++ b/src/contexts/CommentContext.jsx
@@ -19,6 +19,12 @@ export function CommentContextProvider({ children }) {
     inputRef.current?.focus();
   };
 
+  const resetCommentState = () => {
+    setCommentId(undefined);
+    setIsEdit(false);
+    setContent('');
+  };
+
   const value = useMemo(
     () => ({
       isEdit,
@@ -29,20 +35,14 @@ export function CommentContextProvider({ children }) {
       setContent,
       inputRef,
       inputFocus,
+      resetCommentState,
     }),
     [isEdit, commentId, content]
   );
 
-  const onBlur = (event) => {
-    // 클릭한 요소가 input이 아닐 경우에만 commentId를 undefined로 설정
-    if (!isEdit && !inputRef.current?.contains(event.target)) {
-      setCommentId(undefined);
-    }
-  };
-
   useEffect(() => {
-    window.addEventListener('click', onBlur);
-    return () => window.removeEventListener('click', onBlur);
+    window.addEventListener('click', resetCommentState);
+    return () => window.removeEventListener('click', resetCommentState);
   }, [isEdit]);
 
   return (

--- a/src/pages/LoginPage/LoginPage/LoginPage.jsx
+++ b/src/pages/LoginPage/LoginPage/LoginPage.jsx
@@ -49,12 +49,7 @@ export default function Login() {
               inputData={setFormData}
             />
           </div>
-          <div
-            className={!isError ? styles.input : undefined}
-            onChange={() => {
-              setErrmsg(false);
-            }}
-          >
+          <div className={!isError ? styles.input : undefined}>
             <div
               className={`${styles.pwFrame} ${styles[isError ? 'wrong' : 'ready']}`}
             >


### PR DESCRIPTION
## 🎯 관련 이슈

close #408

<br />

## 🚀 작업 내용

- 댓글 외부 영역 클릭 시 `commentId`을 undefined로 변경하는 로직 수정
  - 기존 event.stopPropagation()을 Comment와 NestedComment 최상위 div로 옮기고, `commentId`을 `undefined`로 설정하는 책임을 CommentContext로 위임
- DeleteModal과 OptionModal 최상위 div에도 event.stopPropagation()을 추가
  - 모달이 열렸을 때 아무 영역 클릭 시 CommentContext에 의해 `commentId`가 `undefined`로 set되는 문제를 방지하기 위함

<br />

<!--
## 📸 스크린샷

| (스크린샷을 넣어주세요) |
| :---------------------: |
-->

<br />

## 🔎 발견된 장애가 있었나요?

- 댓글 수정, 삭제 시 외부 영역을 잘못 클릭하면 `commentId`가 `undefined`로 set 되어 401 에러가 발생했습니다.
  - 필요한 경우에만  `commentId`를 `undefined`로 set 하도록 수정해서 버그 해결했습니다.

<br />

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
