### PR TITLE
#420 [FIX] 이미 다운받은 시험후기인데도 마이페이지 포인트가 차감되는 버그 해결

### DIFF
--- a/src/components/ReviewDownload/ReviewDownload.jsx
+++ b/src/components/ReviewDownload/ReviewDownload.jsx
@@ -44,13 +44,16 @@ export default function ReviewDownload({
     try {
       await downloadExamReview();
 
+      const reviewDetail = queryClient.getQueryData(['reviewDetail', postId]);
+      const { isDownloaded } = reviewDetail ?? { isDownloaded: false };
+
       queryClient.setQueryData(['reviewDetail', postId], (prev) => {
         return { ...prev, isDownloaded: true };
       });
 
       queryClient.setQueryData(['myPageUserInfo'], (prev) => ({
         ...prev,
-        balance: prev.balance - 50,
+        balance: isDownloaded ? prev.balance : prev.balance - 50,
       }));
 
       toast(TOAST.EXAM_REVIEW.download);


### PR DESCRIPTION
## 🎯 관련 이슈

close #420

<br />

## 🚀 작업 내용

- `['reviewDetail', postId]` 키에 대한 쿼리에서 `isDownloaded`을 가져와서 조건부로 마이페이지 포인트를 set 하도록 수정

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
