### PR TITLE
#682 [PERF] 페이지네이션 API 호출 최적화

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,10 +1,8 @@
 export * from './AppBar';
 export * from './BoardBar';
 export * from './BoardCard';
-// export * from './BoardHeader';
 export * from './Card';
 export * from './Carousel';
-// export * from './CategoryBoard';
 export * from './Comment';
 export * from './DropDownBlue';
 export * from './DropDownMenu';
@@ -22,7 +20,6 @@ export * from './MainPageListItem';
 export * from './Margin';
 export * from './MenuIcon';
 export * from './Modal';
-export * from './Navbar';
 export * from './Portal';
 export * from './NoticeBar';
 export * from './PostBar';

--- a/src/constants/reactQuery.js
+++ b/src/constants/reactQuery.js
@@ -35,3 +35,9 @@ export const MUTATION_KEY = Object.freeze({
   updateUserInfo: 'updateUserInfo',
   updatePassword: 'updatePassword',
 });
+
+export const STALE_TIME = Object.freeze({
+  examReview: 1000 * 60 * 5,
+  boardPostList: 1000 * 60 * 1,
+  mypageActivity: 1000 * 60 * 5,
+});

--- a/src/hooks/usePagination.jsx
+++ b/src/hooks/usePagination.jsx
@@ -2,7 +2,12 @@ import { useEffect, useCallback } from 'react';
 import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
 import { useInView } from 'react-intersection-observer';
 
-export default function usePagination({ queryKey, queryFn, enabled }) {
+export default function usePagination({
+  queryKey,
+  queryFn,
+  staleTime = 0,
+  enabled,
+}) {
   const queryClient = useQueryClient();
 
   const {
@@ -25,6 +30,7 @@ export default function usePagination({ queryKey, queryFn, enabled }) {
       }
       return lastPageParam + 1;
     },
+    staleTime,
     enabled,
   });
 

