### PR TITLE
#791 [FEAT] 팝업 3일간 보지 않기

### DIFF
--- a/src/components/PopUp/PopUp.jsx
+++ b/src/components/PopUp/PopUp.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { usePopUp } from '@/hooks/index.js';
 import { Heading, Content } from '@/components/PopUp/Component.jsx';
 
 import styles from './PopUp.module.css';
@@ -46,10 +47,19 @@ const content = (
   </div>
 );
 
-export default function PopUp({ close }) {
-  const [closeForToday, setCloseForToday] = useState(false);
-  const toggleCloseForToday = (event) => setCloseForToday(event.target.checked);
-  const closePopUp = () => close({ closeForToday });
+export default function PopUp() {
+  const [popupHideDuration, setPopupHideDuration] = useState();
+  const updatePopupHideDuration = (event) => {
+    const { value } = event.target;
+    setPopupHideDuration(Number(value));
+  };
+
+  const { isPopUpOpend, closePopUp } = usePopUp();
+  const close = () => closePopUp({ popupHideDuration });
+
+  if (!isPopUpOpend) {
+    return null;
+  }
 
   return (
     <section className={styles.container}>
@@ -58,15 +68,17 @@ export default function PopUp({ close }) {
           <pre>{content}</pre>
         </div>
         <div className={styles.bottom}>
-          <label className={styles.checkBox}>
-            <input
-              type='checkbox'
-              checked={closeForToday}
-              onChange={toggleCloseForToday}
-            />
-            <span>오늘 하루 보지 않기</span>
-          </label>
-          <button onClick={closePopUp}>닫기</button>
+          <div className={styles.radios} onChange={updatePopupHideDuration}>
+            <label className={styles.radio}>
+              <input type='radio' value={0} name='hideDuration' />
+              <span>오늘 하루 보지 않기</span>
+            </label>
+            <label className={styles.radio}>
+              <input type='radio' value={2} name='hideDuration' />
+              <span>3일간 보지 않기</span>
+            </label>
+          </div>
+          <button onClick={close}>닫기</button>
         </div>
       </div>
     </section>

--- a/src/components/PopUp/PopUp.module.css
+++ b/src/components/PopUp/PopUp.module.css
@@ -73,7 +73,13 @@
   color: var(--white);
 }
 
-.checkBox {
+.radios {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.radio {
   display: flex;
   align-items: center;
   gap: 0.5rem;

--- a/src/hooks/usePopUp.jsx
+++ b/src/hooks/usePopUp.jsx
@@ -1,15 +1,17 @@
 import { useEffect, useState } from 'react';
 
+import { addDays } from 'date-fns';
+
 import { isDayOver } from '@/utils';
 
 const POP_UP_STATE_LOCAL_STORAGE_KEY = 'popUpState';
-const POP_UO_DATE_LOCAL_STORAGE_KEY = 'popUpDate';
-const POP_UP_OPEN = 'open';
-const POP_UP_CLOSE = 'close';
+const POP_UP_DATE_LOCAL_STORAGE_KEY = 'popUpDate';
+const POP_UP_DISPLAY = 'display';
+const POP_UP_HIDDEN = 'hidden';
 
 const initializePopupStorage = () => {
-  localStorage.setItem(POP_UP_STATE_LOCAL_STORAGE_KEY, POP_UP_OPEN);
-  localStorage.setItem(POP_UO_DATE_LOCAL_STORAGE_KEY, new Date());
+  localStorage.setItem(POP_UP_STATE_LOCAL_STORAGE_KEY, POP_UP_DISPLAY);
+  localStorage.removeItem(POP_UP_DATE_LOCAL_STORAGE_KEY);
 };
 
 export default function usePopUp() {
@@ -17,7 +19,7 @@ export default function usePopUp() {
 
   useEffect(() => {
     const popUpState = localStorage.getItem(POP_UP_STATE_LOCAL_STORAGE_KEY);
-    const popUpDate = localStorage.getItem(POP_UO_DATE_LOCAL_STORAGE_KEY);
+    const popUpDate = localStorage.getItem(POP_UP_DATE_LOCAL_STORAGE_KEY);
 
     const initialStatus = popUpState === null || popUpDate === null;
 
@@ -27,17 +29,20 @@ export default function usePopUp() {
       return;
     }
 
-    if (popUpState === POP_UP_OPEN) {
+    if (popUpState === POP_UP_DISPLAY) {
       setIsPopUpOpend(true);
     }
   }, []);
 
-  const closePopUp = ({ closeForToday = false }) => {
+  const closePopUp = ({ popupHideDuration }) => {
     setIsPopUpOpend(false);
-    localStorage.setItem(
-      POP_UP_STATE_LOCAL_STORAGE_KEY,
-      closeForToday ? POP_UP_CLOSE : POP_UP_OPEN
-    );
+
+    if (popupHideDuration !== undefined) {
+      const popupHideUntilDate = addDays(new Date(), popupHideDuration);
+
+      localStorage.setItem(POP_UP_STATE_LOCAL_STORAGE_KEY, POP_UP_HIDDEN);
+      localStorage.setItem(POP_UP_DATE_LOCAL_STORAGE_KEY, popupHideUntilDate);
+    }
   };
 
   return { isPopUpOpend, closePopUp };

--- a/src/pages/MainPage/MainPage.jsx
+++ b/src/pages/MainPage/MainPage.jsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getBannerImage, getHomeNotice, getBest3 } from '@/apis';
 
-import { useAuth, usePopUp } from '@/hooks';
+import { useAuth } from '@/hooks';
 
 import {
   BoardCard,
@@ -27,7 +27,6 @@ const DEFAULT_BESOOKTS = Array.from({ length: 3 }, (_, i) => ({ postId: i }));
 
 export default function MainPage() {
   const { status, userInfo } = useAuth();
-  const { isPopUpOpend, closePopUp } = usePopUp();
   const isLogin = status === 'authenticated';
 
   const {
@@ -153,7 +152,7 @@ export default function MainPage() {
         </Margin>
       )}
       <Footer />
-      {isPopUpOpend && <PopUp close={closePopUp} />}
+      <PopUp />
     </main>
   );
 }

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -26,3 +26,9 @@ export const isDayOver = (date) => {
 
   return target < today;
 };
+
+export const addDays = (date, days) => {
+  const newDate = new Date(date);
+  newDate.setDate(newDate.getDate() + days);
+  return newDate;
+};


### PR DESCRIPTION
## 🎯 관련 이슈

close #791 

<br />

## 🚀 작업 내용

- `usePopUp` 훅 의존성을 MainPage에서 `PopUp` 컴포넌트로 옮겼습니다.
- 매개변수로 전달한 `date`와 숫자를 더해서 새로운 날짜를 반환하는 `addDays` 유틸 함수를 추가했습니다.
- 팝업 보지 않기 버튼을 checkbox에서 라디오 버튼으로 변경했습니다.
- 팝업 3일간 보지 않기 버튼을 추가했습니다.

<br />

## 📸 스크린샷

| <img width="1470" alt="image" src="https://github.com/user-attachments/assets/99615aec-a7a9-4107-87ae-2e447fb7835c" /> |
| :---------------------: |

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
-->
 
<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
