### PR TITLE
#790 [FEAT] 댓글 하이퍼링크 활성화

### DIFF
--- a/src/components/Comment/Comment/Comment.jsx
+++ b/src/components/Comment/Comment/Comment.jsx
@@ -8,7 +8,7 @@ import { DeleteModal, OptionModal, ConfirmModal } from '@/components/Modal';
 import { Icon } from '@/components/Icon';
 import { NestedComment } from '@/components/Comment';
 
-import { timeAgo } from '@/utils';
+import { convertHyperlink, timeAgo } from '@/utils';
 
 import { LIKE_TYPE, MUTATION_KEY } from '@/constants';
 
@@ -132,7 +132,14 @@ const Comment = forwardRef((props, ref) => {
           className={`${styles.commentCenter} ${(isDeleted || !isVisible) && styles.hide}`}
         >
           {!isDeleted &&
-            (isVisible ? content : '(관리자에 의해 차단된 댓글입니다)')}
+            (isVisible ? (
+              <p
+                className={styles.content}
+                dangerouslySetInnerHTML={convertHyperlink(content)}
+              ></p>
+            ) : (
+              '(관리자에 의해 차단된 댓글입니다)'
+            ))}
           {isDeleted && '(삭제된 댓글입니다)'}
         </div>
         <div className={styles.commentBottom}>

--- a/src/components/Comment/Comment/Comment.module.css
+++ b/src/components/Comment/Comment/Comment.module.css
@@ -55,6 +55,14 @@
   color: var(--gray-3-1);
 }
 
+.content a {
+  color: var(--blue-3);
+}
+
+.content a:hover {
+  text-decoration: underline;
+}
+
 .commentBottom {
   min-height: 2.5rem;
   margin-right: 0.5rem;

--- a/src/components/Comment/NestedComment/NestedComment.jsx
+++ b/src/components/Comment/NestedComment/NestedComment.jsx
@@ -4,7 +4,7 @@ import { useLike } from '@/hooks';
 
 import { Icon } from '@/components/Icon';
 
-import { timeAgo } from '@/utils';
+import { convertHyperlink, timeAgo } from '@/utils';
 
 import { LIKE_TYPE } from '@/constants';
 
@@ -69,7 +69,14 @@ export default function NestedComment({
           className={`${styles.nestedPadding} ${(isDeleted || !isVisible) && styles.hide}`}
         >
           {!isDeleted &&
-            (isVisible ? content : '(관리자에 의해 차단된 댓글입니다)')}
+            (isVisible ? (
+              <p
+                className={styles.content}
+                dangerouslySetInnerHTML={convertHyperlink(content)}
+              ></p>
+            ) : (
+              '(관리자에 의해 차단된 댓글입니다)'
+            ))}
           {isDeleted && '(삭제된 댓글입니다)'}
         </div>
       </div>

--- a/src/pages/PostPage/PostPage/PostContent.jsx
+++ b/src/pages/PostPage/PostPage/PostContent.jsx
@@ -1,22 +1,12 @@
+import { convertHyperlink } from '@/utils';
+
 import styles from './PostContent.module.css';
 
-const urlRegex = /(https?:\/\/[^\s]+)/g;
-
 export default function PostContent({ content }) {
-  const replace = (text) => {
-    const convertedText = text.replace(
-      urlRegex,
-      (url) =>
-        `<a href=${url} target='_blank' rel='noopener noreferrer'>${url}</a>`
-    );
-
-    return { __html: convertedText };
-  };
-
   return (
     <p
       className={styles.content}
-      dangerouslySetInnerHTML={replace(content)}
+      dangerouslySetInnerHTML={convertHyperlink(content)}
     ></p>
   );
 }

--- a/src/utils/hyperlink.js
+++ b/src/utils/hyperlink.js
@@ -1,0 +1,11 @@
+const urlRegex = /(https?:\/\/[^\s]+)/g;
+
+export const convertHyperlink = (text) => {
+  const convertedText = text.replace(
+    urlRegex,
+    (url) =>
+      `<a href=${url} target='_blank' rel='noopener noreferrer'>${url}</a>`
+  );
+
+  return { __html: convertedText };
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -6,6 +6,7 @@ export * from './filterComment.js';
 export * from './findRoute.js';
 export * from './formattedNowTime.js';
 export * from './getBoardTextId.js';
+export * from './hyperlink.js';
 export * from './pagination.js';
 export * from './timeAgo.js';
 export * from './validate.js';


### PR DESCRIPTION
## 🎯 관련 이슈

close #790

<br />

## 🚀 작업 내용

- `PostContent` 컴포넌트에서 사용중인 URL에 a 태그를 감싸는 `replace` 함수를 `convertHyperlink`라는 유틸 함수로 분리했습니다.
- `Comment`와 `NestedComment` 컴포넌트의 댓글 내용에 `convertHyperlink` 함수를 사용하여 하이퍼링크를 활성화했습니다.

<br />

## 📸 스크린샷

| <img width="1470" alt="스크린샷 2025-01-03 오후 5 38 31" src="https://github.com/user-attachments/assets/3cbff932-de3c-4bad-9458-f996537bae04" /> |
| :---------------------: |

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
-->
 
<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
