### PR TITLE
#826 [FIX] BackAppBar 히스토리가 비정상적으로 동작하는 문제 수정

### DIFF
--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -18,7 +18,7 @@ export default function Search({ className, placeholder, onKeyDown }) {
     }
 
     searchParams.set('keyword', keyword);
-    setSearchParams(searchParams);
+    setSearchParams(searchParams, { replace: true });
   };
 
   useEffect(() => {

--- a/src/pages/NoticeListPage/NoticeListPage.jsx
+++ b/src/pages/NoticeListPage/NoticeListPage.jsx
@@ -66,11 +66,6 @@ export default function NoticeListPage() {
             : `${currentBoard.title} 공지`
         }
         hasNotice={true}
-        backNavTo={
-          currentBoardTextId === 'notice'
-            ? '/home'
-            : `/board/${currentBoardTextId}`
-        }
       />
       <div className={styles.content}>
         {Array.isArray(noticeList) && noticeList.length > 0 ? (

--- a/src/pages/PostsPage/PostsPage.jsx
+++ b/src/pages/PostsPage/PostsPage.jsx
@@ -29,7 +29,6 @@ export default function PostsPage() {
         title={currentBoard.title}
         hasMenu
         {...(!isBesookt && { hasSearch: true })}
-        backNavTo={'/board'}
       />
       {!isBesookt && (
         <div className={styles.top}>

--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -20,10 +20,7 @@ export default function SearchPage() {
 
   return (
     <div className={styles.container} ref={scrollRef}>
-      <BackAppBar
-        hasSearchInput={true}
-        backNavTo={current !== 'all' ? `/board/${current}` : `/board`}
-      >
+      <BackAppBar hasSearchInput={true}>
         <Search placeholder={PLACEHOLDER[current]} />
       </BackAppBar>
 


### PR DESCRIPTION
## 🎯 관련 이슈

close #826

<br />

## 🚀 작업 내용

- `SearchPage`의 `BackAppBar`에서 현재 라우트에 따라 `backNavTo`를 분기 처리하지 않고, 항상 **이전 페이지**로 이동할 수 있도록 `Search` 컴포넌트의 `setSearchParams`에 replace 옵션을 `true`로 설정했습니다.
- 게시판 페이지와 공지 페이지는 뒤로가기 버튼 클릭 시 항상 이전 히스토리로 이동해야 하므로 `backNavTo` prop을 제거했습니다.

<br />

<!--
## 📸 스크린샷

| (스크린샷을 넣어주세요) |
| :---------------------: |

<br />
-->

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
-->
 
<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
