### PR TITLE
#608 [FIX] 사파리에서 BoardBar의 배경 이미지가 보이지 않는 문제 수정

### DIFF
--- a/src/components/BoardBar/BoardBar.jsx
+++ b/src/components/BoardBar/BoardBar.jsx
@@ -4,14 +4,17 @@ import styles from './BoardBar.module.css';
 
 export default function BoardBar({ data }) {
   return (
-    <Link to={`/board/${data.textId}`} className={styles.board_list_bar}>
-      <svg
-        className={styles.board_bar_background}
-        style={{ backgroundImage: `url("${data.image}")` }}
-      ></svg>
-      <div className={styles.board_bar_text}>
-        <div className={styles.board_bar_title}>{data.title}</div>
-        <div className={styles.board_bar_description}>{data.desc}</div>
+    <Link to={`/board/${data.textId}`}>
+      <div
+        className={styles.container}
+        style={{
+          backgroundImage: `url(${data.image})`,
+        }}
+      >
+        <div className={styles.textBox}>
+          <div className={styles.title}>{data.title}</div>
+          <div className={styles.description}>{data.desc}</div>
+        </div>
       </div>
     </Link>
   );

--- a/src/components/BoardBar/BoardBar.module.css
+++ b/src/components/BoardBar/BoardBar.module.css
@@ -1,16 +1,13 @@
-.board_list_bar {
+.container {
+  width: 100%;
   height: 5.25rem;
-  display: flex;
   border-radius: 0.375rem;
-  background-color: var(--gray-1-1);
-}
-
-.board_bar_background {
+  background: var(--gray-1-1);
   background-repeat: no-repeat;
-  background-position: right;
+  background-position: right bottom;
 }
 
-.board_bar_text {
+.textBox {
   display: flex;
   flex-direction: column;
   position: absolute;
@@ -18,12 +15,12 @@
   margin: 0.875rem;
 }
 
-.board_bar_title {
+.title {
   font-size: 0.875rem;
   font-weight: 500;
 }
 
-.board_bar_description {
+.description {
   font-size: 0.6875rem;
   color: var(--gray-3-1);
 }

--- a/src/components/BoardCard/BoardCard.module.css
+++ b/src/components/BoardCard/BoardCard.module.css
@@ -25,7 +25,7 @@
 }
 
 .desc {
-  width: 4rem;
+  width: 4.5rem;
   font-size: 0.5625rem;
   color: var(--gray-3-1);
   word-break: keep-all;

--- a/src/constants/boardMenus.js
+++ b/src/constants/boardMenus.js
@@ -33,7 +33,7 @@ export const BOARD_MENUS = [
     to: '/board/permanent-snow',
     textId: 'permanent-snow',
     title: '만년설방',
-    desc: '졸업생 전용 게시판',
+    desc: '졸업생 전용 커뮤니티',
     image: permanentSnow,
   },
   // 2차 개발 시 추가 예정

--- a/src/pages/BoardPage/BoardPage/BoardPage.jsx
+++ b/src/pages/BoardPage/BoardPage/BoardPage.jsx
@@ -39,7 +39,7 @@ export default function BoardPage() {
             {BOARD_MENUS.filter((board) =>
               [20, 21, 22, 23].includes(board.id)
             ).map((board, index) => (
-              <BoardBar key={index} data={board} />
+              <BoardBar key={board.id} data={board} />
             ))}
           </div>
         </div>


### PR DESCRIPTION
## 🎯 관련 이슈

close #608

<br />

## 🚀 작업 내용

- BoardBar에서 svg 태그를 삭제하고 배경 이미지를 div의 background-image로 삽입
- BoardCard의 desc 너비와 내용 수정

<br />

## 📸 스크린샷

| <img width="1464" alt="스크린샷 2024-10-10 오전 5 09 40" src="https://github.com/user-attachments/assets/97908466-bed1-428e-a987-d2e7842136d2"> |
| :---------------------: |
| 수정 전 |

| <img width="1464" alt="스크린샷 2024-10-10 오전 5 08 50" src="https://github.com/user-attachments/assets/769c6b0c-0a53-4334-8752-1c59aef5022a"> |
| :---------------------: |
| 수정 후 |

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
