### PR TITLE
#799 [FIX] 현재 게시판에 따른 일러스트 이미지 적용

### DIFF
--- a/src/feature/my/component/MyPostList/MyPostList.jsx
+++ b/src/feature/my/component/MyPostList/MyPostList.jsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom';
 
 import { useSuspensePagination } from '@/shared/hook';
-import { FetchLoading } from '@/shared/component';
+import { FetchLoading, Icon } from '@/shared/component';
 import {
   getBoardTextId,
   deduplicatePaginatedData,
@@ -10,9 +10,9 @@ import {
 import { STALE_TIME } from '@/shared/constant';
 
 import { PostBar } from '@/feature/board/component';
-import frustratedWomanIllustration from '@/assets/images/frustratedWoman.svg';
 
 import styles from './MyPostList.module.css';
+import { ACTIVITIES } from '../../constant/activity';
 
 export default function MyPostList({
   queryKey,
@@ -29,16 +29,18 @@ export default function MyPostList({
 
   const list = deduplicatePaginatedData(flatPaginationCache(data));
 
+  const activity = ACTIVITIES.find(
+    (activity) => activity.queryKey === queryKey
+  );
+  const emptyStateIllustrationId =
+    activity?.emptyStateIllustrationId || 'star-no-post';
+
   if (list.length === 0) {
     return (
       <div className={styles.noContentWrapper}>
         <p className={styles.noContentMessage}>{errorMessage}</p>
         <div className={styles.imageWrapper}>
-          <img
-            src={frustratedWomanIllustration}
-            alt='frustrated woman'
-            className={styles.image}
-          />
+          <Icon id={emptyStateIllustrationId} width={220} height={182} />
         </div>
       </div>
     );

--- a/src/feature/my/component/MyPostList/MyPostList.module.css
+++ b/src/feature/my/component/MyPostList/MyPostList.module.css
@@ -14,17 +14,13 @@
 
 .imageWrapper {
   display: flex;
-  justify-content: flex-end;
+  justify-content: center;
+  align-items: center;
   position: relative;
   width: auto;
   height: auto;
   min-height: 36.25rem;
-}
-
-.image {
-  position: absolute;
-  right: 0;
-  bottom: 0;
+  flex: 1;
 }
 
 .posts {

--- a/src/feature/my/constant/activity.js
+++ b/src/feature/my/constant/activity.js
@@ -15,6 +15,7 @@ export const ACTIVITIES = [
     queryKey: QUERY_KEY.myPosts,
     queryFn: getMyPosts,
     errorMessage: '아직 작성한 글이 없어요',
+    emptyStateIllustrationId: 'star-no-post',
   },
   {
     path: ROUTE.mypageComment,
@@ -22,6 +23,7 @@ export const ACTIVITIES = [
     queryKey: QUERY_KEY.myCommentedPosts,
     queryFn: getMyComments,
     errorMessage: '아직 작성한 댓글이 없어요',
+    emptyStateIllustrationId: 'star-no-comment',
   },
   {
     path: ROUTE.mypageDownloadExamReview,
@@ -30,6 +32,7 @@ export const ACTIVITIES = [
     queryFn: getDonwloadedExamReviews,
     hasLike: false,
     errorMessage: '아직 다운받은 후기가 없어요',
+    emptyStateIllustrationId: 'star-no-review',
   },
   {
     path: ROUTE.mypageExamReviewScrap,
@@ -38,6 +41,7 @@ export const ACTIVITIES = [
     queryFn: getScrapedExamReviews,
     hasLike: false,
     errorMessage: '아직 스크랩한 시험 후기가 없어요',
+    emptyStateIllustrationId: 'star-no-review',
   },
   {
     path: ROUTE.mypageScrap,
@@ -45,5 +49,6 @@ export const ACTIVITIES = [
     queryKey: QUERY_KEY.myScrapedPosts,
     queryFn: getScrapedPosts,
     errorMessage: '아직 스크랩 한 글이 없어요',
+    emptyStateIllustrationId: 'star-no-post',
   },
 ];


### PR DESCRIPTION
## 🎯 관련 이슈

close #799

<br />

## 🚀 작업 내용

- 마이페이지 - 내 활동 탭 내 항목별 빈 상태 일러스트 적용

<br />

## 📸 스크린샷

| 내가 쓴 글 | 댓글 단 글 모아보기 | 다운 받은 시험 후기 모아보기 |
| :---------------------: |:---------------------: |:---------------------: |
| <img width='250' src='https://github.com/user-attachments/assets/e03bac1a-2b06-4afd-90f4-64c3b79b8dc0' /> |  <img width='250' src='https://github.com/user-attachments/assets/1678ad0d-cd90-47ec-8002-1c3d01efd325' /> |  <img width='250' src='https://github.com/user-attachments/assets/a9df8250-36af-4f1a-89b1-314ae6073d86' /> |


| 시험 후기 스크랩 | 스크랩 모아보기 |
| :---------------------: |:---------------------: |
| <img width='250' src='https://github.com/user-attachments/assets/21746c6a-499f-4a51-bfa1-786bc4770c39' /> |  <img width='250' src='https://github.com/user-attachments/assets/8b9c8fbb-d033-4a37-b0dd-48c5f725705b' /> | 

<br />

