### PR TITLE
#526 [FIX] commentId set 문제 수정

### DIFF
--- a/src/components/InputBar/InputBar.jsx
+++ b/src/components/InputBar/InputBar.jsx
@@ -40,7 +40,6 @@ const InputBar = () => {
         commentId,
         content,
       });
-      // setIsEdit(false);
     } else {
       createComment.mutate({ parentId: commentId, content });
     }

--- a/src/components/InputBar/InputBar.jsx
+++ b/src/components/InputBar/InputBar.jsx
@@ -42,11 +42,11 @@ const InputBar = () => {
         content,
       });
       setIsEdit(false);
-      setCommentId(undefined);
     } else {
       createComment.mutate({ parentId: commentId, content });
     }
 
+    setCommentId(undefined);
     setContent('');
   };
 

--- a/src/components/InputBar/InputBar.jsx
+++ b/src/components/InputBar/InputBar.jsx
@@ -14,11 +14,10 @@ const InputBar = () => {
 
   const {
     isEdit,
-    setIsEdit,
     commentId,
     content,
-    setCommentId,
     setContent,
+    resetCommentState,
     inputRef,
   } = useCommentContext();
 
@@ -41,13 +40,12 @@ const InputBar = () => {
         commentId,
         content,
       });
-      setIsEdit(false);
+      // setIsEdit(false);
     } else {
       createComment.mutate({ parentId: commentId, content });
     }
 
-    setCommentId(undefined);
-    setContent('');
+    resetCommentState();
   };
 
   // command + enter 또는 ctrl + enter 입력 시 댓글 등록
@@ -63,7 +61,10 @@ const InputBar = () => {
   };
 
   return (
-    <div className={styles.container}>
+    <div
+      className={styles.container}
+      onClick={(event) => event.stopPropagation()}
+    >
       <div className={styles.input_bar}>
         <Icon id='cloud' width='25' height='16' />
         <TextareaAutosize

--- a/src/contexts/CommentContext.jsx
+++ b/src/contexts/CommentContext.jsx
@@ -20,11 +20,9 @@ export function CommentContextProvider({ children }) {
   };
 
   const resetCommentState = (event) => {
-    if (event && inputRef.current && !inputRef.current.contains(event.target)) {
-      setCommentId(undefined);
-      setIsEdit(false);
-      // setContent('');
-    }
+    setCommentId(undefined);
+    setIsEdit(false);
+    setContent('');
   };
 
   const value = useMemo(


### PR DESCRIPTION
## 🎯 관련 이슈

close #526

<br />

## 🚀 작업 내용

- 댓글 작성 시에도 commentId를 `undefined`로 초기화
- InputBar를 클릭했을 때 comment context의 value 값이 초기화 되지 않도록 클릭 이벤트에 대해 `event.stopPropagation` 호출

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
