### PR TITLE
#711 [REFACTOR] 게시글 페이지네이션 데이터 평탄화 로직을 함수로 교체

### DIFF
--- a/src/components/PostList/PostList.jsx
+++ b/src/components/PostList/PostList.jsx
@@ -3,7 +3,11 @@ import { Link } from 'react-router-dom';
 import { FetchLoading } from '@/components/Loading';
 import { PostBar } from '@/components/PostBar';
 
-import { getBoardTitleToTextId } from '@/utils';
+import {
+  deduplicatePaginatedData,
+  flatPaginationCache,
+  getBoardTitleToTextId,
+} from '@/utils';
 
 import styles from './PostList.module.css';
 
@@ -26,10 +30,7 @@ export default function PostList({ result, saveScrollPosition }) {
     );
   }
 
-  const postList =
-    data && !data.pages.includes(undefined)
-      ? data.pages.flatMap((page) => page.data)
-      : [];
+  const postList = deduplicatePaginatedData(flatPaginationCache(data));
 
   return (
     <div className={styles.posts}>

--- a/src/pages/BoardPage/BoardListPage/BoardPostList/BoardPostList.jsx
+++ b/src/pages/BoardPage/BoardListPage/BoardPostList/BoardPostList.jsx
@@ -6,7 +6,12 @@ import { usePagination } from '@/hooks';
 
 import { PostBar, PTR, FetchLoading } from '@/components';
 
-import { getBoard, timeAgo } from '@/utils';
+import {
+  deduplicatePaginatedData,
+  flatPaginationCache,
+  getBoard,
+  timeAgo,
+} from '@/utils';
 import { QUERY_KEY, STALE_TIME } from '@/constants';
 
 import styles from './BoardPostList.module.css';
@@ -36,10 +41,7 @@ export default function BoardPostList({ saveScrollPosition }) {
     );
   }
 
