### PR TITLE
#550 [MODIFY] 시험후기 리스트 content를 qeustionDetail로 교체

### DIFF
--- a/src/components/PostBar/PostBar.jsx
+++ b/src/components/PostBar/PostBar.jsx
@@ -37,7 +37,7 @@ export default function PostBar({ data, hasComment = true, hasLike = true }) {
       </div>
       <div className={styles.post_center}>
         <p className={styles.title}>{data.title}</p>
-        <p className={styles.text}>{data.content}</p>
+        <p className={styles.text}>{data.content ?? data.questionDetail}</p>
       </div>
       <div className={styles.post_bottom}>
         <span className={styles.board}>{data.boardName}</span>


### PR DESCRIPTION
## 🎯 관련 이슈

close #550

<br />

## 🚀 작업 내용

- 시험후기 리스트 content를 qeustionDetail로 교체

<br />

## 📸 스크린샷

| <img width="322" alt="image" src="https://github.com/user-attachments/assets/965e4ad5-73ec-47be-af92-deec124490be"> |
| :---------------------: |
|  content 대신 questionDetail로 변경 |

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
