### PR TITLE
#799 [FIX] 마이페이지 - 내 활동 탭 내 항목별 빈 상태 일러스트 적용

### DIFF
--- a/src/constants/mypage.js
+++ b/src/constants/mypage.js
@@ -15,6 +15,7 @@ export const ACTIVITIES = [
     queryKey: QUERY_KEY.myPosts,
     queryFn: getMyPosts,
     errorMessage: '아직 작성한 글이 없어요',
+    emptyStateIllustrationId: 'star-no-post',
   },
   {
     path: ROUTE.mypageComment,
@@ -22,6 +23,7 @@ export const ACTIVITIES = [
     queryKey: QUERY_KEY.myCommentedPosts,
     queryFn: getMyComments,
     errorMessage: '아직 작성한 댓글이 없어요',
+    emptyStateIllustrationId: 'star-no-comment',
   },
   {
     path: ROUTE.mypageDownloadExamReview,
@@ -30,6 +32,7 @@ export const ACTIVITIES = [
     queryFn: getDonwloadedExamReviews,
     hasLike: false,
     errorMessage: '아직 다운받은 후기가 없어요',
+    emptyStateIllustrationId: 'star-no-review',
   },
   {
     path: ROUTE.mypageExamReviewScrap,
@@ -38,6 +41,7 @@ export const ACTIVITIES = [
     queryFn: getScrapedExamReviews,
     hasLike: false,
     errorMessage: '아직 스크랩한 시험 후기가 없어요',
+    emptyStateIllustrationId: 'star-no-review',
   },
   {
     path: ROUTE.mypageScrap,
@@ -45,5 +49,6 @@ export const ACTIVITIES = [
     queryKey: QUERY_KEY.myScrapedPosts,
     queryFn: getScrapedPosts,
     errorMessage: '아직 스크랩 한 글이 없어요',
+    emptyStateIllustrationId: 'star-no-post',
   },
 ];

--- a/src/pages/MyPage/pages/ActivityPage/components/Posts/Posts.jsx
+++ b/src/pages/MyPage/pages/ActivityPage/components/Posts/Posts.jsx
@@ -7,7 +7,7 @@ import {
   flatPaginationCache,
   getBoardTextId,
 } from '@/utils';
-import { STALE_TIME } from '@/constants';
+import { ACTIVITIES, STALE_TIME } from '@/constants';
 
 import styles from './Posts.module.css';
 
@@ -26,13 +26,20 @@ export default function Posts({
 
   const list = deduplicatePaginatedData(flatPaginationCache(data));
 
+  const activity = ACTIVITIES.find(
+    (activity) => activity.queryKey === queryKey
+  );
+  const emptyStateIllustrationId =
+    activity?.emptyStateIllustrationId || 'star-no-post';
+
   if (list.length === 0) {
     return (
       <div className={styles.noContentWrapper}>
         <p className={styles.noContentMessage}>{errorMessage}</p>
         <div className={styles.imageWrapper}>
-          <Icon id='star-no-post' width={220} height={182} />
+          <Icon id={emptyStateIllustrationId} width={220} height={182} />
         </div>
+        ;
       </div>
     );
   }

--- a/src/pages/MyPage/pages/ActivityPage/components/Posts/Posts.jsx
+++ b/src/pages/MyPage/pages/ActivityPage/components/Posts/Posts.jsx
@@ -1,14 +1,13 @@
 import { Link } from 'react-router-dom';
 
 import { useSuspensePagination } from '@/hooks';
-import { FetchLoading, PostBar } from '@/components';
+import { FetchLoading, Icon, PostBar } from '@/components';
 import {
   deduplicatePaginatedData,
   flatPaginationCache,
   getBoardTextId,
 } from '@/utils';
 import { STALE_TIME } from '@/constants';
-import frustratedWomanIllustration from '@/assets/images/frustratedWoman.svg';
 
 import styles from './Posts.module.css';
 
@@ -32,11 +31,7 @@ export default function Posts({
       <div className={styles.noContentWrapper}>
         <p className={styles.noContentMessage}>{errorMessage}</p>
         <div className={styles.imageWrapper}>
-          <img
-            src={frustratedWomanIllustration}
-            alt='frustrated woman'
-            className={styles.image}
-          />
+          <Icon id='star-no-post' width={220} height={182} />
         </div>
       </div>
     );

--- a/src/pages/MyPage/pages/ActivityPage/components/Posts/Posts.module.css
+++ b/src/pages/MyPage/pages/ActivityPage/components/Posts/Posts.module.css
@@ -2,7 +2,6 @@
   display: flex;
   position: relative;
   flex-direction: column;
-  justify-content: space-between;
   flex-grow: 1;
 }
 
@@ -14,17 +13,13 @@
 
 .imageWrapper {
   display: flex;
-  justify-content: flex-end;
+  justify-content: center;
+  align-items: center;
   position: relative;
   width: auto;
   height: auto;
   min-height: 36.25rem;
-}
-
-.image {
-  position: absolute;
-  right: 0;
-  bottom: 0;
+  flex: 1;
 }
 
 .posts {


### PR DESCRIPTION
## 🎯 관련 이슈

close #799

<br />

## 🚀 작업 내용

- 마이페이지 - 내 활동 탭 내 항목별 빈 상태 일러스트 적용

<br />

## 📸 스크린샷

| 내가 쓴 글 | 댓글 단 글 모아보기 | 다운 받은 시험 후기 모아보기 |
| :---------------------: |:---------------------: |:---------------------: |
| <img width='250' src='https://github.com/user-attachments/assets/e03bac1a-2b06-4afd-90f4-64c3b79b8dc0' /> |  <img width='250' src='https://github.com/user-attachments/assets/1678ad0d-cd90-47ec-8002-1c3d01efd325' /> |  <img width='250' src='https://github.com/user-attachments/assets/a9df8250-36af-4f1a-89b1-314ae6073d86' /> |


| 시험 후기 스크랩 | 스크랩 모아보기 |
| :---------------------: |:---------------------: |
| <img width='250' src='https://github.com/user-attachments/assets/21746c6a-499f-4a51-bfa1-786bc4770c39' /> |  <img width='250' src='https://github.com/user-attachments/assets/8b9c8fbb-d033-4a37-b0dd-48c5f725705b' /> | 

<br />

