### PR TITLE
#614 [STYLE] BoardCard 폰트 사이즈 키우기

### DIFF
--- a/src/components/BoardCard/BoardCard.module.css
+++ b/src/components/BoardCard/BoardCard.module.css
@@ -16,7 +16,7 @@
 }
 
 .name {
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   font-weight: 500;
 }
 
@@ -25,8 +25,8 @@
 }
 
 .desc {
-  width: 4.5rem;
-  font-size: 0.5625rem;
+  width: 5rem;
+  font-size: 0.6875rem;
   color: var(--gray-3-1);
   word-break: keep-all;
 }


### PR DESCRIPTION
## 🎯 관련 이슈

close #614

<br />

## 🚀 작업 내용

- BoardCard 폰트 사이즈 키우기

<br />

## 📸 스크린샷

| <img width="322" alt="image" src="https://github.com/user-attachments/assets/79814679-bb74-4344-b827-d2f7b2adaeb7"> | <img width="322" alt="image" src="https://github.com/user-attachments/assets/e91cf6ae-3309-4577-8450-f43ce65718ac"> |
| :---------------------: | :---------------------: |
| 수정 전 | 수정 후 |

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
