### PR TITLE
#457 [FIX] 시험후기 상세에 누락된 온라인 여부 항목 추가

### DIFF
--- a/src/components/Fieldset/TextField/TextField.module.css
+++ b/src/components/Fieldset/TextField/TextField.module.css
@@ -1,5 +1,5 @@
 .input {
-  padding: 0.625rem 0;
+  padding: 0.4rem 0;
   outline: none;
   border: none;
   border-bottom: 0.5px solid rgba(137, 137, 137, 0.7);

--- a/src/components/Input/InputItem/InputItem.jsx
+++ b/src/components/Input/InputItem/InputItem.jsx
@@ -3,6 +3,7 @@ import styles from './InputItem.module.css';
 export default function InputItem({
   className,
   tag,
+  required,
   value,
   placeholder,
   setFn,
@@ -13,7 +14,10 @@ export default function InputItem({
 
   return (
     <div className={`${styles.item} ${className}`}>
-      <span className={styles.tag}>{tag}</span>
+      <span className={styles.tag}>
+        {tag}
+        {required && <span className={styles.required}></span>}
+      </span>
       <input
         className={styles.input}
         type='text'

--- a/src/components/Input/InputItem/InputItem.module.css
+++ b/src/components/Input/InputItem/InputItem.module.css
@@ -6,11 +6,24 @@
 }
 
 .tag {
+  align-self: flex-start;
+  position: relative;
   font-weight: 400;
   font-size: 11px;
   line-height: 150%;
   letter-spacing: -0.5px;
   color: #898989;
+}
+
+.required {
+  width: 5px;
+  height: 5px;
+  display: inline-block;
+  position: absolute;
+  top: 0.125rem;
+  right: -0.625rem;
+  border-radius: 10px;
+  background-color: #ff4b6c;
 }
 
 .input {

--- a/src/pages/ExamReviewEditPage/ExamReviewEditPage.jsx
+++ b/src/pages/ExamReviewEditPage/ExamReviewEditPage.jsx
@@ -172,14 +172,12 @@ export default function ExamReviewEditPage() {
       </CategoryFieldset>
       <CategoryFieldset
         title='P/F 수업입니다'
-        required
         hasCheckbox
         value={isPF}
         setFn={setIsPF}
       />
       <CategoryFieldset
         title='온라인 수업입니다'
-        required
         hasCheckbox
         value={isOnline}
         setFn={setIsOnline}

--- a/src/pages/ExamReviewEditPage/ExamReviewEditPage.jsx
+++ b/src/pages/ExamReviewEditPage/ExamReviewEditPage.jsx
@@ -106,12 +106,14 @@ export default function ExamReviewEditPage() {
       <InputList>
         <InputItem
           tag='강의명'
+          required
           value={lectureName}
           placeholder='강의명을 입력하세요'
           setFn={setLectureName}
         />
         <InputItem
           tag='교수명'
+          required
           value={professor}
           placeholder='교수명을 입력하세요'
           setFn={setProfessor}

--- a/src/pages/ExamReviewPage/ExamReviewDetailPage/ExamReviewDetailPage.jsx
+++ b/src/pages/ExamReviewPage/ExamReviewDetailPage/ExamReviewDetailPage.jsx
@@ -111,6 +111,7 @@ export default function ExamReviewDetailPage() {
     isConfirmed,
     isDownloaded,
     isEdited,
+    isOnline,
     isPF,
     isScrapped,
     isWriter,
@@ -171,6 +172,10 @@ export default function ExamReviewDetailPage() {
           />
           <ReviewContentItem tag='시험 종류' value={EXAM_TYPE[examType]} />
           <ReviewContentItem tag='P/F 여부' value={isPF ? 'O' : 'X'} />
+          <ReviewContentItem
+            tag='온라인 수업 여부'
+            value={isOnline ? 'O' : 'X'}
+          />
           <ReviewContentItem
             tag='시험 유형 및 문항수'
             value={questionDetail}

--- a/src/pages/ExamReviewWritePage/ExamReviewWritePage.jsx
+++ b/src/pages/ExamReviewWritePage/ExamReviewWritePage.jsx
@@ -226,14 +226,12 @@ export default function ExamReviewWritePage() {
       </CategoryFieldset>
       <CategoryFieldset
         title='P/F 수업입니다'
-        required
         hasCheckbox
         value={isPF}
         setFn={setIsPF}
       />
       <CategoryFieldset
         title='온라인 수업입니다'
-        required
         hasCheckbox
         value={isOnline}
         setFn={setIsOnline}

--- a/src/pages/ExamReviewWritePage/ExamReviewWritePage.jsx
+++ b/src/pages/ExamReviewWritePage/ExamReviewWritePage.jsx
@@ -160,12 +160,14 @@ export default function ExamReviewWritePage() {
       <InputList>
         <InputItem
           tag='강의명'
+          required
           value={lectureName}
           placeholder='강의명을 입력하세요'
           setFn={setLectureName}
         />
         <InputItem
           tag='교수명'
+          required
           value={professor}
           placeholder='교수명을 입력하세요'
           setFn={setProfessor}


### PR DESCRIPTION
## 🎯 관련 이슈

close #457

<br />

## 🚀 작업 내용

- 시험후기 상세에서 isOnline 값에 따라 O 또는 X를 보여주게 수정
- 시험후기 작성 및 수정 페이지에서 P/F, 온라인 수업 여부 필드에 필수 마크 삭제
- 시험후기 작성 및 수정 페이지에서 수업명, 교수명 필드에 필수 마크 부여

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
