### PR TITLE
#522 [FIX] 시험후기 마지막 리스트 아이템이 Navbar에 가려지는 문제 수정

### DIFF
--- a/src/pages/ExamReviewPage/ExamReviewPage/ExamReviewPage.module.css
+++ b/src/pages/ExamReviewPage/ExamReviewPage/ExamReviewPage.module.css
@@ -37,7 +37,7 @@
 }
 
 .list {
-  padding: 0.25rem 1rem 0 1rem;
+  padding: 0.25rem 1rem 6rem 1rem;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## 🎯 관련 이슈

close #522

<br />

## 🚀 작업 내용

- 시험후기 리스트에 하단 padding 추가 (`6rem`)

<br />

## 📸 스크린샷

| <img width="325" alt="image" src="https://github.com/user-attachments/assets/edccdf44-6807-4037-8788-89a29967b192"> |
| :---------------------: |
| 시험후기 페이지에서 맨 하단까지 스크롤한 경우 |

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
