### PR TITLE
#701 [FIX] 다운로드 된 시험후기 파일명이 잘리는 문제 수정

### DIFF
--- a/src/components/ReviewDownload/ReviewDownload.jsx
+++ b/src/components/ReviewDownload/ReviewDownload.jsx
@@ -14,6 +14,10 @@ import { LOADING_MESSAGE, QUERY_KEY, TOAST } from '@/constants';
 
 import styles from './ReviewDownload.module.css';
 
+const appendTimestampToFileName = (fileName) => {
+  return fileName.replace('.pdf', `_${Date.now()}.pdf`);
+};
+
 export default function ReviewDownload({
   className,
   fileName,
@@ -34,10 +38,9 @@ export default function ReviewDownload({
       type: 'application/pdf',
     });
     const fileUrl = window.URL.createObjectURL(blob);
-    const downloadedFileName = `${fileName.split('.')[0]}_${Date.now()}.pdf`;
     const link = document.createElement('a');
     link.setAttribute('href', fileUrl);
-    link.setAttribute('download', downloadedFileName);
+    link.setAttribute('download', appendTimestampToFileName(fileName));
     link.click();
     window.URL.revokeObjectURL(fileUrl);
   };


### PR DESCRIPTION
## 🎯 관련 이슈

close #701

<br />

## 🚀 작업 내용

- 시험후기 파일명에 타임스탬프 추가하는 로직 변경
  - .(dot)을 기준으로 split 하는 대신 `.pdf`를 `_타임스탬프.pdf`로 replace
- 시험후기 파일명을 변경하는 로직을 `appendTimestampToFileName` 함수로 추출

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
