### PR TITLE
#418 [FIX] 에러 발생 시 빈 토스트가 노출되는 버그 해결

### DIFF
--- a/src/pages/SnoroseVerifyPage/VerifyPage/VerifyPage.jsx
+++ b/src/pages/SnoroseVerifyPage/VerifyPage/VerifyPage.jsx
@@ -42,7 +42,8 @@ export default function VerifyPage({ setStep }) {
 
       setStep('complete');
     } catch ({ response }) {
-      toast(response.data.message);
+      const { data } = response;
+      toast(Object.values(data)[0]);
     }
   };
 


### PR DESCRIPTION
## 🎯 관련 이슈

close #418

<br />

## 🚀 작업 내용

- 숙명인 인증 에러 핸들링 로직에서 `error.response.data`의 첫 번째 value를 토스트로 노출하도록 수정

<br />

## 📸 스크린샷

| <img width="321" alt="image" src="https://github.com/user-attachments/assets/a77753da-309b-4b0d-9231-57bafa4e7191"> |
| :---------------------: |
| 아이디 필드에 학번을 입력하지 않았을 경우 |

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