-  const postList =
-    data && !data.pages.includes(undefined)
-      ? data.pages.flatMap((page) => page.data)
-      : [];
+  const postList = deduplicatePaginatedData(flatPaginationCache(data));
 
   return (
     <PTR onRefresh={() => refetch().then(() => console.log('Refreshed!'))}>

--- a/src/pages/ExamReviewPage/ExamReviewList/ExamReviewList.jsx
+++ b/src/pages/ExamReviewPage/ExamReviewList/ExamReviewList.jsx
@@ -2,6 +2,8 @@ import { Link } from 'react-router-dom';
 
 import { FetchLoading, PostBar, PTR } from '@/components';
 
+import { deduplicatePaginatedData, flatPaginationCache } from '@/utils';
+
 import styles from '@/pages/ExamReviewPage/ExamReviewPage/ExamReviewPage.module.css';
 
 export default function ExamReviewList({ result, saveScrollPosition }) {
@@ -19,10 +21,7 @@ export default function ExamReviewList({ result, saveScrollPosition }) {
     );
   }
 
-  const reviewList =
-    data && !data.pages.includes(undefined)
-      ? data.pages.flatMap((page) => page.data)
-      : [];
+  const reviewList = deduplicatePaginatedData(flatPaginationCache(data));
 
   return (
     <PTR onRefresh={() => refetch().then(() => console.log('Refreshed!'))}>

--- a/src/pages/ExamReviewPage/ExamReviewSearchList/ExamReviewSearchList.jsx
+++ b/src/pages/ExamReviewPage/ExamReviewSearchList/ExamReviewSearchList.jsx
@@ -2,9 +2,11 @@ import { Link } from 'react-router-dom';
 
 import { FetchLoading } from '@/components/Loading';
 import { PostBar } from '@/components/PostBar';
+import { PTR } from '@/components';
+
+import { deduplicatePaginatedData, flatPaginationCache } from '@/utils';
 
 import styles from '@/pages/ExamReviewPage/ExamReviewPage/ExamReviewPage.module.css';
-import { PTR } from '@/components/index.js';
 
 export default function ExamReviewSearchList({ result, saveScrollPosition }) {
   const { data, ref, isLoading, isFetching, isError, error, refetch } = result;
@@ -25,10 +27,7 @@ export default function ExamReviewSearchList({ result, saveScrollPosition }) {
     );
   }
 
-  const searchList =
-    data && !data.pages.includes(undefined)
-      ? data.pages.flatMap((page) => page.data)
-      : [];
+  const searchList = deduplicatePaginatedData(flatPaginationCache(data));
 
   return (
     <PTR onRefresh={() => refetch().then(() => console.log('Refreshed!'))}>

--- a/src/pages/MyPage/ActivityPage/CommentPage.jsx
+++ b/src/pages/MyPage/ActivityPage/CommentPage.jsx
@@ -6,9 +6,12 @@ import { usePagination, useScrollRestoration } from '@/hooks';
 
 import { BackAppBar, FetchLoading, PostBar } from '@/components';
 
-import { getBoardTextId } from '@/utils';
+import {
+  deduplicatePaginatedData,
+  flatPaginationCache,
+  getBoardTextId,
+} from '@/utils';
 import { QUERY_KEY, STALE_TIME } from '@/constants';
-
 import frustratedWomanIllustration from '@/assets/images/frustratedWoman.svg';
 
 import styles from './ActivityPage.module.css';
@@ -32,10 +35,7 @@ export default function CommentPage() {
     return <FetchLoading animation={false}>{message}</FetchLoading>;
   }
 
-  const myCommentList =
-    data && !data.pages.includes(undefined)
-      ? data.pages.flatMap((page) => page.data)
-      : [];
+  const myCommentList = deduplicatePaginatedData(flatPaginationCache(data));
 
   return (
     <main className={styles.activityPage} ref={scrollRef}>

--- a/src/pages/MyPage/ActivityPage/DownloadExamReviewPage.jsx
+++ b/src/pages/MyPage/ActivityPage/DownloadExamReviewPage.jsx
@@ -6,6 +6,7 @@ import { usePagination, useScrollRestoration } from '@/hooks';
 
 import { BackAppBar, FetchLoading, PostBar } from '@/components';
 
+import { deduplicatePaginatedData, flatPaginationCache } from '@/utils';
 import { QUERY_KEY, STALE_TIME } from '@/constants';
 import frustratedWomanIllustration from '@/assets/images/frustratedWoman.svg';
 
@@ -30,10 +31,7 @@ export default function DownloadExamReviewPage() {
     return <FetchLoading animation={false}>{message}</FetchLoading>;
   }
 
-  const myReviewFileList =
-    data && !data.pages.includes(undefined)
-      ? data.pages.flatMap((page) => page.data)
-      : [];
+  const myReviewFileList = deduplicatePaginatedData(flatPaginationCache(data));
 
   return (
     <main className={styles.activityPage} ref={scrollRef}>

--- a/src/pages/MyPage/ActivityPage/MyPostPage.jsx
+++ b/src/pages/MyPage/ActivityPage/MyPostPage.jsx
@@ -6,8 +6,11 @@ import { usePagination, useScrollRestoration } from '@/hooks';
 
 import { BackAppBar, FetchLoading, PostBar } from '@/components';
 
-import { getBoardTextId } from '@/utils';
-
+import {
+  deduplicatePaginatedData,
+  flatPaginationCache,
+  getBoardTextId,
+} from '@/utils';
 import { QUERY_KEY, STALE_TIME } from '@/constants';
 import frustratedWomanIllustration from '@/assets/images/frustratedWoman.svg';
 
@@ -32,10 +35,7 @@ export default function MyPostPage() {
     return <FetchLoading animation={false}>{message}</FetchLoading>;
   }
 
-  const myPostList =
-    data && !data.pages.includes(undefined)
-      ? data.pages.flatMap((page) => page.data)
-      : [];
+  const myPostList = deduplicatePaginatedData(flatPaginationCache(data));
 
   return (
     <main className={styles.activityPage} ref={scrollRef}>

--- a/src/pages/MyPage/ActivityPage/ScrapExamReviewPage.jsx
+++ b/src/pages/MyPage/ActivityPage/ScrapExamReviewPage.jsx
@@ -6,6 +6,7 @@ import { usePagination, useScrollRestoration } from '@/hooks';
 
 import { BackAppBar, FetchLoading, PostBar } from '@/components';
 
+import { deduplicatePaginatedData, flatPaginationCache } from '@/utils';
 import { QUERY_KEY, STALE_TIME } from '@/constants';
 import frustratedWomanIllustration from '@/assets/images/frustratedWoman.svg';
 
@@ -30,10 +31,7 @@ export default function ScrapExamReviewPage() {
     return <FetchLoading animation={false}>{message}</FetchLoading>;
   }
 
-  const myScrapReviewList =
-    data && !data.pages.includes(undefined)
-      ? data.pages.flatMap((page) => page.data)
-      : [];
+  const myScrapReviewList = deduplicatePaginatedData(flatPaginationCache(data));
 
   return (
     <main className={styles.activityPage} ref={scrollRef}>

--- a/src/pages/MyPage/ActivityPage/ScrapPage.jsx
+++ b/src/pages/MyPage/ActivityPage/ScrapPage.jsx
@@ -6,8 +6,11 @@ import { usePagination, useScrollRestoration } from '@/hooks';
 
 import { BackAppBar, FetchLoading, PostBar } from '@/components';
 
-import { getBoardTitleToTextId } from '@/utils';
-
+import {
+  deduplicatePaginatedData,
+  flatPaginationCache,
+  getBoardTitleToTextId,
+} from '@/utils';
 import { QUERY_KEY, STALE_TIME } from '@/constants';
 import frustratedWomanIllustration from '@/assets/images/frustratedWoman.svg';
 
@@ -32,10 +35,7 @@ export default function ScrapPage() {
     return <FetchLoading animation={false}>{message}</FetchLoading>;
   }
 
-  const myScrapPostList =
-    data && !data.pages.includes(undefined)
-      ? data.pages.flatMap((page) => page.data)
-      : [];
+  const myScrapPostList = deduplicatePaginatedData(flatPaginationCache(data));
 
   return (
     <main className={styles.activityPage} ref={scrollRef}>


### PR DESCRIPTION
## 🎯 관련 이슈

close #711

<br />

## 🚀 작업 내용

- 게시글 페이지네이션 데이터 평탄화 로직을 @/utils/pagination.js에 있던 `flatPaginationCache` 함수로 교체
  ```js
  // 리팩터링 전
  const postList =
    data && !data.pages.includes(undefined)
      ? deduplicatePaginatedData(data.pages.flatMap((page) => page.data))
      : [];

  // 리팩터링 후
  const postList = deduplicatePaginatedData(flatPaginationCache(data));
  ```

<br />

<!--
## 📸 스크린샷

| (스크린샷을 넣어주세요) |
| :---------------------: |

<br />
-->

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
-->
 
<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
