### PR TITLE
# 848 [FIX] 팝업 공지 좌우 스크롤 이슈 및 게시글 폰트가 비정상적으로 작은 문제 수정

### DIFF
--- a/src/feature/home/component/PopUp/PopUp.module.css
+++ b/src/feature/home/component/PopUp/PopUp.module.css
@@ -134,11 +134,5 @@
 .content {
   margin: 0.5rem 0 2rem 0;
   white-space: pre-wrap;
-  word-break: keep-all;
-}
-
-.content img {
-  max-width: 100%;
-  height: auto;
-  display: block;
+  word-break: break-all;
 }

--- a/src/feature/home/component/PopUp/PopUp.module.css
+++ b/src/feature/home/component/PopUp/PopUp.module.css
@@ -136,3 +136,9 @@
   white-space: pre-wrap;
   word-break: keep-all;
 }
+
+.content img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}

--- a/src/page/board/PostPage/PostPage.jsx
+++ b/src/page/board/PostPage/PostPage.jsx
@@ -210,7 +210,7 @@ export default function PostPage() {
           </p>
         </div>
         <p
-          className={styles.content}
+          className={styles.contentText}
           dangerouslySetInnerHTML={convertHyperlink(data.content)}
         ></p>
         <div className={styles.post_bottom}>


### PR DESCRIPTION
## 🎯 관련 이슈

close #848 

<br />

## 🚀 작업 내용

- 게시글 내용이 작게 보이는 오류 수정
- 팝업창의 이미지로 인한 좌우 스크롤 문제 수정

<br />

## 📸 스크린샷

| ![스크린샷_게시글](https://github.com/user-attachments/assets/406ebfce-0d2b-4128-afa3-ac547f967ffc) |
| ![스크린샷_팝업](https://github.com/user-attachments/assets/f298907c-2a88-4cf7-9ff4-2c5f8f93fb35) |
| :---------------------: |

<br />


<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
-->
 
## 💡 어떻게 해결했나요?

- PostPage에서 css 이름 지정 오타 수정 (content -> contentText)
- Popup 이미지 스크롤 생기는 문제를 img태그 max-width 지정

<br />

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
