### PR TITLE
#768 [CHORE] 팝업 공지에서 리뉴얼 만족도 조사 안내 삭제

### DIFF
--- a/src/components/PopUp/Component.jsx
+++ b/src/components/PopUp/Component.jsx
@@ -1,0 +1,9 @@
+import styles from './Component.module.css';
+
+export function Heading({ children }) {
+  return <h2 className={styles.title}>{children}</h2>;
+}
+
+export function Content({ children }) {
+  return <p className={styles.content}>{children}</p>;
+}

--- a/src/components/PopUp/Component.module.css
+++ b/src/components/PopUp/Component.module.css
@@ -1,0 +1,10 @@
+.title {
+  font-size: 1.1rem;
+  font-weight: 500;
+}
+
+.content {
+  margin: 0.5rem 0 2rem 0;
+  white-space: pre-wrap;
+  word-break: keep-all;
+}

--- a/src/components/PopUp/PopUp.jsx
+++ b/src/components/PopUp/PopUp.jsx
@@ -1,38 +1,30 @@
 import { useState } from 'react';
 
+import { Heading, Content } from '@/components/PopUp/Component.jsx';
+
 import styles from './PopUp.module.css';
 
-const CONTENT = (
-  <>
-    <p className={styles.hello}>
-      ❄️ 안녕하세요. 숙명인을 위한 커뮤니티, 스노로즈입니다. ❄️
-    </p>
+const content = (
+  <div className={styles.notice}>
+    <div>
+      <p className={styles.hello}>
+        ❄️ 안녕하세요. 숙명인을 위한 커뮤니티, 스노로즈입니다. ❄️
+      </p>
+      <Heading>1. 24-2 기말고사 포인트 미지급 기간</Heading>
+      <Content>12.02(월) 00:00 ~ 12.20(금) 23:59</Content>
 
-    <h2 className={styles.title}>1. 24-2 기말고사 포인트 미지급 기간</h2>
-    <p className={styles.content}>12.02(월) 00:00 ~ 12.20(금) 23:59</p>
-
-    <h2 className={styles.title}>2. 시험후기 게시판 운영 기간</h2>
-    <p className={styles.content}>12.21(토) 00:00 ~ 2025.01.20(월) 23:59</p>
-
-    <h2 className={styles.title}>3. 리뉴얼 사이트 만족도 조사 안내</h2>
-    <p className={styles.content}>
-      {`리뉴얼 오픈 1개월을 맞이하여 스노로즈 이용자를 대상으로 종합적인 만족도 조사를 진행하고자 합니다. 스노로즈의 발전을 위한 숙명인 여러분의 소중한 의견을 기다리고 있겠습니다.\n\n`}
-      <li>
-        설문지 링크:{' '}
-        <a className={styles.link} href='https://forms.gle/x6j8SRujTdKbXhk88'>
-          https://forms.gle/x6j8SRujTdKbXhk88
-        </a>
-      </li>
-      <li>설문 기간: 2024.11.12(화) ~ 2024.12.12(목)</li>
-    </p>
-
-    <hr />
-    <p className={styles.content}>
-      ※공식 문의 창구 (이메일(snorose1906@gmail.com), 카카오톡 1:1 문의) 이외의
-      문의는 받고 있지 않습니다. 공식 문의 창구 이외의 문의 글은 답변 없이
-      삭제될 수 있음을 알려드립니다.
-    </p>
-  </>
+      <Heading>2. 시험후기 게시판 운영 기간</Heading>
+      <Content>12.21(토) 00:00 ~ 2025.01.20(월) 23:59</Content>
+    </div>
+    <div>
+      <hr />
+      <Content>
+        ※공식 문의 창구 (이메일(snorose1906@gmail.com), 카카오톡 1:1 문의)
+        이외의 문의는 받고 있지 않습니다. 공식 문의 창구 이외의 문의 글은 답변
+        없이 삭제될 수 있음을 알려드립니다.
+      </Content>
+    </div>
+  </div>
 );
 
 export default function PopUp({ close }) {
@@ -44,7 +36,7 @@ export default function PopUp({ close }) {
     <section className={styles.container}>
       <div className={styles.popUp}>
         <div className={styles.top}>
-          <pre>{CONTENT}</pre>
+          <pre>{content}</pre>
         </div>
         <div className={styles.bottom}>
           <label className={styles.checkBox}>

--- a/src/components/PopUp/PopUp.module.css
+++ b/src/components/PopUp/PopUp.module.css
@@ -16,7 +16,7 @@
   width: 80%;
   max-width: 500px;
   max-height: 80%;
-  min-height: 30%;
+  min-height: 60%;
   display: flex;
   flex-direction: column;
 }
@@ -27,6 +27,7 @@
   padding: 1rem;
   width: 100%;
   height: 100%;
+  display: flex;
   background-color: var(--blue-1);
   border-radius: 5px 5px 0 0;
   overflow: auto;
@@ -52,6 +53,13 @@
   text-wrap: wrap;
   word-break: keep-all;
   font-size: 1rem;
+}
+
+.notice {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 
 /* bottom */
@@ -84,17 +92,6 @@
 .hello {
   margin-bottom: 1rem;
   display: block;
-}
-
-.title {
-  font-size: 1.1rem;
-  font-weight: 500;
-}
-
-.content {
-  margin: 0.5rem 0 2rem 0;
-  white-space: pre-wrap;
-  word-break: keep-all;
 }
 
 .content > li {


### PR DESCRIPTION
## 🎯 관련 이슈

close #768

<br />

## 🚀 작업 내용

- 팝업 공지에서 리뉴얼 만족도 조사 안내 삭제
- 팝업 컴포넌트에서 사용하는 제목, 내용 태그를 Heading, Content 컴포넌트로 분리

<br />

<!--
## 📸 스크린샷

| (스크린샷을 넣어주세요) |
| :---------------------: |

<br />
-->

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
-->
 
<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
