### PR TITLE
#454 [FEAT] 숙명인 인증 페이지에 준회원 또는 관리자만 접근 가능

### DIFF
--- a/src/route.js
+++ b/src/route.js
@@ -420,7 +420,10 @@ export const routeList = [
       {
         path: '/verify',
         element: (
-          <ProtectedRoute>
+          <ProtectedRoute
+            roles={[ROLE.preUser, ROLE.admin]}
+            message='이미 인증을 완료했거나 인증 대상이 아닙니다'
+          >
             <SnoroseVerifyPage />
           </ProtectedRoute>
         ),


### PR DESCRIPTION
## 🎯 관련 이슈

close #454

<br />

## 🚀 작업 내용

- 숙명인 페이지를 감싸는 ProtectedRoute에 권한 설정
  - 준회원, 관리자만 접근 가능

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
