### PR TITLE
#644 [MODIFY] questionDetail을 먼저 검사해서 시험후기 PostBar에서 우선 순위로 노출하도록 변경

### DIFF
--- a/src/components/PostBar/PostBar.jsx
+++ b/src/components/PostBar/PostBar.jsx
@@ -37,7 +37,7 @@ export default function PostBar({ data, hasComment = true, hasLike = true }) {
       </div>
       <div className={styles.post_center}>
         <p className={styles.title}>{data.title}</p>
-        <p className={styles.text}>{data.content ?? data.questionDetail}</p>
+        <p className={styles.text}>{data.questionDetail ?? data.content}</p>
       </div>
       <div className={styles.post_bottom}>
         <span className={styles.board}>{data.boardName}</span>


### PR DESCRIPTION
## 🎯 관련 이슈

close #644

<br />

## 🚀 작업 내용

- 시험후기 PostBar에서 questionDetail이 우선하여 보여지도록 Nullish coalescing 연산에서 인자 순서 변경

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
