### PR TITLE
#779 [FIX] 시험후기 필터가 pull refresh 시 다른 UI 뒤로 숨는 문제 해결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,8 @@
         "styled-components": "^6.1.12",
         "swiper": "^11.1.15",
         "uuid": "^10.0.0",
-        "web-vitals": "^2.1.0"
+        "web-vitals": "^2.1.0",
+        "zustand": "^5.0.2"
       },
       "devDependencies": {
         "@craco/craco": "^7.1.0",
@@ -15981,6 +15982,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.2.tgz",
+      "integrity": "sha512-8qNdnJVJlHlrKXi50LDqqUNmUbuBjoKLrYQBnoChIbVph7vni+sY+YpvdjXG9YLd/Bxr6scMcR+rm5H3aSqPaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "styled-components": "^6.1.12",
     "swiper": "^11.1.15",
     "uuid": "^10.0.0",
-    "web-vitals": "^2.1.0"
+    "web-vitals": "^2.1.0",
+    "zustand": "^5.0.2"
   },
   "scripts": {
     "start": "craco start",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,7 @@
 import { Outlet, useLocation } from 'react-router-dom';
 
-import { Navbar } from '@/components/Navbar';
-
+import { Navbar, Sidebar } from '@/components';
 import { findRouteByPath } from '@/utils';
-
 import { routeList } from '@/route.js';
 
 import styles from './App.module.css';
@@ -17,6 +15,7 @@ function App() {
     <div className={styles.app}>
       <Outlet />
       {!hideNav && <Navbar />}
+      <Sidebar />
     </div>
   );
 }

