### PR TITLE
#434 [FIX] 생년월일 입력란에 추가 제한 걸어놓기

### DIFF
--- a/src/pages/LoginPage/FindIdPage/inputCheck.js
+++ b/src/pages/LoginPage/FindIdPage/inputCheck.js
@@ -93,15 +93,47 @@ export function checkIfSame(input1, input2) {
 
 export function checkBirthday(input) {
   input = input.trim();
+
   if (!input) return 'ready';
+
   const [year, month, date] = input.split('-');
+  const todayDate = new Date();
+  const birthDate = new Date(year, month - 1, date);
+
   for (let i = 0; i < 3; i++) {
     if (!/^\d+$/.test(year) || !/^\d+$/.test(month) || !/^\d+$/.test(date)) {
       return 'wrong';
     }
   }
-  if (year.length !== 4 || month.length !== 2 || date.length !== 2) {
+  if (
+    todayDate < birthDate ||
+    year.length !== 4 ||
+    month.length !== 2 ||
+    date.length !== 2 ||
+    parseInt(month) < 1 ||
+    parseInt(month) > 12
+  ) {
     return 'wrong';
+  }
+  switch (parseInt(month)) {
+    case 1:
+    case 3:
+    case 5:
+    case 7:
+    case 8:
+    case 10:
+    case 12:
+      if (parseInt(date) < 1 || parseInt(date) > 31) return 'wrong';
+      break;
+    case 2:
+    case 4:
+    case 6:
+    case 9:
+    case 11:
+      if (parseInt(date) < 1 || parseInt(date) > 30) return 'wrong';
+      break;
+    default:
+      return 'right';
   }
   return 'right';
 }


### PR DESCRIPTION
## 🎯 관련 이슈

close #434

<br />

## 🚀 작업 내용
- 회원가입에 생년월일 입력란에 추가 제한을 걸어놨습니다
- Month 입력을 1~12 사이의 숫자로 제한
- Month가 1월, 3월, 5월 7월, 8월, 10월, 12월 일시 Date 입력을 1~31 사이의 숫자로 제한
- Month가 2월, 4월, 6월 9월, 11월 일시 Date 입력을 1~30 사이의 숫자로 제한
- 입력한 생일이 현 날짜를 초과하지 않게 제한

<br />

## 📸 스크린샷
<img src="https://github.com/user-attachments/assets/85ea1347-e139-4de6-aa9c-ba82bce50766" width="500">
<img src="https://github.com/user-attachments/assets/001d321d-f4a4-4e3e-85c3-adcd9b5743da" width="500">
<img src="https://github.com/user-attachments/assets/feaabd6e-f400-4700-97ca-11868b82957a" width="500">
<img src="https://github.com/user-attachments/assets/47b46cd2-b830-43b6-9e68-7b168364de40" width="500">

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
