### PR TITLE
#710 [FIX] 게시글 pagination data에서 postId가 중복인 게시글을 걸러냄

### DIFF
--- a/src/components/PostList/PostList.jsx
+++ b/src/components/PostList/PostList.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { FetchLoading } from '@/components/Loading';
 import { PostBar } from '@/components/PostBar';
 
-import { getBoardTitleToTextId } from '@/utils';
+import { deduplicatePaginatedData, getBoardTitleToTextId } from '@/utils';
 
 import styles from './PostList.module.css';
 
@@ -28,7 +28,7 @@ export default function PostList({ result, saveScrollPosition }) {
 
   const postList =
     data && !data.pages.includes(undefined)
-      ? data.pages.flatMap((page) => page.data)
+      ? deduplicatePaginatedData(data.pages.flatMap((page) => page.data))
       : [];
 
   return (

--- a/src/pages/BoardPage/BoardListPage/BoardPostList/BoardPostList.jsx
+++ b/src/pages/BoardPage/BoardListPage/BoardPostList/BoardPostList.jsx
@@ -6,7 +6,7 @@ import { usePagination } from '@/hooks';
 
 import { PostBar, PTR, FetchLoading } from '@/components';
 
-import { getBoard, timeAgo } from '@/utils';
+import { deduplicatePaginatedData, getBoard, timeAgo } from '@/utils';
 import { QUERY_KEY, STALE_TIME } from '@/constants';
 
 import styles from './BoardPostList.module.css';
@@ -38,7 +38,7 @@ export default function BoardPostList({ saveScrollPosition }) {
 
   const postList =
     data && !data.pages.includes(undefined)
-      ? data.pages.flatMap((page) => page.data)
+      ? deduplicatePaginatedData(data.pages.flatMap((page) => page.data))
       : [];
 
   return (

--- a/src/pages/ExamReviewPage/ExamReviewList/ExamReviewList.jsx
+++ b/src/pages/ExamReviewPage/ExamReviewList/ExamReviewList.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { FetchLoading, PostBar, PTR } from '@/components';
 
 import styles from '@/pages/ExamReviewPage/ExamReviewPage/ExamReviewPage.module.css';
+import { deduplicatePaginatedData } from '@/utils/pagination.js';
 
 export default function ExamReviewList({ result, saveScrollPosition }) {
   const { data, ref, isLoading, isFetching, isError, refetch } = result;
@@ -21,7 +22,7 @@ export default function ExamReviewList({ result, saveScrollPosition }) {
 
   const reviewList =
     data && !data.pages.includes(undefined)
-      ? data.pages.flatMap((page) => page.data)
+      ? deduplicatePaginatedData(data.pages.flatMap((page) => page.data))
       : [];
 
   return (

--- a/src/pages/ExamReviewPage/ExamReviewSearchList/ExamReviewSearchList.jsx
+++ b/src/pages/ExamReviewPage/ExamReviewSearchList/ExamReviewSearchList.jsx
@@ -5,6 +5,7 @@ import { PostBar } from '@/components/PostBar';
 
 import styles from '@/pages/ExamReviewPage/ExamReviewPage/ExamReviewPage.module.css';
 import { PTR } from '@/components/index.js';
+import { deduplicatePaginatedData } from '@/utils/pagination.js';
 
 export default function ExamReviewSearchList({ result, saveScrollPosition }) {
   const { data, ref, isLoading, isFetching, isError, error, refetch } = result;
@@ -27,7 +28,7 @@ export default function ExamReviewSearchList({ result, saveScrollPosition }) {
 
   const searchList =
     data && !data.pages.includes(undefined)
-      ? data.pages.flatMap((page) => page.data)
+      ? deduplicatePaginatedData(data.pages.flatMap((page) => page.data))
       : [];
 
   return (

--- a/src/pages/MyPage/ActivityPage/CommentPage.jsx
+++ b/src/pages/MyPage/ActivityPage/CommentPage.jsx
@@ -6,7 +6,7 @@ import { usePagination, useScrollRestoration } from '@/hooks';
 
 import { BackAppBar, FetchLoading, PostBar } from '@/components';
 
-import { getBoardTextId } from '@/utils';
+import { deduplicatePaginatedData, getBoardTextId } from '@/utils';
 import { QUERY_KEY, STALE_TIME } from '@/constants';
 
 import frustratedWomanIllustration from '@/assets/images/frustratedWoman.svg';
@@ -34,7 +34,7 @@ export default function CommentPage() {
 
   const myCommentList =
     data && !data.pages.includes(undefined)
-      ? data.pages.flatMap((page) => page.data)
+      ? deduplicatePaginatedData(data.pages.flatMap((page) => page.data))
       : [];
 
   return (

--- a/src/pages/MyPage/ActivityPage/DownloadExamReviewPage.jsx
+++ b/src/pages/MyPage/ActivityPage/DownloadExamReviewPage.jsx
@@ -10,6 +10,7 @@ import { QUERY_KEY, STALE_TIME } from '@/constants';
 import frustratedWomanIllustration from '@/assets/images/frustratedWoman.svg';
 
 import styles from './ActivityPage.module.css';
+import { deduplicatePaginatedData } from '@/utils/pagination.js';
 
 export default function DownloadExamReviewPage() {
   const { data, ref, isLoading, isFetching, isError, error } = usePagination({
@@ -32,7 +33,7 @@ export default function DownloadExamReviewPage() {
 
   const myReviewFileList =
     data && !data.pages.includes(undefined)
-      ? data.pages.flatMap((page) => page.data)
+      ? deduplicatePaginatedData(data.pages.flatMap((page) => page.data))
       : [];
 
   return (

--- a/src/pages/MyPage/ActivityPage/MyPostPage.jsx
+++ b/src/pages/MyPage/ActivityPage/MyPostPage.jsx
@@ -6,7 +6,7 @@ import { usePagination, useScrollRestoration } from '@/hooks';
 
 import { BackAppBar, FetchLoading, PostBar } from '@/components';
 
-import { getBoardTextId } from '@/utils';
+import { deduplicatePaginatedData, getBoardTextId } from '@/utils';
 
 import { QUERY_KEY, STALE_TIME } from '@/constants';
 import frustratedWomanIllustration from '@/assets/images/frustratedWoman.svg';
@@ -34,7 +34,7 @@ export default function MyPostPage() {
 
   const myPostList =
     data && !data.pages.includes(undefined)
-      ? data.pages.flatMap((page) => page.data)
+      ? deduplicatePaginatedData(data.pages.flatMap((page) => page.data))
       : [];
 
   return (

--- a/src/pages/MyPage/ActivityPage/ScrapExamReviewPage.jsx
+++ b/src/pages/MyPage/ActivityPage/ScrapExamReviewPage.jsx
@@ -10,6 +10,7 @@ import { QUERY_KEY, STALE_TIME } from '@/constants';
 import frustratedWomanIllustration from '@/assets/images/frustratedWoman.svg';
 
 import styles from './ActivityPage.module.css';
+import { deduplicatePaginatedData } from '@/utils/pagination.js';
 
 export default function ScrapExamReviewPage() {
   const { data, ref, isLoading, isFetching, isError, error } = usePagination({
@@ -32,7 +33,7 @@ export default function ScrapExamReviewPage() {
 
   const myScrapReviewList =
     data && !data.pages.includes(undefined)
-      ? data.pages.flatMap((page) => page.data)
+      ? deduplicatePaginatedData(data.pages.flatMap((page) => page.data))
       : [];
 
   return (

--- a/src/pages/MyPage/ActivityPage/ScrapPage.jsx
+++ b/src/pages/MyPage/ActivityPage/ScrapPage.jsx
@@ -6,7 +6,7 @@ import { usePagination, useScrollRestoration } from '@/hooks';
 
 import { BackAppBar, FetchLoading, PostBar } from '@/components';
 
-import { getBoardTitleToTextId } from '@/utils';
+import { deduplicatePaginatedData, getBoardTitleToTextId } from '@/utils';
 
 import { QUERY_KEY, STALE_TIME } from '@/constants';
 import frustratedWomanIllustration from '@/assets/images/frustratedWoman.svg';
@@ -34,7 +34,7 @@ export default function ScrapPage() {
 
   const myScrapPostList =
     data && !data.pages.includes(undefined)
-      ? data.pages.flatMap((page) => page.data)
+      ? deduplicatePaginatedData(data.pages.flatMap((page) => page.data))
       : [];
 
   return (

--- a/src/utils/pagination.js
+++ b/src/utils/pagination.js
@@ -1,5 +1,15 @@
 const PAGE_SIZE = 10;
 
+export const deduplicatePaginatedData = (array) => {
+  const seen = new Set();
+  const uniquePages = array.filter(({ postId }) => {
+    const duplicate = seen.has(postId);
+    seen.add(postId);
+    return !duplicate;
+  });
+  return uniquePages;
+};
+
 export const flatPaginationCache = (data) => {
   return data && !data.pages.includes(undefined)
     ? data.pages.flatMap((page) => page.data)


### PR DESCRIPTION
## 🎯 관련 이슈

close #710

<br />

## 🚀 작업 내용

- 페이지네이션 데이터에서 중복 데이터를 제거하는 `deduplicatePaginatedData` 함수 구현
- 게시글 페이지네이션 데이터 평탄화 로직에 `deduplicatePaginatedData` 적용

<br />

<!--
## 📸 스크린샷

| (스크린샷을 넣어주세요) |
| :---------------------: |

<br />
-->

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
-->
 
<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
