### PR TITLE
#634 [MODIFY] 시험후기 상세에 content 내용 추가

### DIFF
--- a/src/pages/ExamReviewPage/ExamReviewDetailPage/ExamReviewDetailPage.jsx
+++ b/src/pages/ExamReviewPage/ExamReviewDetailPage/ExamReviewDetailPage.jsx
@@ -174,6 +174,7 @@ export default function ExamReviewDetailPage() {
   }
 
   const {
+    content,
     commentCount,
     createdAt,
     examType,
@@ -232,7 +233,7 @@ export default function ExamReviewDetailPage() {
           />
         </div>
         <div className={styles.title}>{title}</div>
-        <div className={styles.content}>
+        <div className={styles.info}>
           <ReviewContentItem tag='강의명' value={lectureName} />
           <ReviewContentItem tag='교수' value={professor} />
           <ReviewContentItem tag='강의 종류' value={COURSE_TYPE[lectureType]} />
@@ -249,6 +250,7 @@ export default function ExamReviewDetailPage() {
             align={FLEX_ALIGN.flexStart}
           />
         </div>
+        {content && <div className={styles.content}>{content}</div>}
         <ReviewDownload
           className={styles.fileDownload}
           fileName={fileName}

--- a/src/pages/ExamReviewPage/ExamReviewDetailPage/ExamReviewDetailPage.module.css
+++ b/src/pages/ExamReviewPage/ExamReviewDetailPage/ExamReviewDetailPage.module.css
@@ -49,11 +49,17 @@
   font-size: 1rem;
 }
 
-.content {
+.info {
   padding: 0.125rem 0.8125rem;
   margin: 1.4375rem var(--default-margin);
   background: var(--white);
   border-radius: 0.3125rem;
+}
+
+.content {
+  margin: 0 var(--default-margin) 1.4375rem var(--default-margin);
+  font-size: 0.875rem;
+  word-break: keep-all;
 }
 
 .fileDownload {


### PR DESCRIPTION
## 🎯 관련 이슈

close #634

<br />

## 🚀 작업 내용

- 시험후기 상세에 content 데이터 추가

<br />

## 📸 스크린샷

| <img width="322" alt="image" src="https://github.com/user-attachments/assets/153dc53c-4e36-4fab-8df6-dd1c81991773"> |
| :---------------------: |
| content가 추가된 시험후기 상세 |

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
