### PR TITLE
#562 [FIX] 댓글 신고 시 Input 창에 해당 댓글 들어오는 오류 & 한글 오류 해결

### DIFF
--- a/src/components/Comment/Comment/Comment.jsx
+++ b/src/components/Comment/Comment/Comment.jsx
@@ -47,9 +47,11 @@ const Comment = forwardRef((props, ref) => {
       setIsReportModalOpen(false);
       reportConfirmModal.closeModal();
       toast(message);
+      resetCommentState();
     },
     onError: () => {
       toast('댓글 신고에 실패했습니다.');
+      resetCommentState();
     },
   });
 

--- a/src/components/InputBar/InputBar.jsx
+++ b/src/components/InputBar/InputBar.jsx
@@ -1,11 +1,8 @@
+import React from 'react';
 import TextareaAutosize from 'react-textarea-autosize';
-
 import { useCommentContext } from '@/contexts/CommentContext.jsx';
-
 import { useComment, useToast } from '@/hooks';
-
 import { Icon } from '@/components/Icon';
-
 import styles from './InputBar.module.css';
 
 const InputBar = () => {
@@ -35,16 +32,20 @@ const InputBar = () => {
       return;
     }
 
-    if (isEdit) {
-      editComment.mutate({
-        commentId,
-        content,
-      });
-    } else {
-      createComment.mutate({ parentId: commentId, content });
-    }
+    const mutation = isEdit ? editComment : createComment;
 
-    resetCommentState();
+    mutation.mutate(
+      {
+        ...(isEdit ? { commentId } : { parentId: commentId }),
+        content,
+      },
+      {
+        onSuccess: () => {
+          resetCommentState();
+          inputRef.current.blur();
+        },
+      }
+    );
   };
 
   // command + enter 또는 ctrl + enter 입력 시 댓글 등록


### PR DESCRIPTION
## 🎯 관련 이슈

close #562 

<br />

## 🚀 작업 내용

- 댓글 신고 시 input창에 해당 댓글 내용 들어오는 오류 해결 
- 한글 댓글 등록 시 마지막 글자가 Input에 남는 오류 해결

<br />

## 📸 스크린샷

| <img width="613" alt="image" src="https://github.com/user-attachments/assets/2d92fcb3-dbad-41a7-bdfe-0d89f2c902ad"> | <img width="619" alt="스크린샷 2024-10-06 오후 8 58 23" src="https://github.com/user-attachments/assets/db44e896-2bac-4dae-901a-9b216ff559d7"> |
| :---------------------: | :---------------------: |
| 한글 댓글 등록 시 마지막 글자가 Input에 남음 | 해결 완료 |
