### PR TITLE
#484 [FIX] FetchLoading & InputBar와Modal 겹치는 오류 해결 & 한 줄 공지 폰트사이즈 키우기

### DIFF
--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -5,7 +5,7 @@
   position: fixed;
   top: 0;
   left: 50%;
-  z-index: 1;
+  z-index: 101;
   width: 100vw;
   max-width: var(--default-width);
   height: 100vh;

--- a/src/components/PostBar/PostBar.module.css
+++ b/src/components/PostBar/PostBar.module.css
@@ -13,6 +13,7 @@
   align-items: center;
   font-size: 0.6875rem;
   color: #484848;
+  white-space: nowrap;
 }
 
 .name {

--- a/src/pages/BoardPage/BoardListPage/BoardListPage.module.css
+++ b/src/pages/BoardPage/BoardListPage/BoardListPage.module.css
@@ -28,7 +28,8 @@ body {
   gap: 0.861rem;
   border-radius: 0.3125rem;
   background-color: #fee9eb;
-  font-size: 0.688rem;
+  /* font-size: 0.688rem; */
+  font-size: 0.8125rem;
   color: #ff4b6c;
   box-sizing: border-box;
   cursor: pointer;


### PR DESCRIPTION
## 🎯 관련 이슈

close #484

<br />

## 🚀 작업 내용

- FetchLoading & InputBar와Modal 겹치는 오류 해결 (Modal의 z-index를 101로 높임)
- PostBar에서 줄바꿈 생기는 오류 수정 (렉으로 오류 생긴 것일 수도 있어서 nowrap으로 해결될 지는 모르겠음)
- 한 줄 공지 폰트사이즈 키우기

<br />

## 📸 스크린샷
<img width="613" alt="image" src="https://github.com/user-attachments/assets/30044eb7-d604-4ef9-9791-f56ea1e8c5d1">
<img width="610" alt="스크린샷 2024-09-22 오후 9 03 24" src="https://github.com/user-attachments/assets/afda74bb-0089-40cb-9213-10ae7656f5d2">
