### PR TITLE
#639 [CHORE] Slide에서 Link를 a 태그로 변경

### DIFF
--- a/src/components/Carousel/Slide/Slide.jsx
+++ b/src/components/Carousel/Slide/Slide.jsx
@@ -3,14 +3,13 @@ import { useState } from 'react';
 import defaultBanner from '@/assets/images/bannerError.svg';
 
 import styles from './Slide.module.css';
-import { Link } from 'react-router-dom';
 
 export default function Slide({ src, redirectUrl, alt }) {
   const [imgSrc, setImgSrc] = useState(src);
 
   return (
-    <Link className={styles.slide} to={redirectUrl}>
+    <a className={styles.slide} href={redirectUrl}>
       <img src={imgSrc} alt={alt} onError={() => setImgSrc(defaultBanner)} />
-    </Link>
+    </a>
   );
 }


### PR DESCRIPTION
배너 랜딩 URL이 외부 링크인 경우가 있어 수정했습니다.

## 🎯 관련 이슈

close #639

<br />

## 🚀 작업 내용

- 배너 랜딩 URL이 외부 링크인 경우가 있어서 Slide 컴포넌트에서 Link를 a 태그로 변경했습니다.

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
