### PR TITLE
#599 [MODIFY] 게시글 및 게시판 상단 공지 한 줄 staleTime을 5분으로 설정

### DIFF
--- a/src/pages/BoardPage/BoardListPage/BoardListPage.jsx
+++ b/src/pages/BoardPage/BoardListPage/BoardListPage.jsx
@@ -19,6 +19,7 @@ export default function BoardListPage() {
   const { data: noticeLineData } = useQuery({
     queryKey: [QUERY_KEY.noticeLine, currentBoard.id],
     queryFn: () => getNoticeLine(currentBoard?.id),
+    staleTime: 1000 * 60 * 5,
   });
 
   return (

--- a/src/pages/PostPage/PostPage/PostPage.jsx
+++ b/src/pages/PostPage/PostPage/PostPage.jsx
@@ -52,6 +52,7 @@ export default function PostPage() {
   const { data, isLoading, error, isError } = useQuery({
     queryKey: [QUERY_KEY.post, postId],
     queryFn: () => getPostContent(currentBoard?.id, postId),
+    staleTime: 1000 * 60 * 5,
     enabled: !!currentBoard?.id && !!postId,
   });
 


### PR DESCRIPTION
## 🎯 관련 이슈

close #599

<br />

## 🚀 작업 내용

- `getPostContent`, `getNoticeLine`의 staleTime을 5분으로 설정

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
