### PR TITLE
#595 [STYLE] DropDownBlue의 z-index 삭제

### DIFF
--- a/src/components/DropDownBlue/DropDownBlue.module.css
+++ b/src/components/DropDownBlue/DropDownBlue.module.css
@@ -27,7 +27,6 @@
   border-radius: 0.3125rem;
   position: absolute;
   top: calc(100% + 0.625rem);
-  z-index: 1;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
## 🎯 관련 이슈

close #595

<br />

## 🚀 작업 내용

- DropDownBlue의 z-index 삭제

<br />

## 📸 스크린샷

| <img width="322" alt="image" src="https://github.com/user-attachments/assets/78d30858-bca4-4a68-82a1-1e14494c3ee9"> | <img width="322" alt="image" src="https://github.com/user-attachments/assets/8d787e2a-047d-47b1-911d-57878ceea4b3"> |
| :---------------------: | :---------------------: |
| 수정 전 | 수정 후 |

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
