### PR TITLE
#786 [FEAT] 게시판 날짜 표기 방식 변경

### DIFF
--- a/src/components/PostBar/PostBar.jsx
+++ b/src/components/PostBar/PostBar.jsx
@@ -1,16 +1,29 @@
+import { useEffect, useState } from 'react';
 import { Icon } from '@/components/Icon';
-import { timeAgo } from '@/utils';
-
+import { postBarDateFormat } from '@/utils';
 import styles from './PostBar.module.css';
 
 export default function PostBar({ data, hasComment = true, hasLike = true }) {
+  const [formattedTime, setFormattedTime] = useState(
+    postBarDateFormat(data.createdAt)
+  );
+
+  // postBarDateFormat을 1분마다 업데이트
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setFormattedTime(postBarDateFormat(data.createdAt));
+    }, 60000);
+
+    return () => clearInterval(intervalId);
+  }, [data.createdAt]);
+
   return (
     <div className={styles.post}>
       <div className={styles.post_top}>
         <Icon id='cloud' width={18} height={11} />
         <p className={styles.name}>{data.userDisplay}</p>
         <p className={styles.dot}>·</p>
-        <p>{timeAgo(data.createdAt)}</p>
+        <p>{formattedTime}</p>
         {data.isEdited && <p className={styles.edited}>&nbsp;(수정됨)</p>}
         {data.isConfirmed && (
           <Icon

--- a/src/components/PostBar/PostBar.jsx
+++ b/src/components/PostBar/PostBar.jsx
@@ -1,29 +1,15 @@
-import { useEffect, useState } from 'react';
 import { Icon } from '@/components/Icon';
 import { postBarDateFormat } from '@/utils';
 import styles from './PostBar.module.css';
 
 export default function PostBar({ data, hasComment = true, hasLike = true }) {
-  const [formattedTime, setFormattedTime] = useState(
-    postBarDateFormat(data.createdAt)
-  );
-
-  // postBarDateFormat을 1분마다 업데이트
-  useEffect(() => {
-    const intervalId = setInterval(() => {
-      setFormattedTime(postBarDateFormat(data.createdAt));
-    }, 60000);
-
-    return () => clearInterval(intervalId);
-  }, [data.createdAt]);
-
   return (
     <div className={styles.post}>
       <div className={styles.post_top}>
         <Icon id='cloud' width={18} height={11} />
         <p className={styles.name}>{data.userDisplay}</p>
         <p className={styles.dot}>·</p>
-        <p>{formattedTime}</p>
+        <p>{postBarDateFormat(data.createdAt)}</p>
         {data.isEdited && <p className={styles.edited}>&nbsp;(수정됨)</p>}
         {data.isConfirmed && (
           <Icon

--- a/src/pages/PostPage/PostPage/PostPage.jsx
+++ b/src/pages/PostPage/PostPage/PostPage.jsx
@@ -18,7 +18,7 @@ import {
   InputBar,
 } from '@/components';
 
-import { getBoard, timeAgo } from '@/utils';
+import { fullDateTimeFormat, getBoard } from '@/utils';
 import { LIKE_TYPE, MUTATION_KEY, QUERY_KEY, TOAST } from '@/constants';
 
 import styles from './PostPage.module.css';
@@ -182,7 +182,7 @@ export default function PostPage() {
             <p>{data.userDisplay || 'Unknown'}</p>
             <p className={styles.dot}>·</p>
             <p>
-              {timeAgo(data.createdAt)}
+              {fullDateTimeFormat(data.createdAt)}
               {data.isEdited && ' (수정됨)'}
             </p>
           </div>

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,9 +1,56 @@
+import { timeAgo } from './timeAgo';
+import { HOUR_SECONDS } from '@/constants';
+
 export const dateFormat = (date) => {
   const dateObj = new Date(date);
   const year = dateObj.getFullYear();
   const month = `${dateObj.getMonth() + 1}`.padStart(2, '0');
   const day = `${dateObj.getDate()}`.padStart(2, '0');
   return `${year}.${month}.${day}`;
+};
+
+// 게시글 상세 조회: 절대 시각 (연도/월/일 시간)
+export const fullDateTimeFormat = (date) => {
+  const dateObj = new Date(date);
+  const year = dateObj.getFullYear();
+  const month = `${dateObj.getMonth() + 1}`.padStart(2, '0');
+  const day = `${dateObj.getDate()}`.padStart(2, '0');
+  const hours = `${dateObj.getHours()}`.padStart(2, '0');
+  const minutes = `${dateObj.getMinutes()}`.padStart(2, '0');
+  return `${year}/${month}/${day} ${hours}:${minutes}`;
+};
+
+// 게시글 목록 날짜 시간 표현
+export const postBarDateFormat = (date) => {
+  const targetDate = new Date(date);
+  const now = new Date();
+  const diffInSeconds = Math.floor((now - targetDate) / 1000);
+
+  const formatTime = (date) =>
+    `${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}`;
+
+  const formatDateTime = (date, includeYear = false) => {
+    const year = includeYear
+      ? `${date.getFullYear().toString().slice(-2)}/`
+      : '';
+    const month = (date.getMonth() + 1).toString().padStart(2, '0');
+    const day = date.getDate().toString().padStart(2, '0');
+    return `${year}${month}/${day} ${formatTime(date)}`;
+  };
+
+  // 1시간 이내: '00분 전' 또는 '00초 전'
+  if (diffInSeconds < HOUR_SECONDS) {
+    return timeAgo(date);
+  }
+
+  // 오늘 날짜인 경우: '16:24'
+  if (isToday(targetDate)) {
+    return formatTime(targetDate);
+  }
+
+  // 1년 이내: '12/28 16:24', 1년 이후: '23/12/28 16:24'
+  const isCurrentYear = targetDate.getFullYear() === now.getFullYear();
+  return formatDateTime(targetDate, !isCurrentYear);
 };
 
 export const isToday = (date) => {

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,4 +1,5 @@
 import { timeAgo } from './timeAgo';
+import { HOUR_SECONDS } from '@/constants';
 
 export const dateFormat = (date) => {
   const dateObj = new Date(date);
@@ -8,7 +9,6 @@ export const dateFormat = (date) => {
   return `${year}.${month}.${day}`;
 };
 
-// 게시글 상세 조회: 절대 시각 (연도/월/일 시간)
 export const fullDateTimeFormat = (date) => {
   const dateObj = new Date(date);
   const year = dateObj.getFullYear();
@@ -19,20 +19,26 @@ export const fullDateTimeFormat = (date) => {
   return `${year}/${month}/${day} ${hours}:${minutes}`;
 };
 
-// 게시글 목록 날짜 시간 표현
 export const postBarDateFormat = (date) => {
-  const targetDate = new Date(date);
   const now = new Date();
+  const targetDate = new Date(date);
   const diffInSeconds = Math.floor((now - targetDate) / 1000);
 
+  const year = targetDate.getFullYear();
+  const month = `${targetDate.getMonth() + 1}`.padStart(2, '0');
+  const day = `${targetDate.getDate()}`.padStart(2, '0');
+  const hours = `${targetDate.getHours()}`.padStart(2, '0');
+  const minutes = `${targetDate.getMinutes()}`.padStart(2, '0');
+
   if (isToday(targetDate)) {
-    if (diffInSeconds < 60 * 59) {
-      return timeAgo(date); // 1시간 이내: '00분 전' 또는 '00초 전'
-    }
-    return fullDateTimeFormat(date).split(' ')[1]; // 오늘 날짜인 경우: '16:24'
+    return diffInSeconds < HOUR_SECONDS - 60
+      ? timeAgo(date)
+      : `${hours}:${minutes}`;
   }
-  const isCurrentYear = targetDate.getFullYear() === now.getFullYear(); // 1년 이내: '12/28 16:24'
-  return fullDateTimeFormat(date).slice(isCurrentYear ? 5 : 2); // 1년 이후: '23/12/28 16:24'
+
+  return isSameYear(targetDate, now)
+    ? `${month}/${day} ${hours}:${minutes}`
+    : `${year}/${month}/${day} ${hours}:${minutes}`;
 };
 
 export const isToday = (date) => {
@@ -54,6 +60,13 @@ export const isDayOver = (date) => {
   today.setHours(0, 0, 0, 0);
 
   return target < today;
+};
+
+export const isSameYear = (date1, date2) => {
+  const target1 = new Date(date1);
+  const target2 = new Date(date2);
+
+  return target1.getFullYear() === target2.getFullYear();
 };
 
 export const addDays = (date, days) => {

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,5 +1,4 @@
 import { timeAgo } from './timeAgo';
-import { HOUR_SECONDS } from '@/constants';
 
 export const dateFormat = (date) => {
   const dateObj = new Date(date);
@@ -26,31 +25,14 @@ export const postBarDateFormat = (date) => {
   const now = new Date();
   const diffInSeconds = Math.floor((now - targetDate) / 1000);
 
-  const formatTime = (date) =>
-    `${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}`;
-
-  const formatDateTime = (date, includeYear = false) => {
-    const year = includeYear
-      ? `${date.getFullYear().toString().slice(-2)}/`
-      : '';
-    const month = (date.getMonth() + 1).toString().padStart(2, '0');
-    const day = date.getDate().toString().padStart(2, '0');
-    return `${year}${month}/${day} ${formatTime(date)}`;
-  };
-
-  // 1시간 이내: '00분 전' 또는 '00초 전'
-  if (diffInSeconds < HOUR_SECONDS) {
-    return timeAgo(date);
-  }
-
-  // 오늘 날짜인 경우: '16:24'
   if (isToday(targetDate)) {
-    return formatTime(targetDate);
+    if (diffInSeconds < 60 * 59) {
+      return timeAgo(date); // 1시간 이내: '00분 전' 또는 '00초 전'
+    }
+    return fullDateTimeFormat(date).split(' ')[1]; // 오늘 날짜인 경우: '16:24'
   }
-
-  // 1년 이내: '12/28 16:24', 1년 이후: '23/12/28 16:24'
-  const isCurrentYear = targetDate.getFullYear() === now.getFullYear();
-  return formatDateTime(targetDate, !isCurrentYear);
+  const isCurrentYear = targetDate.getFullYear() === now.getFullYear(); // 1년 이내: '12/28 16:24'
+  return fullDateTimeFormat(date).slice(isCurrentYear ? 5 : 2); // 1년 이후: '23/12/28 16:24'
 };
 
 export const isToday = (date) => {


### PR DESCRIPTION
## 🎯 관련 이슈

close #786

<br />

## 🚀 작업 내용
- 게시판 날짜 표기 방식 변경
  - 1시간 이내: '00분 전' 또는 '00초 전'
  - 오늘 날짜인 경우: '16:24'
  - 같은 연도 다른 날짜: '12/28 16:24'
  - 다른 연도: '23/12/28 16:24'

<br />

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/ca18b653-22a1-4e3a-a11c-09f94afce66e)

<br />
