### PR TITLE
#505 [FIX] 만년설방, 시험후기 페이지에서 댓글 삭제 시, 모달에 포인트 관련 내용 안 뜨도록 수정

### DIFF
--- a/src/components/Comment/Comment/Comment.jsx
+++ b/src/components/Comment/Comment/Comment.jsx
@@ -1,4 +1,5 @@
 import { forwardRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 
 import { useCommentContext } from '@/contexts/CommentContext.jsx';
 
@@ -16,6 +17,7 @@ import { useMutation } from '@tanstack/react-query';
 import { reportComment } from '@/apis';
 
 const Comment = forwardRef((props, ref) => {
+  const { pathname } = useLocation();
   const { data } = props;
   const {
     setIsEdit,
@@ -187,7 +189,12 @@ const Comment = forwardRef((props, ref) => {
         }}
       />
       <DeleteModal
-        id='comment-delete'
+        id={
+          pathname.startsWith('/board/permanent-snow') ||
+          pathname.startsWith('/board/exam-review')
+            ? 'comment-delete-no-points'
+            : 'comment-delete'
+        }
         isOpen={isDeleteModalOpen}
         closeFunction={() => {
           resetCommentState();

--- a/src/constants/modalOptions.js
+++ b/src/constants/modalOptions.js
@@ -138,6 +138,18 @@ export const MODAL_OPTIONS = [
     },
   },
   {
+    id: 'comment-delete-no-points',
+    title: '댓글을 삭제할까요?',
+    titleColor: '#000',
+    children: {
+      text: '',
+    },
+    bottom: {
+      redBtn: '삭제',
+      greyBtn: '취소',
+    },
+  },
+  {
     id: 'exam-review-report',
     title: '시험 후기 신고',
     titleColor: '#000',

--- a/src/pages/PostPage/PostPage/PostPage.jsx
+++ b/src/pages/PostPage/PostPage/PostPage.jsx
@@ -130,7 +130,6 @@ export default function PostPage() {
   // BackAppBar 이동 path 설정
   const handleNavigation = () => {
     const previousPath = location.state?.from || '/default';
-    console.log('이전 경로: ', previousPath);
 
     if (previousPath.startsWith('/my-page')) {
       return previousPath;


### PR DESCRIPTION
## 🎯 관련 이슈

close #505

<br />

## 🚀 작업 내용

- 만년설방, 시험후기 페이지에서 댓글 삭제 시, 모달에 포인트 관련 내용 안 뜨도록 수정

<br />

## 📸 스크린샷
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/1c79aaaa-bda6-4df3-af39-5fab69b46402">

<br />