--- a/src/components/DropDownBlue/DropDownBlue.module.css
+++ b/src/components/DropDownBlue/DropDownBlue.module.css
@@ -1,5 +1,6 @@
 .dropdown {
   position: relative;
+  z-index: 1;
 }
 
 .select {

--- a/src/components/MenuIcon/MenuIcon.jsx
+++ b/src/components/MenuIcon/MenuIcon.jsx
@@ -1,10 +1,8 @@
-import { useState } from 'react';
-
+import { useSidebarStore } from '@/stores';
 import { Icon } from '@/components/Icon';
-import { Sidebar } from '@/components/Sidebar';
 
 export default function MenuIcon() {
-  const [isOpen, setIsOpen] = useState(false);
+  const open = useSidebarStore((state) => state.open);
 
   return (
     <>
@@ -14,11 +12,10 @@ export default function MenuIcon() {
         height={16}
         onClick={(event) => {
           event.stopPropagation();
-          setIsOpen((prev) => !prev);
+          open();
         }}
         style={{ cursor: 'pointer' }}
       />
-      <Sidebar isOpen={isOpen} setIsOpen={setIsOpen} />
     </>
   );
 }

--- a/src/components/Sidebar/List/List.jsx
+++ b/src/components/Sidebar/List/List.jsx
@@ -2,13 +2,13 @@ import { Link } from 'react-router-dom';
 
 import styles from './List.module.css';
 
-export default function List({ className, items, onItemClick }) {
+export default function List({ className, items }) {
   if (!items) return null;
 
   return (
     <ul className={styles.list}>
       {items.map(({ to, name }) => (
-        <Link to={to} key={name} className={styles.item} onClick={onItemClick}>
+        <Link to={to} key={name} className={styles.item}>
           <li className={className}>{name}</li>
         </Link>
       ))}

--- a/src/components/Sidebar/List/List.module.css
+++ b/src/components/Sidebar/List/List.module.css
@@ -3,10 +3,24 @@
   margin-bottom: 0.75rem;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
 }
 
 .item {
-  font-size: 0.5rem;
   font-weight: 500;
+}
+
+.item li {
+  padding: 0.375rem 0;
+}
+
+.item > li:hover {
+  color: var(--blue-3);
+}
+
+.item:first-child > li {
+  padding-top: 0;
+}
+
+.item:last-child > li {
+  padding-bottom: 0;
 }

--- a/src/components/Sidebar/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar/Sidebar.jsx
@@ -18,6 +18,7 @@ export default function Sidebar() {
     status === 'authenticated'
       ? SIDEBAR_MENUS
       : SIDEBAR_MENUS.filter((menu) => NOT_LOGIN_MENUS.includes(menu.title));
+
   const handleEventPropagation = (event) => {
     event.stopPropagation();
   };

--- a/src/components/Sidebar/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar/Sidebar.jsx
@@ -1,16 +1,17 @@
 import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 
+import { useSidebarStore } from '@/stores';
 import { useAuth } from '@/hooks';
-
 import { List } from '@/components/Sidebar';
 import { Icon } from '@/components/Icon';
-
 import { NOT_LOGIN_MENUS, SIDEBAR_MENUS } from '@/constants';
 
 import styles from './Sidebar.module.css';
 
-export default function Sidebar({ isOpen, setIsOpen }) {
+export default function Sidebar() {
+  const isOpen = useSidebarStore((state) => state.isOpen);
+  const close = useSidebarStore((state) => state.close);
   const { status } = useAuth();
 
   const MENUS =
@@ -21,13 +22,7 @@ export default function Sidebar({ isOpen, setIsOpen }) {
     event.stopPropagation();
   };
 
-  const handleLinkClick = () => {
-    setIsOpen(false);
-  };
-
   useEffect(() => {
-    const close = () => setIsOpen(false);
-
     if (isOpen) {
       document.addEventListener('click', close);
     }
@@ -47,19 +42,14 @@ export default function Sidebar({ isOpen, setIsOpen }) {
         <Link className={styles.logo} to='/'>
           <Icon id='logo' width={129} height={23} margin={10} />
         </Link>
-        {MENUS &&
-          MENUS.map(({ to, title, items }) => (
-            <div key={title}>
-              <Link to={to}>
-                <h3 className={styles.title}>{title}</h3>
-              </Link>
-              <List
-                className={styles.item}
-                items={items}
-                onItemClick={handleLinkClick}
-              />
-            </div>
-          ))}
+        {MENUS.map(({ to, title, items }) => (
+          <div key={title} onClick={close}>
+            <Link to={to}>
+              <h3 className={styles.title}>{title}</h3>
+            </Link>
+            <List className={styles.item} items={items} />
+          </div>
+        ))}
       </aside>
     </div>
   );

--- a/src/components/Sidebar/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar/Sidebar.module.css
@@ -6,7 +6,7 @@
   top: 0;
   left: 50%;
   transform: translateX(-50%);
-  z-index: 10;
+  z-index: 1;
   background: rgba(228, 228, 228, 0.6);
   backdrop-filter: blur(0.625rem);
   /* Note: backdrop-filter has minimal browser support */

--- a/src/components/Sidebar/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar/Sidebar.module.css
@@ -34,6 +34,10 @@
   color: var(--gray-4);
 }
 
+.title:hover {
+  color: var(--blue-3);
+}
+
 .item {
   font-size: 0.875rem;
   color: var(--gray-4);

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -20,6 +20,7 @@ export * from './MainPageListItem';
 export * from './Margin';
 export * from './MenuIcon';
 export * from './Modal';
+export * from './Navbar';
 export * from './Portal';
 export * from './NoticeBar';
 export * from './PostBar';

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -1,0 +1,1 @@
+export * from './useSidebarStore.js';

--- a/src/stores/useSidebarStore.js
+++ b/src/stores/useSidebarStore.js
@@ -1,0 +1,7 @@
+import { create } from 'zustand';
+
+export const useSidebarStore = create((set) => ({
+  isOpen: 0,
+  open: () => set((state) => ({ isOpen: true })),
+  close: () => set((state) => ({ isOpen: false })),
+}));


### PR DESCRIPTION
## 🎯 관련 이슈

close #779

<br />

## 🚀 작업 내용

- 시험후기 필터의 z-index를 1로 설정했습니다.
- 사이드바보다 시험후기 필터의 쌓임 맥락이 더 위에 있어서 시험후기 필터가 사이드바 위로 올라오는 문제를 사이드바를 MenuIcon에서 App 컴포넌트로 끌어올려 해결했습니다.
- 이 과정에서 사이드바의 상태 관리에는 zustand를 사용했습니다.
- 사이드바 메뉴의 클릭 영역을 padding을 통해 키우고, 어떤 메뉴를 active 중인지 가시적으로 보여주기 위해 hover 상태에 color를 추가했습니다.

<br />

## 📸 스크린샷

| <img width=320 src=https://github.com/user-attachments/assets/a614786b-a25d-4e9a-89f1-6936aa336ce7 /> | <img width=320 src=https://github.com/user-attachments/assets/beb8b792-4d03-4b73-ad67-480bcfaffdf6 /> |
| :---------------------: | :---------------------: |
| 사이드바 `hover` | 시험후기 필터 |



<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
-->
 
<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
