### PR TITLE
#782 [FIX] 시험후기 api 요청 시 수정 데이터를 param이 아니라 request body로 전달하도록 수정

### DIFF
--- a/src/apis/examReview.js
+++ b/src/apis/examReview.js
@@ -19,9 +19,7 @@ export const getReviewDetail = async (postId) => {
 };
 
 export const editReviewDetail = async (postId, edit) => {
-  const response = await authAxios.patch(`/v1/reviews/${postId}`, null, {
-    params: edit,
-  });
+  const response = await authAxios.patch(`/v1/reviews/${postId}`, edit);
   return response;
 };
 


### PR DESCRIPTION
## 🎯 관련 이슈

close #782

<br />

## 🚀 작업 내용

- 시험후기 수정 api 호출 시 수정 데이터를 param이 아니라 request body로 전달하도록 수정

<br />

## 📸 스크린샷

| <img width="706" alt="image" src="https://github.com/user-attachments/assets/f73209bf-872f-485d-aeb2-151c80c3f250" /> |
| :---------------------: |

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
-->
 
<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
