### PR TITLE
#661 [FIX] ProtectedRoute 로그인 접근 제한 및 애드센스가 자동으로 삽입하는 padding 무시

### DIFF
--- a/src/ProtectedRoute.jsx
+++ b/src/ProtectedRoute.jsx
@@ -11,13 +11,13 @@ export default function ProtectedRoute({ roles, message, children }) {
   const { status, userInfo } = useAuth();
 
   useEffect(() => {
-    if (status === USER_STATUS.loading || userInfo === undefined) {
-      return;
-    }
-
     if (status === USER_STATUS.isLogout) {
       alert('로그인이 필요합니다.');
       navigate('/login', { replace: true });
+      return;
+    }
+
+    if (status === USER_STATUS.loading || userInfo === undefined) {
       return;
     }
 

--- a/src/index.css
+++ b/src/index.css
@@ -135,6 +135,7 @@ html {
 }
 
 body {
+  padding: 0 !important;
   margin: 0;
   font-family:
     'Spoqa Han Sans Neo',


### PR DESCRIPTION
## 🎯 관련 이슈

close #661

<br />

## 🚀 작업 내용

- ProtectedRoute 로그인 접근 제한 로직 위로 올리기
- 애드센스가 자동으로 삽입하는 padding을 무시하기 위해 body에 padding: 0 강제

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
