### PR TITLE
#754 [FIX] 홈화면 배너와 사이드바 겹침 이슈 해결을 위해 사이드바 z-index를 10으로 수정

### DIFF
--- a/src/components/Sidebar/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar/Sidebar.module.css
@@ -6,7 +6,7 @@
   top: 0;
   left: 50%;
   transform: translateX(-50%);
-  z-index: 1;
+  z-index: 10;
   background: rgba(228, 228, 228, 0.6);
   backdrop-filter: blur(0.625rem);
   /* Note: backdrop-filter has minimal browser support */


### PR DESCRIPTION
## 🎯 관련 이슈

close #754

<br />

## 🚀 작업 내용

- 홈화면 배너와 사이드바 겹침 이슈 해결을 위해 사이드바 z-index를 10으로 수정

<br />

## 📸 스크린샷
| <img width="250" src="https://github.com/user-attachments/assets/48654646-5bde-4aee-9432-b3bd09d0d7ff" />|<img width="250" src="https://github.com/user-attachments/assets/c6ce2150-d79c-426e-9140-a13a3b21d1e7" />|
| :---------------------: |:---------------------: |
| 이전 | 이후 |