### PR TITLE
#813 [FIX] 게시글 작성 페이지에서 공지글 토글 버튼이 노출되지 않는 문제 해결

### DIFF
--- a/src/assets/icon.svg
+++ b/src/assets/icon.svg
@@ -276,7 +276,14 @@
   <symbol id="blue-triangle" viewBox="0 0 20 20" fill="none" stroke="none">
     <path d="M10 16L3.93782 5.5L16.0622 5.5L10 16Z" fill="#00368E"/>
   </symbol>
-
+  <symbol id="toggle-on" viewBox="0 0 21 21" fill="none" stroke="none">
+    <rect width="21" height="21" rx="10.5" fill="#D9D9D9"/>
+    <circle cx="10.5365" cy="10.4994" r="6.53655" fill="#00368E"/>
+  </symbol>
+  <symbol id="toggle-off" viewBox="0 0 22 21" fill="none" stroke="none">
+    <rect width="21.0731" height="21" rx="10.5" fill="#D9D9D9"/>
+    <circle cx="10.5365" cy="10.4994" r="6.53655" fill="white"/>
+  </symbol>
 
   <!-- fill icon -->
   <symbol id="like" viewBox="0 0 12 10" fill="current" stroke="none">

--- a/src/pages/PostPage/PostWritePage/PostWritePage.module.css
+++ b/src/pages/PostPage/PostWritePage/PostWritePage.module.css
@@ -55,10 +55,12 @@
   align-items: center;
   gap: 0.125rem;
   color: var(--black);
+  cursor: pointer;
 }
 
 .profileBoxRightInvisible {
   display: none;
+  cursor: pointer;
 }
 
 .dot {


### PR DESCRIPTION
## 🎯 관련 이슈

close #813

<br />

## 🚀 작업 내용

- 누락된 `toggle-on`, `toggle-off` 아이콘 추가

<br />

## 📸 스크린샷

| <img width="599" alt="image" src="https://github.com/user-attachments/assets/34d6e6f0-fe92-4d21-a9ce-971b4c01ee54" /> |
| :---------------------: |

<br />

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
-->
 
<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