--- a/src/hooks/useScrollRestoration.js
+++ b/src/hooks/useScrollRestoration.js
@@ -1,22 +1,32 @@
-import { useLayoutEffect, useEffect } from 'react';
+import { useLayoutEffect, useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
-import React from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+
+import { QUERY_KEY } from '@/constants';
+
+const PAGINATION_CACHE_SESSION = 'cachePagination';
+const KEEP_SCROLL_SESSION = 'scrollY';
 
 export default function useScrollRestoration() {
-  const scrollRef = React.useRef(null);
+  const scrollRef = useRef(null);
   const { pathname } = useLocation();
+  const queryClient = useQueryClient();
 
   // 스크롤 위치 저장
   const saveScrollPosition = () => {
     if (scrollRef.current) {
-      sessionStorage.setItem('scrollY', scrollRef.current.scrollTop);
+      sessionStorage.setItem(KEEP_SCROLL_SESSION, scrollRef.current.scrollTop);
+      sessionStorage.setItem(PAGINATION_CACHE_SESSION, 'keep pagination cache');
     }
   };
 
   // 스크롤 위치 복원
   useLayoutEffect(() => {
-    if (scrollRef.current && sessionStorage.scrollY) {
-      const savedScrollY = parseInt(sessionStorage.scrollY, 10);
+    if (scrollRef.current && sessionStorage.getItem(KEEP_SCROLL_SESSION)) {
+      const savedScrollY = parseInt(
+        sessionStorage.getItem(KEEP_SCROLL_SESSION),
+        10
+      );
       scrollRef.current.scrollTop = savedScrollY;
     }
   }, []);
@@ -24,8 +34,18 @@ export default function useScrollRestoration() {
   // 경로 변경 또는 새로고침 시 스크롤 위치 초기화
   useEffect(() => {
     const clearScrollPosition = () => {
-      sessionStorage.removeItem('scrollY');
+      sessionStorage.removeItem(KEEP_SCROLL_SESSION);
     };
+
+    const resetPaginationCache = () => {
+      if (!sessionStorage.getItem(PAGINATION_CACHE_SESSION)) {
+        queryClient.resetQueries([QUERY_KEY.noticeLine]);
+      }
+
+      sessionStorage.removeItem(PAGINATION_CACHE_SESSION);
+    };
+
+    resetPaginationCache();
 
     const shouldSaveScrollPosition =
       pathname.startsWith('/board/') && pathname.includes('/post');

--- a/src/hooks/useSearch.jsx
+++ b/src/hooks/useSearch.jsx
@@ -5,7 +5,7 @@ import { searchByBoard } from '@/apis';
 
 import { usePagination } from '@/hooks';
 
-import { BOARD_ID, QUERY_KEY } from '@/constants';
+import { BOARD_ID, QUERY_KEY, STALE_TIME } from '@/constants';
 
 export default function useSearch({ urlKeyword, filterOption }) {
   const { pathname } = useLocation();
@@ -60,6 +60,7 @@ export default function useSearch({ urlKeyword, filterOption }) {
           keyword,
           ...filterOption,
         }),
+      staleTime: STALE_TIME.examReview,
     });
 
   return {

--- a/src/pages/BoardPage/BoardListPage/BoardListPage.jsx
+++ b/src/pages/BoardPage/BoardListPage/BoardListPage.jsx
@@ -5,13 +5,13 @@ import { getNoticeLine } from '@/apis';
 
 import { useScrollRestoration } from '@/hooks';
 
+import { BoardPostList } from '@/pages/BoardPage';
 import { BackAppBar, Icon, WriteButton } from '@/components';
 
 import { getBoard } from '@/utils';
 import { QUERY_KEY } from '@/constants';
 
 import styles from './BoardListPage.module.css';
-import BoardPostList from './BoardPostList/BoardPostList.jsx';
 
 export default function BoardListPage() {
   const { pathname } = useLocation();

--- a/src/pages/BoardPage/BoardListPage/BoardPostList/BoardPostList.jsx
+++ b/src/pages/BoardPage/BoardListPage/BoardPostList/BoardPostList.jsx
@@ -1,12 +1,13 @@
 import { Link, useLocation } from 'react-router-dom';
-import { getPostList } from '@/apis';
-import { usePagination, useScrollRestoration } from '@/hooks';
 
-import React from 'react';
+import { getPostList } from '@/apis';
+
+import { usePagination } from '@/hooks';
+
 import { PostBar, PTR, FetchLoading } from '@/components';
 
 import { getBoard, timeAgo } from '@/utils';
-import { QUERY_KEY } from '@/constants';
+import { QUERY_KEY, STALE_TIME } from '@/constants';
 
 import styles from './BoardPostList.module.css';
 
@@ -20,6 +21,7 @@ export default function BoardPostList({ saveScrollPosition }) {
     usePagination({
       queryKey: [QUERY_KEY.posts, currentBoard.id],
       queryFn: ({ pageParam }) => getPostList(currentBoard.id, pageParam),
+      staleTime: STALE_TIME.boardPostList,
     });
 
   if (isLoading) {

--- a/src/pages/BoardPage/index.js
+++ b/src/pages/BoardPage/index.js
@@ -1,2 +1,3 @@
 export { default as BoardPage } from './BoardPage/BoardPage';
 export { default as BoardListPage } from './BoardListPage/BoardListPage';
+export { default as BoardPostList } from './BoardListPage/BoardPostList/BoardPostList.jsx';

--- a/src/pages/ExamReviewPage/ExamReviewPage/ExamReviewPage.jsx
+++ b/src/pages/ExamReviewPage/ExamReviewPage/ExamReviewPage.jsx
@@ -11,7 +11,13 @@ import { ExamReviewList, ExamReviewSearchList } from '@/pages/ExamReviewPage';
 import { AppBar, DropDownBlue, Search, WriteButton, Icon } from '@/components';
 
 import { convertToObject } from '@/utils';
-import { YEARS, SEMESTERS, EXAM_TYPES, QUERY_KEY } from '@/constants';
+import {
+  YEARS,
+  SEMESTERS,
+  EXAM_TYPES,
+  QUERY_KEY,
+  STALE_TIME,
+} from '@/constants';
 
 import styles from './ExamReviewPage.module.css';
 
@@ -48,6 +54,7 @@ export default function ExamReviewPage() {
   const reviewResult = usePagination({
     queryKey: [QUERY_KEY.posts, 32],
     queryFn: ({ pageParam }) => getReviewList(pageParam),
+    staleTime: STALE_TIME.examReview,
     enabled: urlKeyword === null,
   });
 

--- a/src/pages/MyPage/ActivityPage/CommentPage.jsx
+++ b/src/pages/MyPage/ActivityPage/CommentPage.jsx
@@ -7,7 +7,7 @@ import { usePagination, useScrollRestoration } from '@/hooks';
 import { BackAppBar, FetchLoading, PostBar } from '@/components';
 
 import { getBoardTextId } from '@/utils';
-import { QUERY_KEY } from '@/constants';
+import { QUERY_KEY, STALE_TIME } from '@/constants';
 
 import frustratedWomanIllustration from '@/assets/images/frustratedWoman.svg';
 
@@ -17,6 +17,7 @@ export default function CommentPage() {
   const { data, ref, isLoading, isFetching, isError, error } = usePagination({
     queryKey: [QUERY_KEY.myCommentedPosts],
     queryFn: ({ pageParam }) => getMyCommentList({ page: pageParam }),
+    staleTime: STALE_TIME.mypageActivity,
   });
 
   const { scrollRef, saveScrollPosition } = useScrollRestoration();

--- a/src/pages/MyPage/ActivityPage/DownloadExamReviewPage.jsx
+++ b/src/pages/MyPage/ActivityPage/DownloadExamReviewPage.jsx
@@ -6,7 +6,7 @@ import { usePagination, useScrollRestoration } from '@/hooks';
 
 import { BackAppBar, FetchLoading, PostBar } from '@/components';
 
-import { QUERY_KEY } from '@/constants';
+import { QUERY_KEY, STALE_TIME } from '@/constants';
 import frustratedWomanIllustration from '@/assets/images/frustratedWoman.svg';
 
 import styles from './ActivityPage.module.css';
@@ -15,6 +15,7 @@ export default function DownloadExamReviewPage() {
   const { data, ref, isLoading, isFetching, isError, error } = usePagination({
     queryKey: [QUERY_KEY.myDownloadedExamReviews],
     queryFn: ({ pageParam }) => getMyReviewFileList({ page: pageParam }),
+    staleTime: STALE_TIME.mypageActivity,
   });
 
   const { scrollRef, saveScrollPosition } = useScrollRestoration();

--- a/src/pages/MyPage/ActivityPage/MyPostPage.jsx
+++ b/src/pages/MyPage/ActivityPage/MyPostPage.jsx
@@ -8,7 +8,7 @@ import { BackAppBar, FetchLoading, PostBar } from '@/components';
 
 import { getBoardTextId } from '@/utils';
 
-import { QUERY_KEY } from '@/constants';
+import { QUERY_KEY, STALE_TIME } from '@/constants';
 import frustratedWomanIllustration from '@/assets/images/frustratedWoman.svg';
 
 import styles from './ActivityPage.module.css';
@@ -17,6 +17,7 @@ export default function MyPostPage() {
   const { data, ref, isLoading, isFetching, isError, error } = usePagination({
     queryKey: [QUERY_KEY.myPosts],
     queryFn: ({ pageParam }) => getMyPostList({ page: pageParam }),
+    staleTime: STALE_TIME.mypageActivity,
   });
 
   const { scrollRef, saveScrollPosition } = useScrollRestoration();

--- a/src/pages/MyPage/ActivityPage/ScrapExamReviewPage.jsx
+++ b/src/pages/MyPage/ActivityPage/ScrapExamReviewPage.jsx
@@ -6,7 +6,7 @@ import { usePagination, useScrollRestoration } from '@/hooks';
 
 import { BackAppBar, FetchLoading, PostBar } from '@/components';
 
-import { QUERY_KEY } from '@/constants';
+import { QUERY_KEY, STALE_TIME } from '@/constants';
 import frustratedWomanIllustration from '@/assets/images/frustratedWoman.svg';
 
 import styles from './ActivityPage.module.css';
@@ -15,6 +15,7 @@ export default function ScrapExamReviewPage() {
   const { data, ref, isLoading, isFetching, isError, error } = usePagination({
     queryKey: [QUERY_KEY.myScrappedExamReviews],
     queryFn: ({ pageParam }) => getMyScrapReviewList({ page: pageParam }),
+    staleTime: STALE_TIME.mypageActivity,
   });
 
   const { scrollRef, saveScrollPosition } = useScrollRestoration();

--- a/src/pages/MyPage/ActivityPage/ScrapPage.jsx
+++ b/src/pages/MyPage/ActivityPage/ScrapPage.jsx
@@ -8,7 +8,7 @@ import { BackAppBar, FetchLoading, PostBar } from '@/components';
 
 import { getBoardTitleToTextId } from '@/utils';
 
-import { QUERY_KEY } from '@/constants';
+import { QUERY_KEY, STALE_TIME } from '@/constants';
 import frustratedWomanIllustration from '@/assets/images/frustratedWoman.svg';
 
 import styles from './ActivityPage.module.css';
@@ -17,6 +17,7 @@ export default function ScrapPage() {
   const { data, ref, isLoading, isFetching, isError, error } = usePagination({
     queryKey: [QUERY_KEY.myScrappedPosts],
     queryFn: ({ pageParam }) => getMyScrapPostList({ page: pageParam }),
+    staleTime: STALE_TIME.mypageActivity,
   });
 
   const { scrollRef, saveScrollPosition } = useScrollRestoration();


### PR DESCRIPTION
## 🎯 관련 이슈

close #682

<br />

## 🚀 작업 내용

- 페이지네이션에 staleTime 적용
- 상세 페이지 접속 시 session storage에 PAGINATION_CACHE_SESSION 추가
- 세션 스토리지에 PAGINATION_CACHE_SESSION이 없으면 페이지네이션 쿼리 reset

<br />

## 📸 스크린샷

| ![GIFMaker_me](https://github.com/user-attachments/assets/eecf65cb-cb72-4a93-8765-eb3fcc97787f) |
| :---------------------: |
| 수정 전 |

| ![GIFMaker_me2](https://github.com/user-attachments/assets/cbc66392-b316-431d-86f0-6f4a6426c8b9) |
| :---------------------: |
| 수정 후 |



<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
