### PR TITLE
#612 [REFACTOR] DeleteModal의 primary button 위치를 오른쪽으로 변경

### DIFF
--- a/src/components/Modal/DeleteModal.jsx
+++ b/src/components/Modal/DeleteModal.jsx
@@ -2,12 +2,7 @@ import { MODAL_OPTIONS } from '@/constants';
 
 import styles from './Modal.module.css';
 
-export default function DeleteModal({
-  id,
-  isOpen,
-  closeFn,
-  redBtnFunction,
-}) {
+export default function DeleteModal({ id, isOpen, closeFn, redBtnFunction }) {
   const modalOption = MODAL_OPTIONS.find((option) => option.id === id);
 
   if (!isOpen || !modalOption) return null;
@@ -25,6 +20,9 @@ export default function DeleteModal({
         </div>
         <div className={styles.deleteCenter}>{modalOption.children.text}</div>
         <div className={styles.deleteOrBack}>
+          <div className={styles.greyBtn} onClick={closeFn}>
+            {modalOption.bottom.greyBtn}
+          </div>
           <div
             className={styles.redBtn}
             onClick={() => {
@@ -33,9 +31,6 @@ export default function DeleteModal({
             }}
           >
             {modalOption.bottom.redBtn}
-          </div>
-          <div className={styles.greyBtn} onClick={closeFn}>
-            {modalOption.bottom.greyBtn}
           </div>
         </div>
       </div>

--- a/src/pages/ExamReviewWritePage/ExamReviewWritePage.jsx
+++ b/src/pages/ExamReviewWritePage/ExamReviewWritePage.jsx
@@ -287,6 +287,7 @@ export default function ExamReviewWritePage() {
             data: formBody,
             file,
           });
+          setIsConfirmModalOpen(false);
         }}
         onSecondaryButtonClick={() => {
           setIsConfirmModalOpen(false);


### PR DESCRIPTION
## 🎯 관련 이슈

close #612

<br />

## 🚀 작업 내용

- DeleteModal의 primary button 위치를 오른쪽으로 변경


<br />

## 📸 스크린샷

| <img width="322" alt="image" src="https://github.com/user-attachments/assets/a4f9ccd8-b072-4d27-af99-1226e29e551d"> | <img width="322" alt="image" src="https://github.com/user-attachments/assets/bd9d667e-dcf0-41a1-a662-09f5fa7c0bd6"> |
| :---------------------: | :---------------------: |
| 수정 전 | 수정 후 |

<br />

## 🔎 발견된 장애가 있었나요?

- 시험후기 작성 페이지에서 중복 시험후기 안내 모달의 다운 버튼 클릭 시 모달이 닫히지 않는 문제가 있었습니다.
  - ConfirmModal의 `onPrimaryButtonClick` 함수 마지막 줄에 `setIsConfirmModalOpen(false)`을 추가했습니다.

<br />

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
