### PR TITLE
#703 [FIX] 댓글 작성 및 수정에 대한 다중 api 요청 방어

### DIFF
--- a/src/components/InputBar/InputBar.jsx
+++ b/src/components/InputBar/InputBar.jsx
@@ -5,7 +5,7 @@ import { Icon } from '@/components/Icon';
 import styles from './InputBar.module.css';
 
 const InputBar = () => {
-  const { editComment, createComment } = useComment();
+  const { editComment, createComment, loading, setLoading } = useComment();
   const { toast } = useToast();
 
   const {
@@ -21,6 +21,10 @@ const InputBar = () => {
 
   // 댓글 등록 or 수정
   const submitComment = () => {
+    if (loading) {
+      return;
+    }
+
     if (!content.trim()) {
       toast('댓글 내용을 입력하세요.');
       return;
@@ -33,6 +37,7 @@ const InputBar = () => {
 
     const mutation = isEdit ? editComment : createComment;
 
+    setLoading(true);
     mutation.mutate(
       {
         ...(isEdit ? { commentId } : { parentId: commentId }),

--- a/src/hooks/useComment.jsx
+++ b/src/hooks/useComment.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useQueryClient, useMutation } from '@tanstack/react-query';
 import { useLocation } from 'react-router-dom';
@@ -26,10 +27,11 @@ import {
 } from '@/constants';
 
 export default function useComment() {
+  const [loading, setLoading] = useState();
   const { postId } = useParams();
-  const { toast } = useToast();
   const { pathname } = useLocation();
   const queryClient = useQueryClient();
+  const { toast } = useToast();
   const { invalidUserInfoQuery } = useAuth();
   const currentBoard = getBoard(pathname.split('/')[2]);
 
@@ -53,6 +55,10 @@ export default function useComment() {
 
   const onError = ({ response }) => {
     toast(response.data.message);
+  };
+
+  const onSettled = () => {
+    setLoading(false);
   };
 
   const createComment = useMutation({
@@ -87,6 +93,7 @@ export default function useComment() {
         : toast(TOAST.COMMENT.create);
     },
     onError,
+    onSettled,
   });
 
   const deleteComment = useMutation({
@@ -113,6 +120,7 @@ export default function useComment() {
         : toast(TOAST.COMMENT.delete);
     },
     onError,
+    onSettled,
   });
 
   const editComment = useMutation({
@@ -134,11 +142,14 @@ export default function useComment() {
       toast(TOAST.COMMENT.edit);
     },
     onError,
+    onSettled,
   });
 
   return {
     createComment,
     deleteComment,
     editComment,
+    loading,
+    setLoading,
   };
 }


### PR DESCRIPTION
## 🎯 관련 이슈

close #703

<br />

## 🚀 작업 내용

- useComment에 api의 로딩 상태를 나타내는 `loading` state를 추가했습니다.
- `loading` state를 InputBar의 `submitComment`에 연결해서 `true`이면 api를 호출하지 않고 함수를 종료하도록 early return 했습니다.

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
 -->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
