### PR TITLE
#536 [STYLE] AppBar의 z-index css 삭제

### DIFF
--- a/src/components/AppBar/AppBar/AppBar.module.css
+++ b/src/components/AppBar/AppBar/AppBar.module.css
@@ -8,8 +8,6 @@
   background-color: white;
   position: fixed;
   top: 0;
-  z-index: 10;
-  
 }
 
 .title {

--- a/src/components/AppBar/BackAppBar/BackAppBar.module.css
+++ b/src/components/AppBar/BackAppBar/BackAppBar.module.css
@@ -6,7 +6,6 @@
   max-width: 600px;
   position: fixed;
   top: 0;
-  z-index: 10;
 }
 
 .hasGap {

--- a/src/components/AppBar/CloseAppBar/CloseAppBar.module.css
+++ b/src/components/AppBar/CloseAppBar/CloseAppBar.module.css
@@ -8,7 +8,6 @@
   background-color: white;
   position: fixed;
   top: 0;
-  z-index: 10;
 }
 
 .close {


### PR DESCRIPTION
기본값으로 두기

## 🎯 관련 이슈

close #536

<br />

## 🚀 작업 내용

- AppBar, BackAppBar, CloseAppBar의 z-index css를 삭제

<br />

## 📸 스크린샷

| <img width="322" alt="image" src="https://github.com/user-attachments/assets/44750f6c-8828-4872-8f53-df5c9933ef60"> | <img width="322" alt="image" src="https://github.com/user-attachments/assets/5409756d-977e-4a47-8f49-a554c204a67b"> |
| :---------------------: | :---------------------: |
| 수정 전 | 수정 후 |

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
