### PR TITLE
#631 [MODIFY] 아이디 찾기에서 이메일 필드 삭제하고, 서버 응답으로 받은 이메일을 보여주기

### DIFF
--- a/src/apis/login.js
+++ b/src/apis/login.js
@@ -39,14 +39,15 @@ export const findId = async (e, formData, navigate, setLoading) => {
   e.preventDefault();
   const endpoint = '/v1/users/findid';
 
-  if (formData.userName && formData.email && formData.studentNumber) {
+  if (formData.userName && formData.studentNumber) {
     try {
       //로딩중인지 아닌지 확인하는 setLoading
       setLoading(true);
       const response = await defaultAxios.post(endpoint, formData);
       setLoading(false);
+      console.log(response.data.result);
       navigate('/found-id', {
-        state: { email: formData.email },
+        state: { email: response.data.result },
       });
     } catch (e) {
       setLoading(false);

--- a/src/pages/LoginPage/FindIdPage/FindIdPage.jsx
+++ b/src/pages/LoginPage/FindIdPage/FindIdPage.jsx
@@ -10,7 +10,6 @@ import { LOADING_MESSAGE } from '@/constants';
 
 import {
   checkName,
-  checkMail,
   checkStudentNum,
 } from '@/pages/LoginPage/FindIdPage/inputCheck.js';
 
@@ -20,13 +19,11 @@ import { BackAppBar } from '@/components/index.js';
 export default function FindIdPage() {
   const navigate = useNavigate();
   const [nameStyle, setNameStyle] = useState('ready');
-  const [emailStyle, setEmailStyle] = useState('ready');
   const [numberStyle, setNumberStyle] = useState('ready');
   const [allowSubmit, setAllowSubmit] = useState(true);
   const [loading, setLoading] = useState();
   const [formData, setFormData] = useState({
     userName: '',
-    email: '',
     studentNumber: '',
   });
   const inputProps = [
@@ -40,15 +37,6 @@ export default function FindIdPage() {
       '특수문자는 사용할 수 없습니다',
     ],
     [
-      '메일',
-      '메일을 입력해주세요',
-      emailStyle,
-      setEmailStyle,
-      checkMail,
-      'email',
-      '이메일만 입력 가능합니다',
-    ],
-    [
       '학번',
       '학번을 입력해주세요',
       numberStyle,
@@ -59,18 +47,8 @@ export default function FindIdPage() {
     ],
   ];
   const submitState = () => {
-    if (
-      nameStyle === 'right' &&
-      emailStyle === 'right' &&
-      numberStyle === 'right'
-    )
-      return 'right';
-    else if (
-      nameStyle === 'wrong' ||
-      emailStyle === 'wrong' ||
-      numberStyle === 'wrong'
-    )
-      return 'wrong';
+    if (nameStyle === 'right' && numberStyle === 'right') return 'right';
+    else if (nameStyle === 'wrong' || numberStyle === 'wrong') return 'wrong';
     else return 'ready';
   };
 
@@ -79,12 +57,7 @@ export default function FindIdPage() {
       <form
         onSubmit={(e) => {
           e.preventDefault();
-          if (
-            formData.userName &&
-            formData.email &&
-            formData.studentNumber &&
-            allowSubmit
-          ) {
+          if (formData.userName && formData.studentNumber && allowSubmit) {
             findId(e, formData, navigate, setLoading);
             //버튼 한번만 누를 수 있게 제한하는 코드
             setAllowSubmit(false);

--- a/src/pages/LoginPage/FindPwPage/FindPwPage.jsx
+++ b/src/pages/LoginPage/FindPwPage/FindPwPage.jsx
@@ -38,8 +38,8 @@ export default function FindPwPage() {
       '아이디는 영어, 숫자만 가능합니다',
     ],
     [
-      '메일',
-      '메일을 입력해주세요',
+      '이메일',
+      '이메일을 입력해주세요',
       emailStyle,
       setEmailStyle,
       checkMail,

--- a/src/pages/LoginPage/FindPwPage/FindPwPage.jsx
+++ b/src/pages/LoginPage/FindPwPage/FindPwPage.jsx
@@ -84,6 +84,26 @@ export default function FindPwPage() {
                 />
               </div>
             ))}
+            <div className={styles.alert}>
+              <ul style={{ listStyleType: 'circle' }}>
+                <li>
+                  기존 이메일을 알 수 없는 경우, "아이디 찾기" 기능을 통해
+                  확인할 수 있습니다.
+                </li>
+                <li>
+                  "아이디 찾기"에서 이름과 학번을 입력하면, “다음 이메일로
+                  아이디를 전달했습니다.
+                  [snorose@snorose.com](mailto:snorose@snorose.com)”라는 안내를
+                  통해 이메일 주소를 확인할 수 있습니다.
+                </li>
+                <li>
+                  만약 이메일이 존재하지 않거나 유효하지 않을 경우, 아래의 폼을
+                  작성해주시기 바랍니다.
+                  <br />
+                  <a href='https://forms.gle/PDmKuPUuUzKXTh8BA'>구글폼 링크</a>
+                </li>
+              </ul>
+            </div>
           </div>
           <div className={styles.buttonFrame}>
             <Submit btnName='완료' className={submitState()} />

--- a/src/pages/LoginPage/FindPwPage/FindPwPage.module.css
+++ b/src/pages/LoginPage/FindPwPage/FindPwPage.module.css
@@ -40,6 +40,16 @@
   padding: 0 1.25rem;
 }
 
+.alert {
+  font-size: 10px;
+  color: grey;
+  padding: 0 3rem;
+  margin-top: 3rem;
+}
+.alert a {
+  color: lightblue;
+}
+
 .findIDButton {
   display: flex;
   justify-content: center;

--- a/src/pages/LoginPage/SignUpPage/SignUpPageStages/AccountInfoPage.jsx
+++ b/src/pages/LoginPage/SignUpPage/SignUpPageStages/AccountInfoPage.jsx
@@ -52,7 +52,7 @@ export default function AccountInfoPage({ formData, setFormData, setStage }) {
         </div>
         <div className={styles.inputFrame}>
           <Input
-            title={'숙명 구글 메일'}
+            title={'숙명 구글 이메일'}
             placeholder={'sample@sookmyung.ac.kr'}
             className={emailStyle}
             setClassName={setEmailStyle}


### PR DESCRIPTION
## 🎯 관련 이슈

close #631

<br />

## 🚀 작업 내용

- 아이디 찾기에서 사용자에게 이메일을 입력 받지 않고 서버에 저장된 이메일로 아이디 발송
- 아이디 찾기 이메일 필드 삭제
- 결과 페이지에 서버 응답으로 받은 이메일 노출
- 비밀번호 찾기 페이지에 안내 사항 추가
- "메일" 문구를 "이메일"로 바꿈

<br />
