### PR TITLE
#860 [REFACTOR] rem 단위 16px -> 10px 변경

### DIFF
--- a/.storybook/index.css
+++ b/.storybook/index.css
@@ -1,6 +1,8 @@
 :root {
-  --default-width: 600px;
-  --default-margin: 1.25rem;
+  font-size: 62.5%;
+
+  --default-width: 60rem;
+  --default-margin: 2rem;
 
   /* Color */
 

--- a/src/feature/account/component/AuthInput/AuthInput.module.css
+++ b/src/feature/account/component/AuthInput/AuthInput.module.css
@@ -1,19 +1,19 @@
 .label {
-  margin-bottom: 0.375rem;
+  margin-bottom: 6px;
   display: inline-block;
   font-weight: 500;
-  font-size: 0.875rem;
+  font-size: 14px;
   color: var(--gray-4);
 }
 
 .input {
   width: 100%;
-  padding: 0.75rem 0 0.6875rem 0.8125rem;
+  padding: 12px 0 11px 13px;
   background: var(--gray-1-1);
-  border-radius: 0.3125rem;
+  border-radius: 5px;
   border: none;
   outline: none;
-  font-size: 0.75rem;
+  font-size: 12px;
 }
 
 .input::placeholder {
@@ -26,7 +26,7 @@
 }
 
 .errorMessage {
-  margin-top: 0.1875rem;
-  font-size: 0.6875rem;
+  margin-top: 3px;
+  font-size: 11px;
   color: var(--pink-3);
 }

--- a/src/feature/account/component/AuthInput/AuthInput.module.css
+++ b/src/feature/account/component/AuthInput/AuthInput.module.css
@@ -1,19 +1,19 @@
 .label {
-  margin-bottom: 6px;
+  margin-bottom: 0.6rem;
   display: inline-block;
   font-weight: 500;
-  font-size: 14px;
+  font-size: 1.4rem;
   color: var(--gray-4);
 }
 
 .input {
   width: 100%;
-  padding: 12px 0 11px 13px;
+  padding: 1.2rem 0 1.1rem 1.3rem;
   background: var(--gray-1-1);
-  border-radius: 5px;
+  border-radius: 0.5rem;
   border: none;
   outline: none;
-  font-size: 12px;
+  font-size: 1.2rem;
 }
 
 .input::placeholder {
@@ -26,7 +26,7 @@
 }
 
 .errorMessage {
-  margin-top: 3px;
-  font-size: 11px;
+  margin-top: 0.3rem;
+  font-size: 1.1rem;
   color: var(--pink-3);
 }

--- a/src/feature/account/component/AuthInput/AuthInput.module.css
+++ b/src/feature/account/component/AuthInput/AuthInput.module.css
@@ -26,7 +26,7 @@
 }
 
 .errorMessage {
-  margin-top: 3px;
+  margin-top: 0.1875rem;
   font-size: 0.6875rem;
   color: var(--pink-3);
 }

--- a/src/feature/account/component/signUpStep/AccountInfoStep/AccountInfoStep.module.css
+++ b/src/feature/account/component/signUpStep/AccountInfoStep/AccountInfoStep.module.css
@@ -10,15 +10,15 @@
 }
 
 .text {
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: 700;
-  margin-bottom: 30px;
+  margin-bottom: 3rem;
 }
 
 .inputFrame {
-  margin-bottom: 24px;
+  margin-bottom: 2.4rem;
 }
 
 .submit {
-  margin-bottom: 34px;
+  margin-bottom: 3.4rem;
 }

--- a/src/feature/account/component/signUpStep/AccountInfoStep/AccountInfoStep.module.css
+++ b/src/feature/account/component/signUpStep/AccountInfoStep/AccountInfoStep.module.css
@@ -10,15 +10,15 @@
 }
 
 .text {
-  font-size: 1.25rem;
+  font-size: 20px;
   font-weight: 700;
-  margin-bottom: 1.875rem;
+  margin-bottom: 30px;
 }
 
 .inputFrame {
-  margin-bottom: 1.5rem;
+  margin-bottom: 24px;
 }
 
 .submit {
-  margin-bottom: 2.125rem;
+  margin-bottom: 34px;
 }

--- a/src/feature/account/component/signUpStep/AuthorizationStep/AuthorizationStep.module.css
+++ b/src/feature/account/component/signUpStep/AuthorizationStep/AuthorizationStep.module.css
@@ -6,14 +6,14 @@
 }
 
 .title {
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: 700;
 }
 
 .text {
-  margin-bottom: 27.008px;
+  margin-bottom: 2.7;
 }
 
 .submit {
-  margin-bottom: 34px;
+  margin-bottom: 3.4rem;
 }

--- a/src/feature/account/component/signUpStep/AuthorizationStep/AuthorizationStep.module.css
+++ b/src/feature/account/component/signUpStep/AuthorizationStep/AuthorizationStep.module.css
@@ -6,14 +6,14 @@
 }
 
 .title {
-  font-size: 1.25rem;
+  font-size: 20px;
   font-weight: 700;
 }
 
 .text {
-  margin-bottom: 1.688rem;
+  margin-bottom: 27.008px;
 }
 
 .submit {
-  margin-bottom: 2.125rem;
+  margin-bottom: 34px;
 }

--- a/src/feature/account/component/signUpStep/AuthorizationStep/AuthorizationStep.module.css
+++ b/src/feature/account/component/signUpStep/AuthorizationStep/AuthorizationStep.module.css
@@ -11,7 +11,7 @@
 }
 
 .text {
-  margin-bottom: 2.7;
+  margin-bottom: 2.7rem;
 }
 
 .submit {

--- a/src/feature/account/component/signUpStep/UserInfoStep/UserInfoStep.module.css
+++ b/src/feature/account/component/signUpStep/UserInfoStep/UserInfoStep.module.css
@@ -10,20 +10,20 @@
 }
 
 .text {
-  font-size: 1.25rem;
+  font-size: 20px;
   font-weight: 700;
-  margin-bottom: 1.875rem;
+  margin-bottom: 30px;
 }
 
 .inputFrame {
-  margin-bottom: 1.5rem;
+  margin-bottom: 24px;
 }
 
 .majorTitle {
-  font-size: 0.875rem;
-  margin-bottom: 0.375rem;
+  font-size: 14px;
+  margin-bottom: 6px;
 }
 
 .submit {
-  margin-bottom: 2.125rem;
+  margin-bottom: 34px;
 }

--- a/src/feature/account/component/signUpStep/UserInfoStep/UserInfoStep.module.css
+++ b/src/feature/account/component/signUpStep/UserInfoStep/UserInfoStep.module.css
@@ -10,20 +10,20 @@
 }
 
 .text {
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: 700;
-  margin-bottom: 30px;
+  margin-bottom: 3rem;
 }
 
 .inputFrame {
-  margin-bottom: 24px;
+  margin-bottom: 2.4rem;
 }
 
 .majorTitle {
-  font-size: 14px;
-  margin-bottom: 6px;
+  font-size: 1.4rem;
+  margin-bottom: 0.6rem;
 }
 
 .submit {
-  margin-bottom: 34px;
+  margin-bottom: 3.4rem;
 }

--- a/src/feature/account/component/snoroseVerifyStep/CompleteStep/CompleteStep.module.css
+++ b/src/feature/account/component/snoroseVerifyStep/CompleteStep/CompleteStep.module.css
@@ -7,7 +7,7 @@
 }
 
 .illust {
-  margin-bottom: 6.25rem;
+  margin-bottom: 100px;
   flex: 1;
   display: flex;
   justify-content: center;

--- a/src/feature/account/component/snoroseVerifyStep/CompleteStep/CompleteStep.module.css
+++ b/src/feature/account/component/snoroseVerifyStep/CompleteStep/CompleteStep.module.css
@@ -7,7 +7,7 @@
 }
 
 .illust {
-  margin-bottom: 100px;
+  margin-bottom: 10rem;
   flex: 1;
   display: flex;
   justify-content: center;

--- a/src/feature/account/component/snoroseVerifyStep/TermsStep/TermsStep.module.css
+++ b/src/feature/account/component/snoroseVerifyStep/TermsStep/TermsStep.module.css
@@ -8,19 +8,19 @@
 
 .terms {
   flex: 1;
-  margin-bottom: 14px;
-  padding: 14px;
+  margin-bottom: 1.4rem;
+  padding: 1.4rem;
   background: var(--gray-1-1);
-  border-radius: 5px;
+  border-radius: 0.5rem;
 }
 
 .text {
   word-break: keep-all;
   text-wrap: wrap;
-  font-size: 14px;
+  font-size: 1.4rem;
   color: var(--gray-4);
 }
 
 .item {
-  margin-left: 10px;
+  margin-left: 1rem;
 }

--- a/src/feature/account/component/snoroseVerifyStep/TermsStep/TermsStep.module.css
+++ b/src/feature/account/component/snoroseVerifyStep/TermsStep/TermsStep.module.css
@@ -8,19 +8,19 @@
 
 .terms {
   flex: 1;
-  margin-bottom: 0.875rem;
-  padding: 0.875rem;
+  margin-bottom: 14px;
+  padding: 14px;
   background: var(--gray-1-1);
-  border-radius: 0.3125rem;
+  border-radius: 5px;
 }
 
 .text {
   word-break: keep-all;
   text-wrap: wrap;
-  font-size: 0.875rem;
+  font-size: 14px;
   color: var(--gray-4);
 }
 
 .item {
-  margin-left: 0.625rem;
+  margin-left: 10px;
 }

--- a/src/feature/account/component/snoroseVerifyStep/VerifyStep/VerifyStep.module.css
+++ b/src/feature/account/component/snoroseVerifyStep/VerifyStep/VerifyStep.module.css
@@ -9,5 +9,5 @@
 .verify {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 2.4rem;
 }

--- a/src/feature/account/component/snoroseVerifyStep/VerifyStep/VerifyStep.module.css
+++ b/src/feature/account/component/snoroseVerifyStep/VerifyStep/VerifyStep.module.css
@@ -9,5 +9,5 @@
 .verify {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 24px;
 }

--- a/src/feature/attendance/component/Calendar/Calendar.module.css
+++ b/src/feature/attendance/component/Calendar/Calendar.module.css
@@ -1,21 +1,21 @@
 /* Tile */
 
 .tile {
-  width: 32px;
-  height: 52px;
+  width: 3.2rem;
+  height: 5.2rem;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
+  gap: 0.4rem;
 }
 
 .day {
-  width: 32px;
-  height: 32px;
+  width: 3.2rem;
+  height: 3.2rem;
   display: flex;
   justify-content: center;
   align-items: center;
-  font-size: 16px;
+  font-size: 1.6rem;
   text-align: center;
   color: var(--white);
 }
@@ -28,7 +28,7 @@
 }
 
 .difference {
-  font-size: 12px;
+  font-size: 1.2rem;
   text-align: center;
   color: var(--pink-2);
 }

--- a/src/feature/attendance/component/Calendar/Calendar.module.css
+++ b/src/feature/attendance/component/Calendar/Calendar.module.css
@@ -1,21 +1,21 @@
 /* Tile */
 
 .tile {
-  width: 2rem;
-  height: 3.25rem;
+  width: 32px;
+  height: 52px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.25rem;
+  gap: 4px;
 }
 
 .day {
-  width: 2rem;
-  height: 2rem;
+  width: 32px;
+  height: 32px;
   display: flex;
   justify-content: center;
   align-items: center;
-  font-size: 1rem;
+  font-size: 16px;
   text-align: center;
   color: var(--white);
 }
@@ -28,7 +28,7 @@
 }
 
 .difference {
-  font-size: 0.75rem;
+  font-size: 12px;
   text-align: center;
   color: var(--pink-2);
 }

--- a/src/feature/attendance/component/Calendar/Calendar.style.jsx
+++ b/src/feature/attendance/component/Calendar/Calendar.style.jsx
@@ -7,12 +7,12 @@ import 'react-calendar/dist/Calendar.css';
 export const StyledCalendar = styled(Calendar)`
   .react-calendar__navigation {
     margin: 0;
-    border-radius: 5px 5px 0 0;
+    border-radius: 0.5rem 0.5rem 0 0;
   }
 
   .react-calendar__navigation__label {
     font-weight: 700;
-    font-size: 18px;
+    font-size: 1.8rem;
     color: #ffffff;
     cursor: auto;
   }
@@ -41,19 +41,19 @@ export const StyledCalendar = styled(Calendar)`
   }
 
   .react-calendar__viewContainer {
-    padding-top: 16px;
-    border-radius: 0 0 5px 5px;
+    padding-top: 1.6rem;
+    border-radius: 0 0 0.5rem 0.5rem;
   }
 
   // weekday
   .react-calendar__month-view__weekdays__weekday {
-    font-size: 16px;
+    font-size: 1.6rem;
     color: #ffffff;
   }
 
   // tile
   .react-calendar__tile {
-    padding: 2px 0;
+    padding: 0.2rem 0;
     display: flex;
     justify-content: center;
     cursor: normal;

--- a/src/feature/attendance/component/Calendar/Calendar.style.jsx
+++ b/src/feature/attendance/component/Calendar/Calendar.style.jsx
@@ -7,12 +7,12 @@ import 'react-calendar/dist/Calendar.css';
 export const StyledCalendar = styled(Calendar)`
   .react-calendar__navigation {
     margin: 0;
-    border-radius: 0.3125rem 0.3125rem 0 0;
+    border-radius: 5px 5px 0 0;
   }
 
   .react-calendar__navigation__label {
     font-weight: 700;
-    font-size: 1.125rem;
+    font-size: 18px;
     color: #ffffff;
     cursor: auto;
   }
@@ -41,19 +41,19 @@ export const StyledCalendar = styled(Calendar)`
   }
 
   .react-calendar__viewContainer {
-    padding-top: 1rem;
-    border-radius: 0 0 0.3125rem 0.3125rem;
+    padding-top: 16px;
+    border-radius: 0 0 5px 5px;
   }
 
   // weekday
   .react-calendar__month-view__weekdays__weekday {
-    font-size: 1rem;
+    font-size: 16px;
     color: #ffffff;
   }
 
   // tile
   .react-calendar__tile {
-    padding: 0.125rem 0;
+    padding: 2px 0;
     display: flex;
     justify-content: center;
     cursor: normal;

--- a/src/feature/board/component/BoardBar/BoardBar.module.css
+++ b/src/feature/board/component/BoardBar/BoardBar.module.css
@@ -1,7 +1,7 @@
 .container {
   width: 100%;
-  height: 5.25rem;
-  border-radius: 0.375rem;
+  height: 84px;
+  border-radius: 6px;
   background: var(--gray-1-1);
   background-repeat: no-repeat;
   background-position: right bottom;
@@ -12,15 +12,15 @@
   flex-direction: column;
   position: absolute;
   white-space: pre-wrap;
-  margin: 0.875rem;
+  margin: 14px;
 }
 
 .title {
-  font-size: 0.875rem;
+  font-size: 14px;
   font-weight: 500;
 }
 
 .description {
-  font-size: 0.6875rem;
+  font-size: 11px;
   color: var(--gray-3-1);
 }

--- a/src/feature/board/component/BoardBar/BoardBar.module.css
+++ b/src/feature/board/component/BoardBar/BoardBar.module.css
@@ -1,7 +1,7 @@
 .container {
   width: 100%;
-  height: 84px;
-  border-radius: 6px;
+  height: 8.4rem;
+  border-radius: 0.6rem;
   background: var(--gray-1-1);
   background-repeat: no-repeat;
   background-position: right bottom;
@@ -12,15 +12,15 @@
   flex-direction: column;
   position: absolute;
   white-space: pre-wrap;
-  margin: 14px;
+  margin: 1.4rem;
 }
 
 .title {
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 500;
 }
 
 .description {
-  font-size: 11px;
+  font-size: 1.1rem;
   color: var(--gray-3-1);
 }

--- a/src/feature/board/component/DropDownMenu/DropDownMenu.module.css
+++ b/src/feature/board/component/DropDownMenu/DropDownMenu.module.css
@@ -1,12 +1,12 @@
 .container {
-  margin-top: 0.5rem;
-  width: calc(100% - 2.5rem);
-  padding: 0.8125rem 0.375rem;
+  margin-top: 8px;
+  width: calc(100% - 40px);
+  padding: 13px 6px;
   background-color: var(--gray-2);
-  border-radius: 0.3125rem;
+  border-radius: 5px;
   display: flex;
   flex-direction: column;
-  row-gap: 0.3125rem;
+  row-gap: 5px;
   position: absolute;
   z-index: 1;
 }
@@ -17,28 +17,28 @@
 
 .listBar {
   width: 100%;
-  height: 2.5rem;
+  height: 40px;
   display: flex;
   align-items: center;
-  border-radius: 0.3125rem;
+  border-radius: 5px;
   background-color: transparent;
-  padding: 0 0.8125rem;
+  padding: 0 13px;
   color: var(--gray-3-1);
   cursor: pointer;
 }
 
 .SelectedlistBar {
   width: 100%;
-  height: 2.5rem;
+  height: 40px;
   display: flex;
   align-items: center;
-  border-radius: 0.3125rem;
+  border-radius: 5px;
   background-color: var(--blue-1);
-  padding: 0 0.8125rem;
+  padding: 0 13px;
   color: var(--blue-4);
   cursor: pointer;
 }
 
 .item {
-  font-size: 0.8125rem;
+  font-size: 13px;
 }

--- a/src/feature/board/component/DropDownMenu/DropDownMenu.module.css
+++ b/src/feature/board/component/DropDownMenu/DropDownMenu.module.css
@@ -1,12 +1,12 @@
 .container {
-  margin-top: 8px;
-  width: calc(100% - 40px);
-  padding: 13px 6px;
+  margin-top: 0.8rem;
+  width: calc(100% - 4rem);
+  padding: 1.3rem 0.6rem;
   background-color: var(--gray-2);
-  border-radius: 5px;
+  border-radius: 0.5rem;
   display: flex;
   flex-direction: column;
-  row-gap: 5px;
+  row-gap: 0.5rem;
   position: absolute;
   z-index: 1;
 }
@@ -17,28 +17,28 @@
 
 .listBar {
   width: 100%;
-  height: 40px;
+  height: 4rem;
   display: flex;
   align-items: center;
-  border-radius: 5px;
+  border-radius: 0.5rem;
   background-color: transparent;
-  padding: 0 13px;
+  padding: 0 1.3rem;
   color: var(--gray-3-1);
   cursor: pointer;
 }
 
 .SelectedlistBar {
   width: 100%;
-  height: 40px;
+  height: 4rem;
   display: flex;
   align-items: center;
-  border-radius: 5px;
+  border-radius: 0.5rem;
   background-color: var(--blue-1);
-  padding: 0 13px;
+  padding: 0 1.3rem;
   color: var(--blue-4);
   cursor: pointer;
 }
 
 .item {
-  font-size: 13px;
+  font-size: 1.3rem;
 }

--- a/src/feature/board/component/NoticeBar/NoticeBar.module.css
+++ b/src/feature/board/component/NoticeBar/NoticeBar.module.css
@@ -1,8 +1,8 @@
 .post {
-  padding: 0.8125rem 0.9375rem;
+  padding: 13px 15px;
   width: 100%;
   background-color: var(--gray-1);
-  border-radius: 0.3125rem;
+  border-radius: 5px;
   cursor: pointer;
 }
 
@@ -12,7 +12,7 @@
 }
 
 .title {
-  font-size: 0.875rem;
+  font-size: 14px;
   font-weight: 500;
   display: -webkit-box;
   -webkit-line-clamp: 1;
@@ -22,11 +22,11 @@
 }
 
 .post_center {
-  padding-top: 0.375rem;
+  padding-top: 6px;
 }
 
 .text {
-  font-size: 0.8125rem;
+  font-size: 13px;
   color: #484848;
   display: -webkit-box;
   -webkit-line-clamp: 3;
@@ -39,17 +39,17 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding-top: 0.5rem;
+  padding-top: 8px;
   color: var(--gray-3-1);
-  font-size: 0.6875rem;
+  font-size: 11px;
 }
 
 .postBottomRight {
-  gap: 0.375rem;
+  gap: 6px;
   display: flex;
   align-items: center;
 
   p {
-    margin-bottom: 0.1875rem;
+    margin-bottom: 3px;
   }
 }

--- a/src/feature/board/component/NoticeBar/NoticeBar.module.css
+++ b/src/feature/board/component/NoticeBar/NoticeBar.module.css
@@ -1,8 +1,8 @@
 .post {
-  padding: 13px 15px;
+  padding: 1.3rem 1.5rem;
   width: 100%;
   background-color: var(--gray-1);
-  border-radius: 5px;
+  border-radius: 0.5rem;
   cursor: pointer;
 }
 
@@ -12,7 +12,7 @@
 }
 
 .title {
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 500;
   display: -webkit-box;
   -webkit-line-clamp: 1;
@@ -22,11 +22,11 @@
 }
 
 .post_center {
-  padding-top: 6px;
+  padding-top: 0.6rem;
 }
 
 .text {
-  font-size: 13px;
+  font-size: 1.3rem;
   color: #484848;
   display: -webkit-box;
   -webkit-line-clamp: 3;
@@ -39,17 +39,17 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding-top: 8px;
+  padding-top: 0.8rem;
   color: var(--gray-3-1);
-  font-size: 11px;
+  font-size: 1.1rem;
 }
 
 .postBottomRight {
-  gap: 6px;
+  gap: 0.6rem;
   display: flex;
   align-items: center;
 
   p {
-    margin-bottom: 3px;
+    margin-bottom: 0.3rem;
   }
 }

--- a/src/feature/board/component/PostBar/PostBar.module.css
+++ b/src/feature/board/component/PostBar/PostBar.module.css
@@ -1,17 +1,17 @@
 .post {
-  padding: 13px 15px;
+  padding: 1.3rem 1.5rem;
   width: 100%;
   background-color: var(--gray-1);
-  border-radius: 5px;
+  border-radius: 0.5rem;
   cursor: pointer;
   user-select: none;
 }
 
 .post_top {
-  padding-bottom: 9px;
+  padding-bottom: 0.9rem;
   display: flex;
   align-items: center;
-  font-size: 11px;
+  font-size: 1.1rem;
   color: var(--gray-4);
   white-space: nowrap;
 }
@@ -20,27 +20,27 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 156px;
-  padding-left: 6px;
+  max-width: 15.6rem;
+  padding-left: 0.6rem;
 }
 
 .dot {
   font-weight: 800;
-  padding: 0 3px;
+  padding: 0 0.3rem;
 }
 
 .checkCircleIcon {
-  margin-left: 4px;
+  margin-left: 0.4rem;
 }
 
 .post_center {
   display: flex;
   flex-direction: column;
-  row-gap: 6px;
+  row-gap: 0.6rem;
 }
 
 .title {
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 500;
   display: -webkit-box;
   -webkit-line-clamp: 1;
@@ -50,7 +50,7 @@
 }
 
 .text {
-  font-size: 13px;
+  font-size: 1.3rem;
   color: var(--gray-4);
   display: -webkit-box;
   -webkit-line-clamp: 3;
@@ -63,30 +63,30 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-size: 10px;
-  padding: 5px 0 0 0;
+  font-size: 1rem;
+  padding: 0.5rem 0 0 0;
   color: var(--gray-3-1);
   justify-content: space-between;
 
   p {
-    margin-bottom: 3px;
+    margin-bottom: 0.3rem;
   }
 }
 
 .board {
   display: flex;
   align-items: center;
-  margin-bottom: 3px;
+  margin-bottom: 0.3rem;
 }
 
 .iconContainer {
   display: flex;
   align-items: center;
-  gap: 7px;
-  font-size: 11px;
+  gap: 0.7rem;
+  font-size: 1.1rem;
   color: var(--gray-3-1);
 }
 
 .comment {
-  margin-top: 1px;
+  margin-top: 0.1rem;
 }

--- a/src/feature/board/component/PostBar/PostBar.module.css
+++ b/src/feature/board/component/PostBar/PostBar.module.css
@@ -88,5 +88,5 @@
 }
 
 .comment {
-  margin-top: 1px;
+  margin-top: 0.0625rem;
 }

--- a/src/feature/board/component/PostBar/PostBar.module.css
+++ b/src/feature/board/component/PostBar/PostBar.module.css
@@ -1,17 +1,17 @@
 .post {
-  padding: 0.8125rem 0.9375rem;
+  padding: 13px 15px;
   width: 100%;
   background-color: var(--gray-1);
-  border-radius: 0.3125rem;
+  border-radius: 5px;
   cursor: pointer;
   user-select: none;
 }
 
 .post_top {
-  padding-bottom: 0.5625rem;
+  padding-bottom: 9px;
   display: flex;
   align-items: center;
-  font-size: 0.6875rem;
+  font-size: 11px;
   color: var(--gray-4);
   white-space: nowrap;
 }
@@ -20,27 +20,27 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 9.75rem;
-  padding-left: 0.375rem;
+  max-width: 156px;
+  padding-left: 6px;
 }
 
 .dot {
   font-weight: 800;
-  padding: 0 0.1875rem;
+  padding: 0 3px;
 }
 
 .checkCircleIcon {
-  margin-left: 0.25rem;
+  margin-left: 4px;
 }
 
 .post_center {
   display: flex;
   flex-direction: column;
-  row-gap: 0.375rem;
+  row-gap: 6px;
 }
 
 .title {
-  font-size: 0.875rem;
+  font-size: 14px;
   font-weight: 500;
   display: -webkit-box;
   -webkit-line-clamp: 1;
@@ -50,7 +50,7 @@
 }
 
 .text {
-  font-size: 0.8125rem;
+  font-size: 13px;
   color: var(--gray-4);
   display: -webkit-box;
   -webkit-line-clamp: 3;
@@ -63,30 +63,30 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-size: 0.625rem;
-  padding: 0.3125rem 0 0 0;
+  font-size: 10px;
+  padding: 5px 0 0 0;
   color: var(--gray-3-1);
   justify-content: space-between;
 
   p {
-    margin-bottom: 0.1875rem;
+    margin-bottom: 3px;
   }
 }
 
 .board {
   display: flex;
   align-items: center;
-  margin-bottom: 0.1875rem;
+  margin-bottom: 3px;
 }
 
 .iconContainer {
   display: flex;
   align-items: center;
-  gap: 0.4375rem;
-  font-size: 0.6875rem;
+  gap: 7px;
+  font-size: 11px;
   color: var(--gray-3-1);
 }
 
 .comment {
-  margin-top: 0.0625rem;
+  margin-top: 1px;
 }

--- a/src/feature/comment/component/Comment/Comment.module.css
+++ b/src/feature/comment/component/Comment/Comment.module.css
@@ -2,29 +2,29 @@
   width: 100%;
   display: flex;
   flex-direction: column;
-  border-radius: 5px;
+  border-radius: 0.5rem;
   background: var(--gray-1);
 }
 
 .commentTop {
   width: 100%;
-  padding: 6px 0 4px 14px;
+  padding: 0.6rem 0 0.4rem 1.4rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
   color: var(--gray-3-1);
-  font-size: 11px;
+  font-size: 1.1rem;
 }
 
 .commentTopLeft {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 0.8rem;
 }
 
 .cloud {
   display: flex;
-  height: 12px;
+  height: 1.2rem;
   align-items: center;
 }
 
@@ -33,21 +33,21 @@
 }
 
 .dot {
-  width: 3px;
-  height: 3px;
+  width: 0.3rem;
+  height: 0.3rem;
   background: var(--gray-3-1);
   border-radius: 100%;
 }
 
 .dot3 {
-  padding: 20px 14px 2px 10px;
+  padding: 2rem 1.4rem 0.2rem 1rem;
   cursor: pointer;
 }
 
 .commentCenter {
   color: var(--gray-4);
-  font-size: 14px;
-  padding: 0 14px;
+  font-size: 1.4rem;
+  padding: 0 1.4rem;
   white-space: pre-wrap;
 }
 
@@ -64,23 +64,23 @@
 }
 
 .commentBottom {
-  min-height: 40px;
-  margin-right: 8px;
+  min-height: 4rem;
+  margin-right: 0.8rem;
   display: flex;
   justify-content: end;
   align-items: center;
 }
 
 .commentCount {
-  padding: 4px 8px;
+  padding: 0.4rem 0.8rem;
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 6px;
-  border-radius: 5px;
+  gap: 0.6rem;
+  border-radius: 0.5rem;
   color: var(--gray-3-1);
   background-color: transparent;
-  font-size: 11px;
+  font-size: 1.1rem;
 }
 
 .commentCount:hover {
@@ -88,15 +88,15 @@
 }
 
 .likedCount {
-  padding: 4px 8px;
+  padding: 0.4rem 0.8rem;
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 5px;
-  border-radius: 5px;
+  gap: 0.5rem;
+  border-radius: 0.5rem;
   color: var(--gray-3-1);
   background-color: transparent;
-  font-size: 11px;
+  font-size: 1.1rem;
 }
 
 .likedCount:hover {
@@ -111,29 +111,29 @@
 }
 
 .nestedComment.isLast {
-  padding-bottom: 6px;
-  border-radius: 0 0 5px 5px;
+  padding-bottom: 0.6rem;
+  border-radius: 0 0 0.5rem 0.5rem;
 }
 
 .nestedCommentTop {
   width: 100%;
-  padding: 10px 0 0 14px;
+  padding: 1rem 0 0 1.4rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
   color: var(--gray-3-1);
-  font-size: 11px;
+  font-size: 1.1rem;
 }
 
 .nestedIcon {
   display: flex;
-  width: 16px;
-  padding-bottom: 10px;
+  width: 1.6rem;
+  padding-bottom: 1rem;
 }
 
 .nestedPadding {
   width: 100%;
-  padding-left: 22px;
+  padding-left: 2.2rem;
 }
 
 .nestedPadding.hide {

--- a/src/feature/comment/component/Comment/Comment.module.css
+++ b/src/feature/comment/component/Comment/Comment.module.css
@@ -2,29 +2,29 @@
   width: 100%;
   display: flex;
   flex-direction: column;
-  border-radius: 0.3125rem;
+  border-radius: 5px;
   background: var(--gray-1);
 }
 
 .commentTop {
   width: 100%;
-  padding: 0.375rem 0 0.25rem 0.875rem;
+  padding: 6px 0 4px 14px;
   display: flex;
   justify-content: space-between;
   align-items: center;
   color: var(--gray-3-1);
-  font-size: 0.6875rem;
+  font-size: 11px;
 }
 
 .commentTopLeft {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 8px;
 }
 
 .cloud {
   display: flex;
-  height: 0.75rem;
+  height: 12px;
   align-items: center;
 }
 
@@ -33,21 +33,21 @@
 }
 
 .dot {
-  width: 0.1875rem;
-  height: 0.1875rem;
+  width: 3px;
+  height: 3px;
   background: var(--gray-3-1);
   border-radius: 100%;
 }
 
 .dot3 {
-  padding: 1.25rem 0.875rem 0.125rem 0.625rem;
+  padding: 20px 14px 2px 10px;
   cursor: pointer;
 }
 
 .commentCenter {
   color: var(--gray-4);
-  font-size: 0.875rem;
-  padding: 0 0.875rem;
+  font-size: 14px;
+  padding: 0 14px;
   white-space: pre-wrap;
 }
 
@@ -64,23 +64,23 @@
 }
 
 .commentBottom {
-  min-height: 2.5rem;
-  margin-right: 0.5rem;
+  min-height: 40px;
+  margin-right: 8px;
   display: flex;
   justify-content: end;
   align-items: center;
 }
 
 .commentCount {
-  padding: 0.25rem 0.5rem;
+  padding: 4px 8px;
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 0.375rem;
-  border-radius: 0.3125rem;
+  gap: 6px;
+  border-radius: 5px;
   color: var(--gray-3-1);
   background-color: transparent;
-  font-size: 0.6875rem;
+  font-size: 11px;
 }
 
 .commentCount:hover {
@@ -88,15 +88,15 @@
 }
 
 .likedCount {
-  padding: 0.25rem 0.5rem;
+  padding: 4px 8px;
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 0.3125rem;
-  border-radius: 0.3125rem;
+  gap: 5px;
+  border-radius: 5px;
   color: var(--gray-3-1);
   background-color: transparent;
-  font-size: 0.6875rem;
+  font-size: 11px;
 }
 
 .likedCount:hover {
@@ -111,29 +111,29 @@
 }
 
 .nestedComment.isLast {
-  padding-bottom: 0.375rem;
-  border-radius: 0 0 0.3125rem 0.3125rem;
+  padding-bottom: 6px;
+  border-radius: 0 0 5px 5px;
 }
 
 .nestedCommentTop {
   width: 100%;
-  padding: 0.625rem 0 0 0.875rem;
+  padding: 10px 0 0 14px;
   display: flex;
   justify-content: space-between;
   align-items: center;
   color: var(--gray-3-1);
-  font-size: 0.6875rem;
+  font-size: 11px;
 }
 
 .nestedIcon {
   display: flex;
-  width: 1rem;
-  padding-bottom: 0.625rem;
+  width: 16px;
+  padding-bottom: 10px;
 }
 
 .nestedPadding {
   width: 100%;
-  padding-left: 1.375rem;
+  padding-left: 22px;
 }
 
 .nestedPadding.hide {

--- a/src/feature/comment/component/CommentInput/CommentInput.module.css
+++ b/src/feature/comment/component/CommentInput/CommentInput.module.css
@@ -1,15 +1,15 @@
 .container {
   max-width: var(--default-width);
   width: 100%;
-  min-height: 84px;
-  padding: 15px 15px 30px 15px;
+  min-height: 8.4rem;
+  padding: 1.5rem 1.5rem 3rem 1.5rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 8px;
+  gap: 0.8rem;
   background: var(--white);
-  border-radius: 10px 10px 0 0;
-  box-shadow: 0 -4px 7px var(--blue-1);
+  border-radius: 1rem 1rem 0 0;
+  box-shadow: 0 -0.4rem 0.7rem var(--blue-1);
   position: fixed;
   bottom: 0;
 }
@@ -17,21 +17,21 @@
 .input_bar {
   background-color: var(--gray-1-1);
   width: 100%;
-  min-height: 40px;
+  min-height: 4rem;
   display: flex;
   align-items: center;
-  gap: 7px;
-  padding: 9px 12px;
-  border-radius: 5px;
+  gap: 0.7rem;
+  padding: 0.9rem 1.2rem;
+  border-radius: 0.5rem;
 }
 
 .input_zone {
   width: 100%;
-  min-height: 20px;
+  min-height: 2rem;
   outline: none;
   border: none;
   background-color: transparent;
-  font-size: 12px;
+  font-size: 1.2rem;
   resize: none;
 }
 
@@ -41,8 +41,8 @@
 
 .profile_icon {
   display: flex;
-  width: 20px;
-  height: 20px;
+  width: 2rem;
+  height: 2rem;
 }
 
 .enter {

--- a/src/feature/comment/component/CommentInput/CommentInput.module.css
+++ b/src/feature/comment/component/CommentInput/CommentInput.module.css
@@ -1,15 +1,15 @@
 .container {
   max-width: var(--default-width);
   width: 100%;
-  min-height: 5.25rem;
-  padding: 0.9375rem 0.9375rem 1.875rem 0.9375rem;
+  min-height: 84px;
+  padding: 15px 15px 30px 15px;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 0.5rem;
+  gap: 8px;
   background: var(--white);
-  border-radius: 0.625rem 0.625rem 0 0;
-  box-shadow: 0 -0.25rem 0.4375rem var(--blue-1);
+  border-radius: 10px 10px 0 0;
+  box-shadow: 0 -4px 7px var(--blue-1);
   position: fixed;
   bottom: 0;
 }
@@ -17,21 +17,21 @@
 .input_bar {
   background-color: var(--gray-1-1);
   width: 100%;
-  min-height: 2.5rem;
+  min-height: 40px;
   display: flex;
   align-items: center;
-  gap: 0.4375rem;
-  padding: 0.5625rem 0.75rem;
-  border-radius: 0.3125rem;
+  gap: 7px;
+  padding: 9px 12px;
+  border-radius: 5px;
 }
 
 .input_zone {
   width: 100%;
-  min-height: 1.25rem;
+  min-height: 20px;
   outline: none;
   border: none;
   background-color: transparent;
-  font-size: 0.75rem;
+  font-size: 12px;
   resize: none;
 }
 
@@ -41,8 +41,8 @@
 
 .profile_icon {
   display: flex;
-  width: 1.25rem;
-  height: 1.25rem;
+  width: 20px;
+  height: 20px;
 }
 
 .enter {

--- a/src/feature/comment/component/CommentList/CommentList.module.css
+++ b/src/feature/comment/component/CommentList/CommentList.module.css
@@ -1,19 +1,19 @@
 .comments {
   width: 100%;
-  font-size: 12px;
-  padding: 0 20px 100px 20px;
+  font-size: 1.2rem;
+  padding: 0 2rem 10rem 2rem;
   display: flex;
   flex-direction: column;
-  row-gap: 7px;
-  min-height: 300px;
+  row-gap: 0.7rem;
+  min-height: 30rem;
 }
 
 .commentsTitle {
-  padding: 14px 0 2px 0;
+  padding: 1.4rem 0 0.2rem 0;
 }
 
 .failComment {
-  height: 300px;
+  height: 30rem;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/feature/comment/component/CommentList/CommentList.module.css
+++ b/src/feature/comment/component/CommentList/CommentList.module.css
@@ -5,7 +5,7 @@
   display: flex;
   flex-direction: column;
   row-gap: 0.4375rem;
-  min-height: 300px;
+  min-height: 18.75rem;
 }
 
 .commentsTitle {

--- a/src/feature/comment/component/CommentList/CommentList.module.css
+++ b/src/feature/comment/component/CommentList/CommentList.module.css
@@ -1,19 +1,19 @@
 .comments {
   width: 100%;
-  font-size: 0.75rem;
-  padding: 0 1.25rem 6.25rem 1.25rem;
+  font-size: 12px;
+  padding: 0 20px 100px 20px;
   display: flex;
   flex-direction: column;
-  row-gap: 0.4375rem;
-  min-height: 18.75rem;
+  row-gap: 7px;
+  min-height: 300px;
 }
 
 .commentsTitle {
-  padding: 0.875rem 0 0.125rem 0;
+  padding: 14px 0 2px 0;
 }
 
 .failComment {
-  height: 18.75rem;
+  height: 300px;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/feature/exam/component/CategoryButton/CategoryButton.module.css
+++ b/src/feature/exam/component/CategoryButton/CategoryButton.module.css
@@ -1,9 +1,9 @@
 .button {
   width: 100%;
-  padding: 0.5625rem 0;
+  padding: 9px 0;
   background: var(--gray-2);
-  border-radius: 0.3125rem;
-  font-size: 0.8125rem;
+  border-radius: 5px;
+  font-size: 13px;
   color: var(--gray-4);
 }
 

--- a/src/feature/exam/component/CategoryButton/CategoryButton.module.css
+++ b/src/feature/exam/component/CategoryButton/CategoryButton.module.css
@@ -1,9 +1,9 @@
 .button {
   width: 100%;
-  padding: 9px 0;
+  padding: 0.9rem 0;
   background: var(--gray-2);
-  border-radius: 5px;
-  font-size: 13px;
+  border-radius: 0.5rem;
+  font-size: 1.3rem;
   color: var(--gray-4);
 }
 

--- a/src/feature/exam/component/Fieldset/Fieldset.module.css
+++ b/src/feature/exam/component/Fieldset/Fieldset.module.css
@@ -1,10 +1,10 @@
 .field {
-  padding: 0 1.25rem;
-  margin: 1.75rem 0;
+  padding: 0 20px;
+  margin: 28px 0;
 }
 
 .header {
-  margin-bottom: 0.5rem;
+  margin-bottom: 8px;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -12,34 +12,34 @@
 
 .title {
   font-weight: 500;
-  font-size: 0.875rem;
+  font-size: 14px;
   color: var(--gray-4);
   position: relative;
 }
 
 .required {
-  width: 0.3125rem;
-  height: 0.3125rem;
+  width: 5px;
+  height: 5px;
   display: inline-block;
   position: absolute;
-  top: 0.125rem;
-  right: -0.625rem;
-  border-radius: 0.625rem;
+  top: 2px;
+  right: -10px;
+  border-radius: 10px;
   background-color: var(--pink-3);
 }
 
 .cagetories {
   display: grid;
-  grid-template-columns: repeat(2, minmax(6.25rem, 1fr));
-  row-gap: 0.5625rem;
-  column-gap: 0.8125rem;
+  grid-template-columns: repeat(2, minmax(100px, 1fr));
+  row-gap: 9px;
+  column-gap: 13px;
 }
 
 .check {
-  width: 1.3125rem;
-  height: 1.3125rem;
-  border-radius: 1.3125rem;
-  border: 0.25rem solid var(--gray-3);
+  width: 21px;
+  height: 21px;
+  border-radius: 21px;
+  border: 4px solid var(--gray-3);
   cursor: pointer;
 }
 

--- a/src/feature/exam/component/Fieldset/Fieldset.module.css
+++ b/src/feature/exam/component/Fieldset/Fieldset.module.css
@@ -1,10 +1,10 @@
 .field {
-  padding: 0 20px;
-  margin: 28px 0;
+  padding: 0 2rem;
+  margin: 2.8rem 0;
 }
 
 .header {
-  margin-bottom: 8px;
+  margin-bottom: 0.8rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -12,34 +12,34 @@
 
 .title {
   font-weight: 500;
-  font-size: 14px;
+  font-size: 1.4rem;
   color: var(--gray-4);
   position: relative;
 }
 
 .required {
-  width: 5px;
-  height: 5px;
+  width: 0.5rem;
+  height: 0.5rem;
   display: inline-block;
   position: absolute;
-  top: 2px;
-  right: -10px;
-  border-radius: 10px;
+  top: 0.2rem;
+  right: -1rem;
+  border-radius: 1rem;
   background-color: var(--pink-3);
 }
 
 .cagetories {
   display: grid;
-  grid-template-columns: repeat(2, minmax(100px, 1fr));
-  row-gap: 9px;
-  column-gap: 13px;
+  grid-template-columns: repeat(2, minmax(10rem, 1fr));
+  row-gap: 0.9rem;
+  column-gap: 1.3rem;
 }
 
 .check {
-  width: 21px;
-  height: 21px;
-  border-radius: 21px;
-  border: 4px solid var(--gray-3);
+  width: 2.1rem;
+  height: 2.1rem;
+  border-radius: 2.1rem;
+  border: 0.4rem solid var(--gray-3);
   cursor: pointer;
 }
 

--- a/src/feature/exam/component/Fieldset/Fieldset.module.css
+++ b/src/feature/exam/component/Fieldset/Fieldset.module.css
@@ -30,7 +30,7 @@
 
 .cagetories {
   display: grid;
-  grid-template-columns: repeat(2, minmax(100px, 1fr));
+  grid-template-columns: repeat(2, minmax(6.25rem, 1fr));
   row-gap: 0.5625rem;
   column-gap: 0.8125rem;
 }

--- a/src/feature/exam/component/Filter/Filter.module.css
+++ b/src/feature/exam/component/Filter/Filter.module.css
@@ -4,30 +4,30 @@
 }
 
 .display {
-  padding: 0.1875rem 0.875rem;
+  padding: 3px 14px;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 8px;
   background: var(--blue-0);
-  border-radius: 1.25rem;
+  border-radius: 20px;
   cursor: pointer;
 }
 
 .displayOption {
-  font-size: 0.6875rem;
+  font-size: 11px;
   color: var(--blue-4);
 }
 
 .list {
-  width: 10.6rem;
-  max-height: 15rem;
-  padding: 0.375rem;
+  width: 169.6px;
+  max-height: 240px;
+  padding: 6px;
   display: none;
   background: var(--blue-0);
-  box-shadow: 0.25rem 0.25rem 1.25rem rgba(0, 0, 0, 0.05);
-  border-radius: 0.3125rem;
+  box-shadow: 4px 4px 20px rgba(0, 0, 0, 0.05);
+  border-radius: 5px;
   position: absolute;
-  top: calc(100% + 0.625rem);
+  top: calc(100% + 10px);
   overflow-y: auto;
 }
 
@@ -36,9 +36,9 @@
 }
 
 .option {
-  padding: 0.5rem 0 0.5rem 0.75rem;
-  border-radius: 0.3125rem;
-  font-size: 0.8125rem;
+  padding: 8px 0 8px 12px;
+  border-radius: 5px;
+  font-size: 13px;
   color: var(--gray-3-1);
   cursor: pointer;
 }

--- a/src/feature/exam/component/Filter/Filter.module.css
+++ b/src/feature/exam/component/Filter/Filter.module.css
@@ -4,30 +4,30 @@
 }
 
 .display {
-  padding: 3px 14px;
+  padding: 0.3rem 1.4rem;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 0.8rem;
   background: var(--blue-0);
-  border-radius: 20px;
+  border-radius: 2rem;
   cursor: pointer;
 }
 
 .displayOption {
-  font-size: 11px;
+  font-size: 1.1rem;
   color: var(--blue-4);
 }
 
 .list {
-  width: 169.6px;
-  max-height: 240px;
-  padding: 6px;
+  width: 17rem;
+  max-height: 24rem;
+  padding: 0.6rem;
   display: none;
   background: var(--blue-0);
-  box-shadow: 4px 4px 20px rgba(0, 0, 0, 0.05);
-  border-radius: 5px;
+  box-shadow: 0.4rem 0.4rem 2rem rgba(0, 0, 0, 0.05);
+  border-radius: 0.5rem;
   position: absolute;
-  top: calc(100% + 10px);
+  top: calc(100% + 1rem);
   overflow-y: auto;
 }
 
@@ -36,9 +36,9 @@
 }
 
 .option {
-  padding: 8px 0 8px 12px;
-  border-radius: 5px;
-  font-size: 13px;
+  padding: 0.8rem 0 0.8rem 1.2rem;
+  border-radius: 0.5rem;
+  font-size: 1.3rem;
   color: var(--gray-3-1);
   cursor: pointer;
 }

--- a/src/feature/exam/component/FilterList/FilterList.module.css
+++ b/src/feature/exam/component/FilterList/FilterList.module.css
@@ -1,6 +1,6 @@
 .filters {
-  margin: 0 var(--default-margin) 0.875rem var(--default-margin);
+  margin: 0 var(--default-margin) 14px var(--default-margin);
   display: flex;
   align-items: center;
-  gap: 0.3125rem;
+  gap: 5px;
 }

--- a/src/feature/exam/component/FilterList/FilterList.module.css
+++ b/src/feature/exam/component/FilterList/FilterList.module.css
@@ -1,6 +1,6 @@
 .filters {
-  margin: 0 var(--default-margin) 14px var(--default-margin);
+  margin: 0 var(--default-margin) 1.4rem var(--default-margin);
   display: flex;
   align-items: center;
-  gap: 5px;
+  gap: 0.5rem;
 }

--- a/src/feature/exam/component/InputItem/InputItem.module.css
+++ b/src/feature/exam/component/InputItem/InputItem.module.css
@@ -1,25 +1,25 @@
 .item {
-  padding: 10px 0;
+  padding: 1rem 0;
   display: flex;
   flex-direction: column;
-  border-bottom: 0.5008px solid var(--gray-3);
+  border-bottom: 0.1rem solid var(--gray-3);
 }
 
 .tag {
   align-self: flex-start;
   position: relative;
-  font-size: 11px;
+  font-size: 1.1rem;
   color: var(--gray-3-1);
 }
 
 .required {
-  width: 5px;
-  height: 5px;
+  width: 0.5rem;
+  height: 0.5rem;
   display: inline-block;
   position: absolute;
-  top: 2px;
-  right: -10px;
-  border-radius: 10px;
+  top: 0.2rem;
+  right: -1rem;
+  border-radius: 1rem;
   background-color: var(--pink-3);
 }
 
@@ -28,7 +28,7 @@
   border: none;
   outline: none;
   font-weight: 500;
-  font-size: 14px;
+  font-size: 1.4rem;
   color: var(--gray-4);
 }
 

--- a/src/feature/exam/component/InputItem/InputItem.module.css
+++ b/src/feature/exam/component/InputItem/InputItem.module.css
@@ -1,25 +1,25 @@
 .item {
-  padding: 0.625rem 0;
+  padding: 10px 0;
   display: flex;
   flex-direction: column;
-  border-bottom: 0.0313rem solid var(--gray-3);
+  border-bottom: 0.5008px solid var(--gray-3);
 }
 
 .tag {
   align-self: flex-start;
   position: relative;
-  font-size: 0.6875rem;
+  font-size: 11px;
   color: var(--gray-3-1);
 }
 
 .required {
-  width: 0.3125rem;
-  height: 0.3125rem;
+  width: 5px;
+  height: 5px;
   display: inline-block;
   position: absolute;
-  top: 0.125rem;
-  right: -0.625rem;
-  border-radius: 0.625rem;
+  top: 2px;
+  right: -10px;
+  border-radius: 10px;
   background-color: var(--pink-3);
 }
 
@@ -28,7 +28,7 @@
   border: none;
   outline: none;
   font-weight: 500;
-  font-size: 0.875rem;
+  font-size: 14px;
   color: var(--gray-4);
 }
 

--- a/src/feature/exam/component/InputItem/InputItem.module.css
+++ b/src/feature/exam/component/InputItem/InputItem.module.css
@@ -2,7 +2,7 @@
   padding: 0.625rem 0;
   display: flex;
   flex-direction: column;
-  border-bottom: 0.5px solid var(--gray-3);
+  border-bottom: 0.0313rem solid var(--gray-3);
 }
 
 .tag {

--- a/src/feature/exam/component/InputList/InputList.module.css
+++ b/src/feature/exam/component/InputList/InputList.module.css
@@ -1,8 +1,8 @@
 .container {
-  padding: 0.25rem 0.8125rem;
-  margin: 0 1.25rem;
+  padding: 4px 13px;
+  margin: 0 20px;
   background: var(--gray-2);
-  border-radius: 0.3125rem;
+  border-radius: 5px;
 }
 
 .container div:last-child {

--- a/src/feature/exam/component/InputList/InputList.module.css
+++ b/src/feature/exam/component/InputList/InputList.module.css
@@ -1,8 +1,8 @@
 .container {
-  padding: 4px 13px;
-  margin: 0 20px;
+  padding: 0.4rem 1.3rem;
+  margin: 0 2rem;
   background: var(--gray-2);
-  border-radius: 5px;
+  border-radius: 0.5rem;
 }
 
 .container div:last-child {

--- a/src/feature/exam/component/ReviewContentItem/ReviewContentItem.module.css
+++ b/src/feature/exam/component/ReviewContentItem/ReviewContentItem.module.css
@@ -3,7 +3,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-bottom: 0.5px solid var(--gray-3);
+  border-bottom: 0.0313rem solid var(--gray-3);
 }
 
 .item:last-child {

--- a/src/feature/exam/component/ReviewContentItem/ReviewContentItem.module.css
+++ b/src/feature/exam/component/ReviewContentItem/ReviewContentItem.module.css
@@ -1,9 +1,9 @@
 .item {
-  padding: 12px 0;
+  padding: 1.2rem 0;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-bottom: 0.5008px solid var(--gray-3);
+  border-bottom: 0.05rem solid var(--gray-3);
 }
 
 .item:last-child {
@@ -11,14 +11,14 @@
 }
 
 .tag {
-  margin-right: 14px;
+  margin-right: 1.4rem;
   flex-shrink: 0;
-  font-size: 12px;
+  font-size: 1.2rem;
   color: var(--gray-3-1);
 }
 
 .value {
-  font-size: 14px;
+  font-size: 1.4rem;
   color: var(--gray-4);
 }
 

--- a/src/feature/exam/component/ReviewContentItem/ReviewContentItem.module.css
+++ b/src/feature/exam/component/ReviewContentItem/ReviewContentItem.module.css
@@ -1,9 +1,9 @@
 .item {
-  padding: 0.75rem 0;
+  padding: 12px 0;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-bottom: 0.0313rem solid var(--gray-3);
+  border-bottom: 0.5008px solid var(--gray-3);
 }
 
 .item:last-child {
@@ -11,14 +11,14 @@
 }
 
 .tag {
-  margin-right: 0.875rem;
+  margin-right: 14px;
   flex-shrink: 0;
-  font-size: 0.75rem;
+  font-size: 12px;
   color: var(--gray-3-1);
 }
 
 .value {
-  font-size: 0.875rem;
+  font-size: 14px;
   color: var(--gray-4);
 }
 

--- a/src/feature/exam/component/ReviewDownload/ReviewDownload.module.css
+++ b/src/feature/exam/component/ReviewDownload/ReviewDownload.module.css
@@ -1,12 +1,12 @@
 .layout {
   max-width: calc(100% - 2 * var(--default-margin));
-  padding: 5px 12px;
+  padding: 0.5rem 1.2rem;
   display: inline-flex;
   align-items: center;
-  gap: 10px;
+  gap: 1rem;
   background: var(--blue-2);
-  border-radius: 5px;
-  font-size: 12px;
+  border-radius: 0.5rem;
+  font-size: 1.2rem;
   color: var(--blue-4);
   word-break: keep-all;
 }

--- a/src/feature/exam/component/ReviewDownload/ReviewDownload.module.css
+++ b/src/feature/exam/component/ReviewDownload/ReviewDownload.module.css
@@ -1,12 +1,12 @@
 .layout {
   max-width: calc(100% - 2 * var(--default-margin));
-  padding: 0.3125rem 0.75rem;
+  padding: 5px 12px;
   display: inline-flex;
   align-items: center;
-  gap: 0.625rem;
+  gap: 10px;
   background: var(--blue-2);
-  border-radius: 0.3125rem;
-  font-size: 0.75rem;
+  border-radius: 5px;
+  font-size: 12px;
   color: var(--blue-4);
   word-break: keep-all;
 }

--- a/src/feature/exam/component/TextField/TextField.module.css
+++ b/src/feature/exam/component/TextField/TextField.module.css
@@ -1,9 +1,9 @@
 .input {
-  padding: 0.4rem 0;
+  padding: 6.4px 0;
   outline: none;
   border: none;
-  border-bottom: 0.0313rem solid rgba(137, 137, 137, 0.7);
+  border-bottom: 0.5008px solid rgba(137, 137, 137, 0.7);
   font-weight: 500;
-  font-size: 0.875rem;
+  font-size: 14px;
   color: var(--gray-4);
 }

--- a/src/feature/exam/component/TextField/TextField.module.css
+++ b/src/feature/exam/component/TextField/TextField.module.css
@@ -1,9 +1,9 @@
 .input {
-  padding: 6.4px 0;
+  padding: 0.6rem 0;
   outline: none;
   border: none;
-  border-bottom: 0.5008px solid rgba(137, 137, 137, 0.7);
+  border-bottom: 0.05rem solid rgba(137, 137, 137, 0.7);
   font-weight: 500;
-  font-size: 14px;
+  font-size: 1.4rem;
   color: var(--gray-4);
 }

--- a/src/feature/exam/component/TextField/TextField.module.css
+++ b/src/feature/exam/component/TextField/TextField.module.css
@@ -2,7 +2,7 @@
   padding: 0.4rem 0;
   outline: none;
   border: none;
-  border-bottom: 0.5px solid rgba(137, 137, 137, 0.7);
+  border-bottom: 0.0313rem solid rgba(137, 137, 137, 0.7);
   font-weight: 500;
   font-size: 0.875rem;
   color: var(--gray-4);

--- a/src/feature/home/component/Accordion/Accordion.module.css
+++ b/src/feature/home/component/Accordion/Accordion.module.css
@@ -1,5 +1,5 @@
 .accordion {
-  border-bottom: 0.0313rem solid var(--gray-3);
+  border-bottom: 0.5008px solid var(--gray-3);
 }
 
 .accordion:last-child {
@@ -7,7 +7,7 @@
 }
 
 .panelHeader {
-  padding: 0.875rem 0;
+  padding: 14px 0;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -16,12 +16,12 @@
 
 .panelHeader span {
   font-weight: 500;
-  font-size: 0.875rem;
+  font-size: 14px;
   color: var(--gray-4);
 }
 
 .opend .panelHeader {
-  border-bottom: 0.0313rem solid var(--gray-3);
+  border-bottom: 0.5008px solid var(--gray-3);
 }
 
 .toggleIcon {
@@ -35,14 +35,14 @@
 .panelBody {
   max-height: 0;
   color: var(--gray-4);
-  font-size: 0.875rem;
-  letter-spacing: -0.03125rem;
+  font-size: 14px;
+  letter-spacing: -0.5px;
   overflow: hidden;
   transition: 300ms all ease;
 }
 
 .opend .panelBody {
-  padding: 1rem 0 0.625rem 0;
-  max-height: 156.25rem;
+  padding: 16px 0 10px 0;
+  max-height: 2500px;
   overflow-y: auto;
 }

--- a/src/feature/home/component/Accordion/Accordion.module.css
+++ b/src/feature/home/component/Accordion/Accordion.module.css
@@ -1,5 +1,5 @@
 .accordion {
-  border-bottom: 0.5px solid var(--gray-3);
+  border-bottom: 0.0313rem solid var(--gray-3);
 }
 
 .accordion:last-child {
@@ -21,7 +21,7 @@
 }
 
 .opend .panelHeader {
-  border-bottom: 0.5px solid var(--gray-3);
+  border-bottom: 0.0313rem solid var(--gray-3);
 }
 
 .toggleIcon {
@@ -43,6 +43,6 @@
 
 .opend .panelBody {
   padding: 1rem 0 0.625rem 0;
-  max-height: 2500px;
+  max-height: 156.25rem;
   overflow-y: auto;
 }

--- a/src/feature/home/component/Accordion/Accordion.module.css
+++ b/src/feature/home/component/Accordion/Accordion.module.css
@@ -1,5 +1,5 @@
 .accordion {
-  border-bottom: 0.5008px solid var(--gray-3);
+  border-bottom: 0.05rem solid var(--gray-3);
 }
 
 .accordion:last-child {
@@ -7,7 +7,7 @@
 }
 
 .panelHeader {
-  padding: 14px 0;
+  padding: 1.4rem 0;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -16,12 +16,12 @@
 
 .panelHeader span {
   font-weight: 500;
-  font-size: 14px;
+  font-size: 1.4rem;
   color: var(--gray-4);
 }
 
 .opend .panelHeader {
-  border-bottom: 0.5008px solid var(--gray-3);
+  border-bottom: 0.05rem solid var(--gray-3);
 }
 
 .toggleIcon {
@@ -35,14 +35,14 @@
 .panelBody {
   max-height: 0;
   color: var(--gray-4);
-  font-size: 14px;
-  letter-spacing: -0.5px;
+  font-size: 1.4rem;
+  letter-spacing: -0.05rem;
   overflow: hidden;
   transition: 300ms all ease;
 }
 
 .opend .panelBody {
-  padding: 16px 0 10px 0;
-  max-height: 2500px;
+  padding: 1.6rem 0 1rem 0;
+  max-height: 250rem;
   overflow-y: auto;
 }

--- a/src/feature/home/component/AccordionListItem/AccordionListItem.module.css
+++ b/src/feature/home/component/AccordionListItem/AccordionListItem.module.css
@@ -1,17 +1,17 @@
 .list {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 16px;
 }
 
 .item {
   display: flex;
   align-items: flex-start;
-  gap: 0.75rem;
+  gap: 12px;
 }
 
 .icon {
-  margin-top: 0.125rem;
+  margin-top: 2px;
 }
 
 .description {

--- a/src/feature/home/component/AccordionListItem/AccordionListItem.module.css
+++ b/src/feature/home/component/AccordionListItem/AccordionListItem.module.css
@@ -1,17 +1,17 @@
 .list {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 1.6rem;
 }
 
 .item {
   display: flex;
   align-items: flex-start;
-  gap: 12px;
+  gap: 1.2rem;
 }
 
 .icon {
-  margin-top: 2px;
+  margin-top: 0.2rem;
 }
 
 .description {

--- a/src/feature/home/component/AccordionListItem/AccordionListItem.module.css
+++ b/src/feature/home/component/AccordionListItem/AccordionListItem.module.css
@@ -11,7 +11,7 @@
 }
 
 .icon {
-  margin-top: 2px;
+  margin-top: 0.125rem;
 }
 
 .description {

--- a/src/feature/home/component/AccordionTag/AccordionTag.module.css
+++ b/src/feature/home/component/AccordionTag/AccordionTag.module.css
@@ -1,34 +1,34 @@
 .tag {
   flex-shrink: 0;
-  padding: 0.12rem 0.56rem;
+  padding: 1.92px 8.96px;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   background: var(--blue-0);
-  border-radius: 0.3125rem;
+  border-radius: 5px;
 }
 
 /* top */
 .top {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 4px;
 }
 
 .nickname {
   color: var(--blue-3);
-  font-size: 0.6875rem;
+  font-size: 11px;
 }
 
 .title {
   color: var(--gray-3-1);
-  font-size: 0.5625rem;
+  font-size: 9px;
 }
 
 /* bottom */
 
 .studentInfo {
-  font-size: 0.5rem;
+  font-size: 8px;
   color: var(--gray-4);
 }

--- a/src/feature/home/component/AccordionTag/AccordionTag.module.css
+++ b/src/feature/home/component/AccordionTag/AccordionTag.module.css
@@ -1,34 +1,34 @@
 .tag {
   flex-shrink: 0;
-  padding: 1.92px 8.96px;
+  padding: 0.2rem 0.9rem;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   background: var(--blue-0);
-  border-radius: 5px;
+  border-radius: 0.5rem;
 }
 
 /* top */
 .top {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 0.4rem;
 }
 
 .nickname {
   color: var(--blue-3);
-  font-size: 11px;
+  font-size: 1.1rem;
 }
 
 .title {
   color: var(--gray-3-1);
-  font-size: 9px;
+  font-size: 0.9rem;
 }
 
 /* bottom */
 
 .studentInfo {
-  font-size: 8px;
+  font-size: 0.8rem;
   color: var(--gray-4);
 }

--- a/src/feature/home/component/Carousel/Carousel.css
+++ b/src/feature/home/component/Carousel/Carousel.css
@@ -12,9 +12,9 @@
 }
 
 .swiper-pagination-bullet {
-  width: 0.375rem;
-  height: 0.375rem;
-  border-radius: 0.625rem;
+  width: 6px;
+  height: 6px;
+  border-radius: 10px;
   background-color: var(--blue-4);
 }
 
@@ -28,5 +28,5 @@
 .swiper-button-prev::after,
 .swiper-button-next::after {
   color: var(--blue-1);
-  font-size: 2.5rem;
+  font-size: 40px;
 }

--- a/src/feature/home/component/Carousel/Carousel.css
+++ b/src/feature/home/component/Carousel/Carousel.css
@@ -28,5 +28,5 @@
 .swiper-button-prev::after,
 .swiper-button-next::after {
   color: var(--blue-1);
-  font-size: 40px;
+  font-size: 2.5rem;
 }

--- a/src/feature/home/component/Carousel/Carousel.css
+++ b/src/feature/home/component/Carousel/Carousel.css
@@ -12,9 +12,9 @@
 }
 
 .swiper-pagination-bullet {
-  width: 6px;
-  height: 6px;
-  border-radius: 10px;
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 1rem;
   background-color: var(--blue-4);
 }
 
@@ -28,5 +28,5 @@
 .swiper-button-prev::after,
 .swiper-button-next::after {
   color: var(--blue-1);
-  font-size: 40px;
+  font-size: 4rem;
 }

--- a/src/feature/home/component/Carousel/CarouselSkeleton.module.css
+++ b/src/feature/home/component/Carousel/CarouselSkeleton.module.css
@@ -1,5 +1,5 @@
 .layout {
-  margin-bottom: 2.5625rem;
+  margin-bottom: 41px;
   width: 100%;
   aspect-ratio: 3;
   background: linear-gradient(

--- a/src/feature/home/component/Carousel/CarouselSkeleton.module.css
+++ b/src/feature/home/component/Carousel/CarouselSkeleton.module.css
@@ -1,5 +1,5 @@
 .layout {
-  margin-bottom: 41px;
+  margin-bottom: 4.1rem;
   width: 100%;
   aspect-ratio: 3;
   background: linear-gradient(

--- a/src/feature/home/component/HomeBesookt/HomeBesookt.module.css
+++ b/src/feature/home/component/HomeBesookt/HomeBesookt.module.css
@@ -2,5 +2,5 @@
   margin: 0 var(--default-margin);
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 0.6rem;
 }

--- a/src/feature/home/component/HomeBesookt/HomeBesookt.module.css
+++ b/src/feature/home/component/HomeBesookt/HomeBesookt.module.css
@@ -2,5 +2,5 @@
   margin: 0 var(--default-margin);
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
+  gap: 6px;
 }

--- a/src/feature/home/component/HomeBesookt/HomeBesooktErrorFallback.module.css
+++ b/src/feature/home/component/HomeBesookt/HomeBesooktErrorFallback.module.css
@@ -2,19 +2,19 @@
   margin: 0 var(--default-margin);
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 0.6rem;
 }
 
 .item {
   width: 100%;
-  padding: 13px 15px;
+  padding: 1.3rem 1.5rem;
   display: flex;
   justify-content: space-between;
-  gap: 24px;
+  gap: 2.4rem;
   background: var(--gray-1);
-  border-radius: 5px;
+  border-radius: 0.5rem;
   box-sizing: border-box;
   font-weight: 500;
-  font-size: 12px;
+  font-size: 1.2rem;
   color: var(--gray-3-1);
 }

--- a/src/feature/home/component/HomeBesookt/HomeBesooktErrorFallback.module.css
+++ b/src/feature/home/component/HomeBesookt/HomeBesooktErrorFallback.module.css
@@ -2,19 +2,19 @@
   margin: 0 var(--default-margin);
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
+  gap: 6px;
 }
 
 .item {
   width: 100%;
-  padding: 0.8125rem 0.9375rem;
+  padding: 13px 15px;
   display: flex;
   justify-content: space-between;
-  gap: 1.5rem;
+  gap: 24px;
   background: var(--gray-1);
-  border-radius: 0.3125rem;
+  border-radius: 5px;
   box-sizing: border-box;
   font-weight: 500;
-  font-size: 0.75rem;
+  font-size: 12px;
   color: var(--gray-3-1);
 }

--- a/src/feature/home/component/HomeBesookt/HomeBesooktSkeleton.module.css
+++ b/src/feature/home/component/HomeBesookt/HomeBesooktSkeleton.module.css
@@ -2,13 +2,13 @@
   margin: 0 var(--default-margin);
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 0.6rem;
 }
 
 .item {
   width: 100%;
-  height: 115.5008px;
-  border-radius: 5px;
+  height: 11.5rem;
+  border-radius: 0.5rem;
   background: linear-gradient(
     45deg,
     var(--gray-2) 25%,

--- a/src/feature/home/component/HomeBesookt/HomeBesooktSkeleton.module.css
+++ b/src/feature/home/component/HomeBesookt/HomeBesooktSkeleton.module.css
@@ -2,13 +2,13 @@
   margin: 0 var(--default-margin);
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
+  gap: 6px;
 }
 
 .item {
   width: 100%;
-  height: 7.2188rem;
-  border-radius: 0.3125rem;
+  height: 115.5008px;
+  border-radius: 5px;
   background: linear-gradient(
     45deg,
     var(--gray-2) 25%,

--- a/src/feature/home/component/HomeBesookt/HomeBesooktSkeleton.module.css
+++ b/src/feature/home/component/HomeBesookt/HomeBesooktSkeleton.module.css
@@ -7,7 +7,7 @@
 
 .item {
   width: 100%;
-  height: 115.5px;
+  height: 7.2188rem;
   border-radius: 0.3125rem;
   background: linear-gradient(
     45deg,

--- a/src/feature/home/component/HomeBoardCard/HomeBoardCard.module.css
+++ b/src/feature/home/component/HomeBoardCard/HomeBoardCard.module.css
@@ -3,20 +3,20 @@
 }
 
 .card {
-  padding: 11.2px 0 0 14.4px;
+  padding: 1.1rem 0 0 1.4rem;
   width: 100%;
-  height: 84px;
+  height: 8.4rem;
   display: flex;
   flex-direction: column;
-  gap: 1.92px;
-  border-radius: 6px;
+  gap: 0.2rem;
+  border-radius: 0.6rem;
   background: var(--gray-1-1);
   background-repeat: no-repeat;
   background-position: right bottom;
 }
 
 .name {
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 500;
 }
 
@@ -25,8 +25,8 @@
 }
 
 .desc {
-  width: 80px;
-  font-size: 11px;
+  width: 8rem;
+  font-size: 1.1rem;
   color: var(--gray-3-1);
   word-break: keep-all;
 }

--- a/src/feature/home/component/HomeBoardCard/HomeBoardCard.module.css
+++ b/src/feature/home/component/HomeBoardCard/HomeBoardCard.module.css
@@ -3,20 +3,20 @@
 }
 
 .card {
-  padding: 0.7rem 0 0 0.9rem;
+  padding: 11.2px 0 0 14.4px;
   width: 100%;
-  height: 5.25rem;
+  height: 84px;
   display: flex;
   flex-direction: column;
-  gap: 0.12rem;
-  border-radius: 0.375rem;
+  gap: 1.92px;
+  border-radius: 6px;
   background: var(--gray-1-1);
   background-repeat: no-repeat;
   background-position: right bottom;
 }
 
 .name {
-  font-size: 0.875rem;
+  font-size: 14px;
   font-weight: 500;
 }
 
@@ -25,8 +25,8 @@
 }
 
 .desc {
-  width: 5rem;
-  font-size: 0.6875rem;
+  width: 80px;
+  font-size: 11px;
   color: var(--gray-3-1);
   word-break: keep-all;
 }

--- a/src/feature/home/component/HomeCard/HomeCard.module.css
+++ b/src/feature/home/component/HomeCard/HomeCard.module.css
@@ -1,9 +1,9 @@
 /* HomeCard */
 
 .layout {
-  margin: 1.5rem var(--default-margin) 1.75rem var(--default-margin);
+  margin: 24px var(--default-margin) 28px var(--default-margin);
   display: flex;
-  gap: 0.45rem;
+  gap: 7.2px;
 }
 
 .left {
@@ -18,13 +18,13 @@
 
 .card {
   width: 100%;
-  height: 7rem;
-  padding: 0.835rem 0 1rem 0.75rem;
+  height: 112px;
+  padding: 13.36px 0 16px 12px;
   display: flex;
   justify-content: space-between;
   align-items: center;
   background: var(--blue-0);
-  border-radius: 0.375rem;
+  border-radius: 6px;
   box-sizing: border-box;
   color: var(--gray-4);
   overflow: hidden;
@@ -54,12 +54,12 @@
   -webkit-box-orient: vertical; /* Required for the ellipsis effect */
   overflow: hidden; /* Hide text overflow */
   white-space: pre-line;
-  font-size: 1rem;
+  font-size: 16px;
   font-weight: 500;
 }
 
 .tag {
-  font-size: 0.75rem;
+  font-size: 12px;
   color: var(--gray-4);
 }
 
@@ -68,6 +68,6 @@
 }
 
 .image {
-  width: 4.5rem;
+  width: 72px;
   height: auto;
 }

--- a/src/feature/home/component/HomeCard/HomeCard.module.css
+++ b/src/feature/home/component/HomeCard/HomeCard.module.css
@@ -1,9 +1,9 @@
 /* HomeCard */
 
 .layout {
-  margin: 24px var(--default-margin) 28px var(--default-margin);
+  margin: 2.4rem var(--default-margin) 2.8rem var(--default-margin);
   display: flex;
-  gap: 7.2px;
+  gap: 0.72rem;
 }
 
 .left {
@@ -18,13 +18,13 @@
 
 .card {
   width: 100%;
-  height: 112px;
-  padding: 13.36px 0 16px 12px;
+  height: 11.2rem;
+  padding: 1.3rem 0 1.6rem 1.2rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
   background: var(--blue-0);
-  border-radius: 6px;
+  border-radius: 0.6rem;
   box-sizing: border-box;
   color: var(--gray-4);
   overflow: hidden;
@@ -54,12 +54,12 @@
   -webkit-box-orient: vertical; /* Required for the ellipsis effect */
   overflow: hidden; /* Hide text overflow */
   white-space: pre-line;
-  font-size: 16px;
+  font-size: 1.6rem;
   font-weight: 500;
 }
 
 .tag {
-  font-size: 12px;
+  font-size: 1.2rem;
   color: var(--gray-4);
 }
 
@@ -68,6 +68,6 @@
 }
 
 .image {
-  width: 72px;
+  width: 7.2rem;
   height: auto;
 }

--- a/src/feature/home/component/HomeCard/HomeCardSkeleton.module.css
+++ b/src/feature/home/component/HomeCard/HomeCardSkeleton.module.css
@@ -1,12 +1,12 @@
 .layout {
-  margin: 1.5rem var(--default-margin) 1.75rem var(--default-margin);
+  margin: 24px var(--default-margin) 28px var(--default-margin);
   display: flex;
-  gap: 0.45rem;
+  gap: 7.2px;
 }
 
 .layout div {
-  height: 7rem;
-  border-radius: 0.375rem;
+  height: 112px;
+  border-radius: 6px;
   background: linear-gradient(
     45deg,
     var(--gray-2) 25%,

--- a/src/feature/home/component/HomeCard/HomeCardSkeleton.module.css
+++ b/src/feature/home/component/HomeCard/HomeCardSkeleton.module.css
@@ -1,12 +1,12 @@
 .layout {
-  margin: 24px var(--default-margin) 28px var(--default-margin);
+  margin: 2.4rem var(--default-margin) 2.8rem var(--default-margin);
   display: flex;
-  gap: 7.2px;
+  gap: 0.72rem;
 }
 
 .layout div {
-  height: 112px;
-  border-radius: 6px;
+  height: 11.2rem;
+  border-radius: 0.6rem;
   background: linear-gradient(
     45deg,
     var(--gray-2) 25%,

--- a/src/feature/home/component/HomeCard/HomeCardSkeleton.module.css
+++ b/src/feature/home/component/HomeCard/HomeCardSkeleton.module.css
@@ -5,7 +5,7 @@
 }
 
 .layout div {
-  height: 112px;
+  height: 7rem;
   border-radius: 0.375rem;
   background: linear-gradient(
     45deg,

--- a/src/feature/home/component/HomeCommunity/HomeCommunity.module.css
+++ b/src/feature/home/component/HomeCommunity/HomeCommunity.module.css
@@ -1,5 +1,5 @@
 .list {
   margin: 0 var(--default-margin);
   display: flex;
-  gap: 0.625rem;
+  gap: 10px;
 }

--- a/src/feature/home/component/HomeCommunity/HomeCommunity.module.css
+++ b/src/feature/home/component/HomeCommunity/HomeCommunity.module.css
@@ -1,5 +1,5 @@
 .list {
   margin: 0 var(--default-margin);
   display: flex;
-  gap: 10px;
+  gap: 1rem;
 }

--- a/src/feature/home/component/ListHeader/ListHeader.module.css
+++ b/src/feature/home/component/ListHeader/ListHeader.module.css
@@ -1,19 +1,19 @@
 .header {
-  margin: 0 var(--default-margin) 8px var(--default-margin);
+  margin: 0 var(--default-margin) 0.8rem var(--default-margin);
   display: flex;
   justify-content: space-between;
 }
 
 .title {
   font-weight: 700;
-  font-size: 16px;
+  font-size: 1.6rem;
 }
 
 .more {
   display: flex;
   align-items: center;
-  gap: 1px;
+  gap: 0.1rem;
   font-weight: 500;
-  font-size: 12px;
+  font-size: 1.2rem;
   color: var(--gray-4);
 }

--- a/src/feature/home/component/ListHeader/ListHeader.module.css
+++ b/src/feature/home/component/ListHeader/ListHeader.module.css
@@ -1,19 +1,19 @@
 .header {
-  margin: 0 var(--default-margin) 0.5rem var(--default-margin);
+  margin: 0 var(--default-margin) 8px var(--default-margin);
   display: flex;
   justify-content: space-between;
 }
 
 .title {
   font-weight: 700;
-  font-size: 1rem;
+  font-size: 16px;
 }
 
 .more {
   display: flex;
   align-items: center;
-  gap: 0.0625rem;
+  gap: 1px;
   font-weight: 500;
-  font-size: 0.75rem;
+  font-size: 12px;
   color: var(--gray-4);
 }

--- a/src/feature/home/component/ListHeader/ListHeader.module.css
+++ b/src/feature/home/component/ListHeader/ListHeader.module.css
@@ -12,7 +12,7 @@
 .more {
   display: flex;
   align-items: center;
-  gap: 1px;
+  gap: 0.0625rem;
   font-weight: 500;
   font-size: 0.75rem;
   color: var(--gray-4);

--- a/src/feature/home/component/MainPageListItem/MainPageListItem.module.css
+++ b/src/feature/home/component/MainPageListItem/MainPageListItem.module.css
@@ -4,12 +4,12 @@
 
 .item {
   width: 100%;
-  padding: 13px 15px;
+  padding: 1.3rem 1.5rem;
   display: flex;
   justify-content: space-between;
-  gap: 24px;
+  gap: 2.4rem;
   background: var(--gray-1);
-  border-radius: 5px;
+  border-radius: 0.5rem;
   box-sizing: border-box;
 }
 
@@ -19,29 +19,29 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 1.2rem;
 }
 
 .top {
   display: flex;
   align-items: center;
-  gap: 4.8px;
+  gap: 0.48rem;
 }
 
 .meta {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 7px;
-  font-size: 9px;
+  gap: 0.7rem;
+  font-size: 0.9rem;
   color: var(--gray-4);
 }
 
 .dot {
-  width: 2px;
-  height: 2px;
+  width: 0.2rem;
+  height: 0.2rem;
   display: inline-block;
-  border-radius: 10px;
+  border-radius: 1rem;
   background-color: var(--gray-4);
 }
 
@@ -53,17 +53,17 @@
 }
 
 .content {
-  height: 52px;
+  height: 5.2rem;
 }
 
 .title {
-  margin-bottom: 2px;
+  margin-bottom: 0.2rem;
   font-weight: 500;
-  font-size: 12px;
+  font-size: 1.2rem;
 }
 
 .overview {
-  font-size: 11px;
+  font-size: 1.1rem;
   color: var(--gray-4);
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -74,7 +74,7 @@
 }
 
 .boardName {
-  font-size: 8px;
+  font-size: 0.8rem;
   color: var(--gray-3-1);
 }
 
@@ -86,7 +86,7 @@
 }
 
 .right img {
-  width: 76px;
-  height: 76px;
-  border-radius: 4px;
+  width: 7.6rem;
+  height: 7.6rem;
+  border-radius: 0.4rem;
 }

--- a/src/feature/home/component/MainPageListItem/MainPageListItem.module.css
+++ b/src/feature/home/component/MainPageListItem/MainPageListItem.module.css
@@ -4,12 +4,12 @@
 
 .item {
   width: 100%;
-  padding: 0.8125rem 0.9375rem;
+  padding: 13px 15px;
   display: flex;
   justify-content: space-between;
-  gap: 1.5rem;
+  gap: 24px;
   background: var(--gray-1);
-  border-radius: 0.3125rem;
+  border-radius: 5px;
   box-sizing: border-box;
 }
 
@@ -19,29 +19,29 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 12px;
 }
 
 .top {
   display: flex;
   align-items: center;
-  gap: 0.3rem;
+  gap: 4.8px;
 }
 
 .meta {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 0.4375rem;
-  font-size: 0.5625rem;
+  gap: 7px;
+  font-size: 9px;
   color: var(--gray-4);
 }
 
 .dot {
-  width: 0.125rem;
-  height: 0.125rem;
+  width: 2px;
+  height: 2px;
   display: inline-block;
-  border-radius: 0.625rem;
+  border-radius: 10px;
   background-color: var(--gray-4);
 }
 
@@ -53,17 +53,17 @@
 }
 
 .content {
-  height: 3.25rem;
+  height: 52px;
 }
 
 .title {
-  margin-bottom: 0.125rem;
+  margin-bottom: 2px;
   font-weight: 500;
-  font-size: 0.75rem;
+  font-size: 12px;
 }
 
 .overview {
-  font-size: 0.6875rem;
+  font-size: 11px;
   color: var(--gray-4);
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -74,7 +74,7 @@
 }
 
 .boardName {
-  font-size: 0.5rem;
+  font-size: 8px;
   color: var(--gray-3-1);
 }
 
@@ -86,7 +86,7 @@
 }
 
 .right img {
-  width: 4.75rem;
-  height: 4.75rem;
-  border-radius: 0.25rem;
+  width: 76px;
+  height: 76px;
+  border-radius: 4px;
 }

--- a/src/feature/home/component/PopUp/PopUp.module.css
+++ b/src/feature/home/component/PopUp/PopUp.module.css
@@ -4,7 +4,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  font-size: 12.8px;
+  font-size: 1.3rem;
   background-color: rgba(0, 0, 0, 0.3);
   position: fixed;
   top: 0;
@@ -14,7 +14,7 @@
 
 .popUp {
   width: 80%;
-  max-width: 500px;
+  max-width: 50rem;
   max-height: 80%;
   min-height: 60%;
   display: flex;
@@ -24,25 +24,25 @@
 /* top */
 .top {
   flex: 1;
-  padding: 16px;
+  padding: 1.6rem;
   width: 100%;
   height: 100%;
   display: flex;
   background-color: var(--blue-1);
-  border-radius: 5px 5px 0 0;
+  border-radius: 0.5rem 0.5rem 0 0;
   overflow: auto;
   scrollbar-width: thin;
 }
 
 .top::-webkit-scrollbar {
-  width: 10px;
+  width: 1rem;
   display: block;
 }
 
 .top::-webkit-scrollbar-thumb {
   background-color: rgba(0, 0, 0, 0.5); /* 스크롤바 색상 */
-  border-radius: 5px;
-  border: 2px solid var(--blue-1);
+  border-radius: 0.5rem;
+  border: 0.2rem solid var(--blue-1);
 }
 
 .top::-webkit-scrollbar-track {
@@ -52,7 +52,7 @@
 .top pre {
   text-wrap: wrap;
   word-break: keep-all;
-  font-size: 16px;
+  font-size: 1.6rem;
 }
 
 .notice {
@@ -64,11 +64,11 @@
 
 /* bottom */
 .bottom {
-  padding: 8px 12.8px;
+  padding: 0.8rem 1.3rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-radius: 0 0 5px 5px;
+  border-radius: 0 0 0.5rem 0.5rem;
   background-color: var(--gray-4);
   color: var(--white);
 }
@@ -76,27 +76,27 @@
 .radios {
   display: flex;
   flex-direction: column;
-  gap: 3.2px;
+  gap: 0.3rem;
 }
 
 .radio {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 0.8rem;
 }
 
 .bottom button {
-  padding: 3.2px 8px;
+  padding: 0.3rem 0.8rem;
   color: var(--white);
 }
 
 .bottom button:hover {
-  border-radius: 5px;
+  border-radius: 0.5rem;
   background-color: var(--gray-3-1);
 }
 
 .hello {
-  margin-bottom: 16px;
+  margin-bottom: 1.6rem;
   display: block;
 }
 
@@ -120,19 +120,19 @@
 /* component */
 
 .title {
-  margin-bottom: 8px;
-  font-size: 17.6px;
+  margin-bottom: 0.8rem;
+  font-size: 1.8rem;
   font-weight: 500;
 }
 
 .subTitle {
-  margin-bottom: 8px;
-  font-size: 16px;
+  margin-bottom: 0.8rem;
+  font-size: 1.6rem;
   font-weight: 500;
 }
 
 .content {
-  margin: 8px 0 32px 0;
+  margin: 0.8rem 0 3.2rem 0;
   white-space: pre-wrap;
   word-break: break-all;
 }

--- a/src/feature/home/component/PopUp/PopUp.module.css
+++ b/src/feature/home/component/PopUp/PopUp.module.css
@@ -14,7 +14,7 @@
 
 .popUp {
   width: 80%;
-  max-width: 500px;
+  max-width: 31.25rem;
   max-height: 80%;
   min-height: 60%;
   display: flex;
@@ -29,20 +29,20 @@
   height: 100%;
   display: flex;
   background-color: var(--blue-1);
-  border-radius: 5px 5px 0 0;
+  border-radius: 0.3125rem 0.3125rem 0 0;
   overflow: auto;
   scrollbar-width: thin;
 }
 
 .top::-webkit-scrollbar {
-  width: 10px;
+  width: 0.625rem;
   display: block;
 }
 
 .top::-webkit-scrollbar-thumb {
   background-color: rgba(0, 0, 0, 0.5); /* 스크롤바 색상 */
-  border-radius: 5px;
-  border: 2px solid var(--blue-1);
+  border-radius: 0.3125rem;
+  border: 0.125rem solid var(--blue-1);
 }
 
 .top::-webkit-scrollbar-track {
@@ -68,7 +68,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-radius: 0 0 5px 5px;
+  border-radius: 0 0 0.3125rem 0.3125rem;
   background-color: var(--gray-4);
   color: var(--white);
 }
@@ -91,7 +91,7 @@
 }
 
 .bottom button:hover {
-  border-radius: 5px;
+  border-radius: 0.3125rem;
   background-color: var(--gray-3-1);
 }
 

--- a/src/feature/home/component/PopUp/PopUp.module.css
+++ b/src/feature/home/component/PopUp/PopUp.module.css
@@ -4,7 +4,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  font-size: 0.8rem;
+  font-size: 12.8px;
   background-color: rgba(0, 0, 0, 0.3);
   position: fixed;
   top: 0;
@@ -14,7 +14,7 @@
 
 .popUp {
   width: 80%;
-  max-width: 31.25rem;
+  max-width: 500px;
   max-height: 80%;
   min-height: 60%;
   display: flex;
@@ -24,25 +24,25 @@
 /* top */
 .top {
   flex: 1;
-  padding: 1rem;
+  padding: 16px;
   width: 100%;
   height: 100%;
   display: flex;
   background-color: var(--blue-1);
-  border-radius: 0.3125rem 0.3125rem 0 0;
+  border-radius: 5px 5px 0 0;
   overflow: auto;
   scrollbar-width: thin;
 }
 
 .top::-webkit-scrollbar {
-  width: 0.625rem;
+  width: 10px;
   display: block;
 }
 
 .top::-webkit-scrollbar-thumb {
   background-color: rgba(0, 0, 0, 0.5); /* 스크롤바 색상 */
-  border-radius: 0.3125rem;
-  border: 0.125rem solid var(--blue-1);
+  border-radius: 5px;
+  border: 2px solid var(--blue-1);
 }
 
 .top::-webkit-scrollbar-track {
@@ -52,7 +52,7 @@
 .top pre {
   text-wrap: wrap;
   word-break: keep-all;
-  font-size: 1rem;
+  font-size: 16px;
 }
 
 .notice {
@@ -64,11 +64,11 @@
 
 /* bottom */
 .bottom {
-  padding: 0.5rem 0.8rem;
+  padding: 8px 12.8px;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-radius: 0 0 0.3125rem 0.3125rem;
+  border-radius: 0 0 5px 5px;
   background-color: var(--gray-4);
   color: var(--white);
 }
@@ -76,27 +76,27 @@
 .radios {
   display: flex;
   flex-direction: column;
-  gap: 0.2rem;
+  gap: 3.2px;
 }
 
 .radio {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 8px;
 }
 
 .bottom button {
-  padding: 0.2rem 0.5rem;
+  padding: 3.2px 8px;
   color: var(--white);
 }
 
 .bottom button:hover {
-  border-radius: 0.3125rem;
+  border-radius: 5px;
   background-color: var(--gray-3-1);
 }
 
 .hello {
-  margin-bottom: 1rem;
+  margin-bottom: 16px;
   display: block;
 }
 
@@ -120,19 +120,19 @@
 /* component */
 
 .title {
-  margin-bottom: 0.5rem;
-  font-size: 1.1rem;
+  margin-bottom: 8px;
+  font-size: 17.6px;
   font-weight: 500;
 }
 
 .subTitle {
-  margin-bottom: 0.5rem;
-  font-size: 1rem;
+  margin-bottom: 8px;
+  font-size: 16px;
   font-weight: 500;
 }
 
 .content {
-  margin: 0.5rem 0 2rem 0;
+  margin: 8px 0 32px 0;
   white-space: pre-wrap;
   word-break: break-all;
 }

--- a/src/feature/my/component/AccountTab/AccountTab.module.css
+++ b/src/feature/my/component/AccountTab/AccountTab.module.css
@@ -2,17 +2,17 @@
 .infoWrapper {
   display: flex;
   flex-direction: column;
-  padding: 0.25rem 0.8125rem;
-  margin: 0 1.25rem;
-  border-radius: 0.3125rem;
+  padding: 4px 13px;
+  margin: 0 20px;
+  border-radius: 5px;
   background: var(--gray-1);
 }
 
 .info {
   display: flex;
   flex-direction: column;
-  padding: 0.625rem 0;
-  border-bottom: 0.0625rem solid var(--gray-3);
+  padding: 10px 0;
+  border-bottom: 1px solid var(--gray-3);
 
   &:last-child {
     border-bottom: none;
@@ -21,12 +21,12 @@
 
 .label {
   color: var(--gray-3-1);
-  font-size: 0.6875rem;
+  font-size: 11px;
 }
 
 .value {
   color: var(--gray-4);
-  font-size: 0.875rem;
+  font-size: 14px;
   font-weight: 500;
 }
 
@@ -34,30 +34,30 @@
 .buttonWrapper {
   display: flex;
   justify-content: flex-end;
-  gap: 0.9375rem;
-  margin: 1.25rem;
+  gap: 15px;
+  margin: 20px;
 }
 
 .editButton {
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 5.625rem;
-  height: 1.75rem;
-  border-radius: 0.3125rem;
+  width: 90px;
+  height: 28px;
+  border-radius: 5px;
   background: var(--blue-4);
   color: var(--white);
-  font-size: 0.75rem;
+  font-size: 12px;
 }
 
 .passwordButton {
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 5.9375rem;
-  height: 1.75rem;
-  border-radius: 0.3125rem;
+  width: 95px;
+  height: 28px;
+  border-radius: 5px;
   background: var(--blue-1);
   color: var(--blue-4);
-  font-size: 0.75rem;
+  font-size: 12px;
 }

--- a/src/feature/my/component/AccountTab/AccountTab.module.css
+++ b/src/feature/my/component/AccountTab/AccountTab.module.css
@@ -2,17 +2,17 @@
 .infoWrapper {
   display: flex;
   flex-direction: column;
-  padding: 4px 13px;
-  margin: 0 20px;
-  border-radius: 5px;
+  padding: 0.4rem 1.3rem;
+  margin: 0 2rem;
+  border-radius: 0.5rem;
   background: var(--gray-1);
 }
 
 .info {
   display: flex;
   flex-direction: column;
-  padding: 10px 0;
-  border-bottom: 1px solid var(--gray-3);
+  padding: 1rem 0;
+  border-bottom: 0.1rem solid var(--gray-3);
 
   &:last-child {
     border-bottom: none;
@@ -21,12 +21,12 @@
 
 .label {
   color: var(--gray-3-1);
-  font-size: 11px;
+  font-size: 1.1rem;
 }
 
 .value {
   color: var(--gray-4);
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 500;
 }
 
@@ -34,30 +34,30 @@
 .buttonWrapper {
   display: flex;
   justify-content: flex-end;
-  gap: 15px;
-  margin: 20px;
+  gap: 1.5rem;
+  margin: 2rem;
 }
 
 .editButton {
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 90px;
-  height: 28px;
-  border-radius: 5px;
+  width: 9rem;
+  height: 2.8rem;
+  border-radius: 0.5rem;
   background: var(--blue-4);
   color: var(--white);
-  font-size: 12px;
+  font-size: 1.2rem;
 }
 
 .passwordButton {
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 95px;
-  height: 28px;
-  border-radius: 5px;
+  width: 9.5rem;
+  height: 2.8rem;
+  border-radius: 0.5rem;
   background: var(--blue-1);
   color: var(--blue-4);
-  font-size: 12px;
+  font-size: 1.2rem;
 }

--- a/src/feature/my/component/AccountTab/AccountTab.module.css
+++ b/src/feature/my/component/AccountTab/AccountTab.module.css
@@ -2,17 +2,17 @@
 .infoWrapper {
   display: flex;
   flex-direction: column;
-  padding: 4px 13px;
-  margin: 0 20px;
-  border-radius: 5px;
+  padding: 0.25rem 0.8125rem;
+  margin: 0 1.25rem;
+  border-radius: 0.3125rem;
   background: var(--gray-1);
 }
 
 .info {
   display: flex;
   flex-direction: column;
-  padding: 10px 0;
-  border-bottom: 1px solid var(--gray-3);
+  padding: 0.625rem 0;
+  border-bottom: 0.0625rem solid var(--gray-3);
 
   &:last-child {
     border-bottom: none;
@@ -21,12 +21,12 @@
 
 .label {
   color: var(--gray-3-1);
-  font-size: 11px;
+  font-size: 0.6875rem;
 }
 
 .value {
   color: var(--gray-4);
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: 500;
 }
 
@@ -34,30 +34,30 @@
 .buttonWrapper {
   display: flex;
   justify-content: flex-end;
-  gap: 15px;
-  margin: 20px;
+  gap: 0.9375rem;
+  margin: 1.25rem;
 }
 
 .editButton {
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 90px;
-  height: 28px;
-  border-radius: 5px;
+  width: 5.625rem;
+  height: 1.75rem;
+  border-radius: 0.3125rem;
   background: var(--blue-4);
   color: var(--white);
-  font-size: 12px;
+  font-size: 0.75rem;
 }
 
 .passwordButton {
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 95px;
-  height: 28px;
-  border-radius: 5px;
+  width: 5.9375rem;
+  height: 1.75rem;
+  border-radius: 0.3125rem;
   background: var(--blue-1);
   color: var(--blue-4);
-  font-size: 12px;
+  font-size: 0.75rem;
 }

--- a/src/feature/my/component/ActivityTab/ActivityTab.module.css
+++ b/src/feature/my/component/ActivityTab/ActivityTab.module.css
@@ -1,15 +1,15 @@
 .infoWrapper {
   display: flex;
   flex-direction: column;
-  padding: 0.25rem 0.8125rem;
-  margin: 0 1.25rem;
-  border-radius: 0.3125rem;
+  padding: 4px 13px;
+  margin: 0 20px;
+  border-radius: 5px;
   background: var(--gray-1);
 }
 
 /* 내 활동, 이용안내 */
 .itemList {
-  border-bottom: 0.0625rem solid var(--gray-3);
+  border-bottom: 1px solid var(--gray-3);
 
   &:last-child {
     border-bottom: none;
@@ -24,13 +24,13 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.75rem 0;
+  padding: 12px 0;
   color: var(--gray-4);
-  font-size: 0.875rem;
+  font-size: 14px;
   font-weight: 500;
 
   svg {
-    width: 1rem;
-    height: 1rem;
+    width: 16px;
+    height: 16px;
   }
 }

--- a/src/feature/my/component/ActivityTab/ActivityTab.module.css
+++ b/src/feature/my/component/ActivityTab/ActivityTab.module.css
@@ -1,15 +1,15 @@
 .infoWrapper {
   display: flex;
   flex-direction: column;
-  padding: 4px 13px;
-  margin: 0 20px;
-  border-radius: 5px;
+  padding: 0.4rem 1.3rem;
+  margin: 0 2rem;
+  border-radius: 0.5rem;
   background: var(--gray-1);
 }
 
 /* 내 활동, 이용안내 */
 .itemList {
-  border-bottom: 1px solid var(--gray-3);
+  border-bottom: 0.1rem solid var(--gray-3);
 
   &:last-child {
     border-bottom: none;
@@ -24,13 +24,13 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 0;
+  padding: 1.2rem 0;
   color: var(--gray-4);
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 500;
 
   svg {
-    width: 16px;
-    height: 16px;
+    width: 1.6rem;
+    height: 1.6rem;
   }
 }

--- a/src/feature/my/component/ActivityTab/ActivityTab.module.css
+++ b/src/feature/my/component/ActivityTab/ActivityTab.module.css
@@ -1,15 +1,15 @@
 .infoWrapper {
   display: flex;
   flex-direction: column;
-  padding: 4px 13px;
-  margin: 0 20px;
-  border-radius: 5px;
+  padding: 0.25rem 0.8125rem;
+  margin: 0 1.25rem;
+  border-radius: 0.3125rem;
   background: var(--gray-1);
 }
 
 /* 내 활동, 이용안내 */
 .itemList {
-  border-bottom: 1px solid var(--gray-3);
+  border-bottom: 0.0625rem solid var(--gray-3);
 
   &:last-child {
     border-bottom: none;
@@ -24,13 +24,13 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 0;
+  padding: 0.75rem 0;
   color: var(--gray-4);
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: 500;
 
   svg {
-    width: 16px;
-    height: 16px;
+    width: 1rem;
+    height: 1rem;
   }
 }

--- a/src/feature/my/component/CircleProfile/CircleProfile.module.css
+++ b/src/feature/my/component/CircleProfile/CircleProfile.module.css
@@ -1,17 +1,17 @@
 .profileImage {
-  width: 135px;
-  height: 135px;
-  padding: 6px;
+  width: 13.5rem;
+  height: 13.5rem;
+  padding: 0.6rem;
   display: flex;
   justify-content: center;
   align-items: center;
   position: absolute;
-  top: 125px;
+  top: 12.5rem;
   left: 50%;
   transform: translateX(-50%);
   z-index: 2;
   overflow: hidden;
-  filter: drop-shadow(0 4px 4px rgba(var(--black-rgb), 0.15));
+  filter: drop-shadow(0 0.4rem 0.4rem rgba(var(--black-rgb), 0.15));
 }
 
 .profileImage img {

--- a/src/feature/my/component/CircleProfile/CircleProfile.module.css
+++ b/src/feature/my/component/CircleProfile/CircleProfile.module.css
@@ -1,17 +1,17 @@
 .profileImage {
-  width: 135px;
-  height: 135px;
-  padding: 6px;
+  width: 8.4375rem;
+  height: 8.4375rem;
+  padding: 0.375rem;
   display: flex;
   justify-content: center;
   align-items: center;
   position: absolute;
-  top: 125px;
+  top: 7.8125rem;
   left: 50%;
   transform: translateX(-50%);
   z-index: 2;
   overflow: hidden;
-  filter: drop-shadow(0 4px 4px rgba(var(--black-rgb), 0.15));
+  filter: drop-shadow(0 0.25rem 0.25rem rgba(var(--black-rgb), 0.15));
 }
 
 .profileImage img {

--- a/src/feature/my/component/CircleProfile/CircleProfile.module.css
+++ b/src/feature/my/component/CircleProfile/CircleProfile.module.css
@@ -1,17 +1,17 @@
 .profileImage {
-  width: 8.4375rem;
-  height: 8.4375rem;
-  padding: 0.375rem;
+  width: 135px;
+  height: 135px;
+  padding: 6px;
   display: flex;
   justify-content: center;
   align-items: center;
   position: absolute;
-  top: 7.8125rem;
+  top: 125px;
   left: 50%;
   transform: translateX(-50%);
   z-index: 2;
   overflow: hidden;
-  filter: drop-shadow(0 0.25rem 0.25rem rgba(var(--black-rgb), 0.15));
+  filter: drop-shadow(0 4px 4px rgba(var(--black-rgb), 0.15));
 }
 
 .profileImage img {

--- a/src/feature/my/component/MyInfo/MyInfo.module.css
+++ b/src/feature/my/component/MyInfo/MyInfo.module.css
@@ -2,14 +2,14 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 72px;
+  margin-top: 7.2rem;
 }
 
 .name {
   color: var(--black);
-  font-size: 18px;
+  font-size: 1.8rem;
   font-weight: 700;
-  margin-bottom: 5px;
+  margin-bottom: 0.5rem;
 }
 
 .studentIdMemberType {
@@ -17,14 +17,14 @@
   justify-content: center;
   align-items: center;
   color: var(--gray-4);
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 500;
-  margin-bottom: 7px;
-  gap: 8px;
+  margin-bottom: 0.7rem;
+  gap: 0.8rem;
 
   svg {
-    width: 3px;
-    height: 3px;
+    width: 0.3rem;
+    height: 0.3rem;
   }
 }
 
@@ -32,29 +32,29 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 10px;
+  gap: 1rem;
 }
 
 .point {
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 24px;
+  height: 2.4rem;
   flex-shrink: 0;
-  border-radius: 5px;
-  padding: 0 11px;
+  border-radius: 0.5rem;
+  padding: 0 1.1rem;
   background: var(--blue-1);
   color: var(--blue-4);
-  font-size: 12px;
-  gap: 4px;
+  font-size: 1.2rem;
+  gap: 0.4rem;
 
   svg {
     display: flex;
     justify-content: center;
     align-items: center;
-    width: 14px;
-    height: 14px;
-    padding: 1px;
+    width: 1.4rem;
+    height: 1.4rem;
+    padding: 0.1rem;
   }
 }
 
@@ -63,11 +63,11 @@
   justify-content: center;
   align-items: center;
   color: var(--blue-4);
-  font-size: 12px;
-  gap: 3px;
+  font-size: 1.2rem;
+  gap: 0.3rem;
 
   svg {
-    width: 14px;
-    height: 14px;
+    width: 1.4rem;
+    height: 1.4rem;
   }
 }

--- a/src/feature/my/component/MyPostList/MyPostList.module.css
+++ b/src/feature/my/component/MyPostList/MyPostList.module.css
@@ -8,7 +8,7 @@
 
 .noContentMessage {
   color: var(--gray-4);
-  font-size: 16px;
+  font-size: 1.6rem;
   font-weight: 500;
 }
 
@@ -26,7 +26,7 @@
 .posts {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 0.8rem;
 }
 
 .to {

--- a/src/feature/my/component/MyPostList/MyPostList.module.css
+++ b/src/feature/my/component/MyPostList/MyPostList.module.css
@@ -8,7 +8,7 @@
 
 .noContentMessage {
   color: var(--gray-4);
-  font-size: 1rem;
+  font-size: 16px;
   font-weight: 500;
 }
 
@@ -26,7 +26,7 @@
 .posts {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 8px;
 }
 
 .to {

--- a/src/feature/my/component/PointLog/PointLog.module.css
+++ b/src/feature/my/component/PointLog/PointLog.module.css
@@ -2,47 +2,47 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-radius: 5px;
+  border-radius: 0.5rem;
   background: var(--gray-1-1);
-  padding: 15px;
+  padding: 1.5rem;
 }
 
 .pointIconContentWrapper {
   display: flex;
   align-items: center;
-  gap: 15px;
+  gap: 1.5rem;
 
   svg {
-    width: 26px;
-    height: 23px;
+    width: 2.6rem;
+    height: 2.3rem;
   }
 }
 
 .pointContent {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: 0.3rem;
 }
 
 .pointTitle {
   color: var(--blue-4);
-  font-size: 12px;
+  font-size: 1.2rem;
   font-weight: 500;
 }
 
 .pointDesc {
   color: var(--gray-4);
-  font-size: 9px;
+  font-size: 0.9rem;
 }
 
 .pointDate {
   color: var(--gray-3-1);
-  font-size: 9px;
+  font-size: 0.9rem;
 }
 
 .chargePoint {
   color: var(--blue-4);
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 500;
 }
 

--- a/src/feature/my/component/PointLog/PointLog.module.css
+++ b/src/feature/my/component/PointLog/PointLog.module.css
@@ -2,47 +2,47 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-radius: 0.3125rem;
+  border-radius: 5px;
   background: var(--gray-1-1);
-  padding: 0.9375rem;
+  padding: 15px;
 }
 
 .pointIconContentWrapper {
   display: flex;
   align-items: center;
-  gap: 0.9375rem;
+  gap: 15px;
 
   svg {
-    width: 1.625rem;
-    height: 1.4375rem;
+    width: 26px;
+    height: 23px;
   }
 }
 
 .pointContent {
   display: flex;
   flex-direction: column;
-  gap: 0.1875rem;
+  gap: 3px;
 }
 
 .pointTitle {
   color: var(--blue-4);
-  font-size: 0.75rem;
+  font-size: 12px;
   font-weight: 500;
 }
 
 .pointDesc {
   color: var(--gray-4);
-  font-size: 0.5625rem;
+  font-size: 9px;
 }
 
 .pointDate {
   color: var(--gray-3-1);
-  font-size: 0.5625rem;
+  font-size: 9px;
 }
 
 .chargePoint {
   color: var(--blue-4);
-  font-size: 0.875rem;
+  font-size: 14px;
   font-weight: 500;
 }
 

--- a/src/feature/my/component/PointLogList/PointLogList.module.css
+++ b/src/feature/my/component/PointLogList/PointLogList.module.css
@@ -1,5 +1,5 @@
 .pointListContainer {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 1rem;
 }

--- a/src/feature/my/component/PointLogList/PointLogList.module.css
+++ b/src/feature/my/component/PointLogList/PointLogList.module.css
@@ -1,5 +1,5 @@
 .pointListContainer {
   display: flex;
   flex-direction: column;
-  gap: 0.625rem;
+  gap: 10px;
 }

--- a/src/feature/my/component/PolicyTab/PolicyTab.module.css
+++ b/src/feature/my/component/PolicyTab/PolicyTab.module.css
@@ -1,14 +1,14 @@
 .infoWrapper {
   display: flex;
   flex-direction: column;
-  padding: 0.25rem 0.8125rem;
-  margin: 0 1.25rem;
-  border-radius: 0.3125rem;
+  padding: 4px 13px;
+  margin: 0 20px;
+  border-radius: 5px;
   background: var(--gray-1);
 }
 
 .itemList {
-  border-bottom: 0.0625rem solid var(--gray-3);
+  border-bottom: 1px solid var(--gray-3);
 
   &:last-child {
     border-bottom: none;
@@ -23,14 +23,14 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.75rem 0;
+  padding: 12px 0;
   color: var(--gray-4);
-  font-size: 0.875rem;
+  font-size: 14px;
   font-weight: 500;
 
   svg {
-    width: 1rem;
-    height: 1rem;
+    width: 16px;
+    height: 16px;
   }
 }
 
@@ -38,30 +38,30 @@
 .buttonWrapper {
   display: flex;
   justify-content: flex-end;
-  gap: 0.9375rem;
-  margin: 1.25rem;
+  gap: 15px;
+  margin: 20px;
 }
 
 .editButton {
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 5.625rem;
-  height: 1.75rem;
-  border-radius: 0.3125rem;
+  width: 90px;
+  height: 28px;
+  border-radius: 5px;
   background: var(--blue-4);
   color: var(--white);
-  font-size: 0.75rem;
+  font-size: 12px;
 }
 
 .passwordButton {
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 5.9375rem;
-  height: 1.75rem;
-  border-radius: 0.3125rem;
+  width: 95px;
+  height: 28px;
+  border-radius: 5px;
   background: var(--blue-1);
   color: var(--blue-4);
-  font-size: 0.75rem;
+  font-size: 12px;
 }

--- a/src/feature/my/component/PolicyTab/PolicyTab.module.css
+++ b/src/feature/my/component/PolicyTab/PolicyTab.module.css
@@ -1,14 +1,14 @@
 .infoWrapper {
   display: flex;
   flex-direction: column;
-  padding: 4px 13px;
-  margin: 0 20px;
-  border-radius: 5px;
+  padding: 0.4rem 1.3rem;
+  margin: 0 2rem;
+  border-radius: 0.5rem;
   background: var(--gray-1);
 }
 
 .itemList {
-  border-bottom: 1px solid var(--gray-3);
+  border-bottom: 0.1rem solid var(--gray-3);
 
   &:last-child {
     border-bottom: none;
@@ -23,14 +23,14 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 0;
+  padding: 1.2rem 0;
   color: var(--gray-4);
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 500;
 
   svg {
-    width: 16px;
-    height: 16px;
+    width: 1.6rem;
+    height: 1.6rem;
   }
 }
 
@@ -38,30 +38,30 @@
 .buttonWrapper {
   display: flex;
   justify-content: flex-end;
-  gap: 15px;
-  margin: 20px;
+  gap: 1.5rem;
+  margin: 2rem;
 }
 
 .editButton {
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 90px;
-  height: 28px;
-  border-radius: 5px;
+  width: 9rem;
+  height: 2.8rem;
+  border-radius: 0.5rem;
   background: var(--blue-4);
   color: var(--white);
-  font-size: 12px;
+  font-size: 1.2rem;
 }
 
 .passwordButton {
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 95px;
-  height: 28px;
-  border-radius: 5px;
+  width: 9.5rem;
+  height: 2.8rem;
+  border-radius: 0.5rem;
   background: var(--blue-1);
   color: var(--blue-4);
-  font-size: 12px;
+  font-size: 1.2rem;
 }

--- a/src/feature/my/component/PolicyTab/PolicyTab.module.css
+++ b/src/feature/my/component/PolicyTab/PolicyTab.module.css
@@ -1,14 +1,14 @@
 .infoWrapper {
   display: flex;
   flex-direction: column;
-  padding: 4px 13px;
-  margin: 0 20px;
-  border-radius: 5px;
+  padding: 0.25rem 0.8125rem;
+  margin: 0 1.25rem;
+  border-radius: 0.3125rem;
   background: var(--gray-1);
 }
 
 .itemList {
-  border-bottom: 1px solid var(--gray-3);
+  border-bottom: 0.0625rem solid var(--gray-3);
 
   &:last-child {
     border-bottom: none;
@@ -23,14 +23,14 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 0;
+  padding: 0.75rem 0;
   color: var(--gray-4);
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: 500;
 
   svg {
-    width: 16px;
-    height: 16px;
+    width: 1rem;
+    height: 1rem;
   }
 }
 
@@ -38,30 +38,30 @@
 .buttonWrapper {
   display: flex;
   justify-content: flex-end;
-  gap: 15px;
-  margin: 20px;
+  gap: 0.9375rem;
+  margin: 1.25rem;
 }
 
 .editButton {
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 90px;
-  height: 28px;
-  border-radius: 5px;
+  width: 5.625rem;
+  height: 1.75rem;
+  border-radius: 0.3125rem;
   background: var(--blue-4);
   color: var(--white);
-  font-size: 12px;
+  font-size: 0.75rem;
 }
 
 .passwordButton {
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 95px;
-  height: 28px;
-  border-radius: 5px;
+  width: 5.9375rem;
+  height: 1.75rem;
+  border-radius: 0.3125rem;
   background: var(--blue-1);
   color: var(--blue-4);
-  font-size: 12px;
+  font-size: 0.75rem;
 }

--- a/src/feature/my/component/TopOverlay/TopOverlay.module.css
+++ b/src/feature/my/component/TopOverlay/TopOverlay.module.css
@@ -1,7 +1,7 @@
 /* 상단 배경 */
 .myPageUpper {
   width: 100%;
-  height: 197px;
+  height: 12.3125rem;
   opacity: 0.8;
   z-index: 1;
 }
@@ -11,7 +11,7 @@
   top: 0;
   left: 0;
   width: 100%;
-  height: 434px;
+  height: 27.125rem;
   opacity: 0.8;
   background-image: url('/src/assets/images/symbol_White.png');
   background-size: cover;
@@ -21,9 +21,9 @@
 
 .editIcon {
   position: absolute;
-  top: 6px;
-  right: 6px;
-  padding: 20px;
-  width: 20px;
-  height: 20px;
+  top: 0.375rem;
+  right: 0.375rem;
+  padding: 1.25rem;
+  width: 1.25rem;
+  height: 1.25rem;
 }

--- a/src/feature/my/component/TopOverlay/TopOverlay.module.css
+++ b/src/feature/my/component/TopOverlay/TopOverlay.module.css
@@ -1,7 +1,7 @@
 /* 상단 배경 */
 .myPageUpper {
   width: 100%;
-  height: 197px;
+  height: 19.7rem;
   opacity: 0.8;
   z-index: 1;
 }
@@ -11,7 +11,7 @@
   top: 0;
   left: 0;
   width: 100%;
-  height: 434px;
+  height: 43.4rem;
   opacity: 0.8;
   background-image: url('/src/assets/images/symbol_White.png');
   background-size: cover;
@@ -21,9 +21,9 @@
 
 .editIcon {
   position: absolute;
-  top: 6px;
-  right: 6px;
-  padding: 20px;
-  width: 20px;
-  height: 20px;
+  top: 0.6rem;
+  right: 0.6rem;
+  padding: 2rem;
+  width: 2rem;
+  height: 2rem;
 }

--- a/src/feature/my/component/TopOverlay/TopOverlay.module.css
+++ b/src/feature/my/component/TopOverlay/TopOverlay.module.css
@@ -1,7 +1,7 @@
 /* 상단 배경 */
 .myPageUpper {
   width: 100%;
-  height: 12.3125rem;
+  height: 197px;
   opacity: 0.8;
   z-index: 1;
 }
@@ -11,7 +11,7 @@
   top: 0;
   left: 0;
   width: 100%;
-  height: 27.125rem;
+  height: 434px;
   opacity: 0.8;
   background-image: url('/src/assets/images/symbol_White.png');
   background-size: cover;
@@ -21,9 +21,9 @@
 
 .editIcon {
   position: absolute;
-  top: 0.375rem;
-  right: 0.375rem;
-  padding: 1.25rem;
-  width: 1.25rem;
-  height: 1.25rem;
+  top: 6px;
+  right: 6px;
+  padding: 20px;
+  width: 20px;
+  height: 20px;
 }

--- a/src/feature/search/component/Search/Search.module.css
+++ b/src/feature/search/component/Search/Search.module.css
@@ -1,11 +1,11 @@
 .container {
   width: 100%;
-  padding: 0.6875rem 0.75rem;
+  padding: 11px 12px;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 8px;
   background: var(--gray-1-1);
-  border-radius: 0.3125rem;
+  border-radius: 5px;
 }
 
 .search {
@@ -13,11 +13,11 @@
   outline: none;
   border: none;
   background-color: transparent;
-  font-size: 0.75rem;
+  font-size: 12px;
   color: var(--black);
 }
 
 .search::placeholder {
-  font-size: 0.75rem;
+  font-size: 12px;
   color: var(--gray-3-1);
 }

--- a/src/feature/search/component/Search/Search.module.css
+++ b/src/feature/search/component/Search/Search.module.css
@@ -1,11 +1,11 @@
 .container {
   width: 100%;
-  padding: 11px 12px;
+  padding: 1.1rem 1.2rem;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 0.8rem;
   background: var(--gray-1-1);
-  border-radius: 5px;
+  border-radius: 0.5rem;
 }
 
 .search {
@@ -13,11 +13,11 @@
   outline: none;
   border: none;
   background-color: transparent;
-  font-size: 12px;
+  font-size: 1.2rem;
   color: var(--black);
 }
 
 .search::placeholder {
-  font-size: 12px;
+  font-size: 1.2rem;
   color: var(--gray-3-1);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -131,7 +131,7 @@ button {
 
 html {
   background-color: #dfdfdf;
-  /* font-size: 62.5%; */
+  font-size: 62.5%;
 }
 
 body {

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 :root {
-  --default-width: 37.5rem;
-  --default-margin: 1.25rem;
+  --default-width: 600px;
+  --default-margin: 20px;
 
   /* Color */
 
@@ -90,7 +90,7 @@ pre {
   box-sizing: border-box;
   font: inherit;
   vertical-align: baseline;
-  letter-spacing: -0.0313rem;
+  letter-spacing: -0.5008px;
 }
 
 p,
@@ -180,7 +180,7 @@ code {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.25rem;
+  gap: 4px;
   position: fixed;
   top: 50%;
   left: 50%;
@@ -189,14 +189,14 @@ code {
 }
 
 .react-calendar {
-  margin: 0 1.25rem;
+  margin: 0 20px;
   background-color: rgba(95, 133, 191, 0.4);
-  border-radius: 0.3125rem;
+  border-radius: 5px;
   border: none;
 }
 
-@media screen and (max-width: 25rem) {
+@media screen and (max-width: 400px) {
   html {
-    font-size: 0.875rem;
+    font-size: 14px;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -195,8 +195,8 @@ code {
   border: none;
 }
 
-@media screen and (max-width: 40rem) {
+/* @media screen and (max-width: 400px) {
   html {
-    font-size: 1.4rem;
+    font-size: 55%
   }
-}
+} */

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 :root {
-  --default-width: 600px;
-  --default-margin: 20px;
+  --default-width: 60rem;
+  --default-margin: 2rem;
 
   /* Color */
 
@@ -90,7 +90,7 @@ pre {
   box-sizing: border-box;
   font: inherit;
   vertical-align: baseline;
-  letter-spacing: -0.5008px;
+  letter-spacing: -0.05rem;
 }
 
 p,
@@ -180,7 +180,7 @@ code {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
+  gap: 0.4rem;
   position: fixed;
   top: 50%;
   left: 50%;
@@ -189,14 +189,14 @@ code {
 }
 
 .react-calendar {
-  margin: 0 20px;
+  margin: 0 2rem;
   background-color: rgba(95, 133, 191, 0.4);
-  border-radius: 5px;
+  border-radius: 0.5rem;
   border: none;
 }
 
-@media screen and (max-width: 400px) {
+@media screen and (max-width: 40rem) {
   html {
-    font-size: 14px;
+    font-size: 1.4rem;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,5 @@
 :root {
-  --default-width: 600px;
+  --default-width: 37.5rem;
   --default-margin: 1.25rem;
 
   /* Color */
@@ -90,7 +90,7 @@ pre {
   box-sizing: border-box;
   font: inherit;
   vertical-align: baseline;
-  letter-spacing: -0.5px;
+  letter-spacing: -0.0313rem;
 }
 
 p,
@@ -131,6 +131,7 @@ button {
 
 html {
   background-color: #dfdfdf;
+  /* font-size: 62.5%; */
 }
 
 body {
@@ -179,7 +180,7 @@ code {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
+  gap: 0.25rem;
   position: fixed;
   top: 50%;
   left: 50%;
@@ -194,8 +195,8 @@ code {
   border: none;
 }
 
-@media screen and (max-width: 400px) {
+@media screen and (max-width: 25rem) {
   html {
-    font-size: 14px;
+    font-size: 0.875rem;
   }
 }

--- a/src/page/account/FindIdPage/FindIdPage.module.css
+++ b/src/page/account/FindIdPage/FindIdPage.module.css
@@ -5,7 +5,7 @@
   justify-content: center;
   align-items: center;
   overflow-y: scroll;
-  padding: 0 1.25rem;
+  padding: 0 20px;
 }
 
 .pageFrame form {
@@ -13,8 +13,8 @@
   height: 100%;
 }
 .back {
-  margin-top: 0.875rem;
-  margin-bottom: 0.875rem;
+  margin-top: 14px;
+  margin-bottom: 14px;
 }
 .back:hover {
   cursor: pointer;
@@ -29,31 +29,31 @@
 }
 
 .arrowLeft {
-  margin-top: 0.875rem;
-  margin-bottom: 1.703rem;
+  margin-top: 14px;
+  margin-bottom: 27.248px;
 }
 
 .pageTitle {
-  font-size: 1.25rem;
+  font-size: 20px;
   font-weight: 700;
-  margin-top: 0.875rem;
-  margin-bottom: 3.5rem;
+  margin-top: 14px;
+  margin-bottom: 56px;
 }
 
 .inputFrame {
-  margin-bottom: 1.5rem;
+  margin-bottom: 24px;
 }
 
 .buttonFrame {
-  margin-top: 1.5rem;
-  margin-bottom: 2.125rem;
+  margin-top: 24px;
+  margin-bottom: 34px;
 }
 
 .alert {
-  font-size: 0.75rem;
+  font-size: 12px;
   color: grey;
-  padding: 0 2rem;
-  margin-top: 3rem;
+  padding: 0 32px;
+  margin-top: 48px;
   line-height: 1.7;
   word-break: keep-all;
 }

--- a/src/page/account/FindIdPage/FindIdPage.module.css
+++ b/src/page/account/FindIdPage/FindIdPage.module.css
@@ -5,7 +5,7 @@
   justify-content: center;
   align-items: center;
   overflow-y: scroll;
-  padding: 0 20px;
+  padding: 0 2rem;
 }
 
 .pageFrame form {
@@ -13,8 +13,8 @@
   height: 100%;
 }
 .back {
-  margin-top: 14px;
-  margin-bottom: 14px;
+  margin-top: 1.4rem;
+  margin-bottom: 1.4rem;
 }
 .back:hover {
   cursor: pointer;
@@ -29,31 +29,31 @@
 }
 
 .arrowLeft {
-  margin-top: 14px;
-  margin-bottom: 27.248px;
+  margin-top: 1.4rem;
+  margin-bottom: 2.7rem;
 }
 
 .pageTitle {
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: 700;
-  margin-top: 14px;
-  margin-bottom: 56px;
+  margin-top: 1.4rem;
+  margin-bottom: 5.6rem;
 }
 
 .inputFrame {
-  margin-bottom: 24px;
+  margin-bottom: 2.4rem;
 }
 
 .buttonFrame {
-  margin-top: 24px;
-  margin-bottom: 34px;
+  margin-top: 2.4rem;
+  margin-bottom: 3.4rem;
 }
 
 .alert {
-  font-size: 12px;
+  font-size: 1.2rem;
   color: grey;
-  padding: 0 32px;
-  margin-top: 48px;
+  padding: 0 3.2rem;
+  margin-top: 4.8rem;
   line-height: 1.7;
   word-break: keep-all;
 }

--- a/src/page/account/FindIdPage/FindIdPage.module.css
+++ b/src/page/account/FindIdPage/FindIdPage.module.css
@@ -50,7 +50,7 @@
 }
 
 .alert {
-  font-size: 12px;
+  font-size: 0.75rem;
   color: grey;
   padding: 0 2rem;
   margin-top: 3rem;

--- a/src/page/account/FindPwPage/FindPwPage.module.css
+++ b/src/page/account/FindPwPage/FindPwPage.module.css
@@ -5,7 +5,7 @@
   justify-content: center;
   align-items: center;
   overflow-y: scroll;
-  padding: 0 20px;
+  padding: 0 2rem;
 }
 
 .pageFrame form {
@@ -25,32 +25,32 @@
 }
 
 .back {
-  margin-top: 14px;
-  margin-bottom: 14px;
+  margin-top: 1.4rem;
+  margin-bottom: 1.4rem;
 }
 .back:hover {
   cursor: pointer;
 }
 
 .pageTitle {
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: 700;
-  margin-top: 14px;
-  margin-bottom: 56px;
+  margin-top: 1.4rem;
+  margin-bottom: 5.6rem;
 }
 
 .inputFrame {
-  margin-bottom: 24px;
+  margin-bottom: 2.4rem;
 }
 
 .buttonFrame {
 }
 
 .alert {
-  font-size: 12px;
+  font-size: 1.2rem;
   color: grey;
-  padding: 0 32px;
-  margin-top: 48px;
+  padding: 0 3.2rem;
+  margin-top: 4.8rem;
   line-height: 1.7;
   word-break: keep-all;
 }
@@ -66,6 +66,6 @@
   justify-content: center;
   align-items: center;
   color: var(--gray-4);
-  font-size: 12px;
-  margin: 21.008px 0;
+  font-size: 1.2rem;
+  margin: 2.1rem 0;
 }

--- a/src/page/account/FindPwPage/FindPwPage.module.css
+++ b/src/page/account/FindPwPage/FindPwPage.module.css
@@ -47,7 +47,7 @@
 }
 
 .alert {
-  font-size: 12px;
+  font-size: 0.75rem;
   color: grey;
   padding: 0 2rem;
   margin-top: 3rem;

--- a/src/page/account/FindPwPage/FindPwPage.module.css
+++ b/src/page/account/FindPwPage/FindPwPage.module.css
@@ -5,7 +5,7 @@
   justify-content: center;
   align-items: center;
   overflow-y: scroll;
-  padding: 0 1.25rem;
+  padding: 0 20px;
 }
 
 .pageFrame form {
@@ -25,32 +25,32 @@
 }
 
 .back {
-  margin-top: 0.875rem;
-  margin-bottom: 0.875rem;
+  margin-top: 14px;
+  margin-bottom: 14px;
 }
 .back:hover {
   cursor: pointer;
 }
 
 .pageTitle {
-  font-size: 1.25rem;
+  font-size: 20px;
   font-weight: 700;
-  margin-top: 0.875rem;
-  margin-bottom: 3.5rem;
+  margin-top: 14px;
+  margin-bottom: 56px;
 }
 
 .inputFrame {
-  margin-bottom: 1.5rem;
+  margin-bottom: 24px;
 }
 
 .buttonFrame {
 }
 
 .alert {
-  font-size: 0.75rem;
+  font-size: 12px;
   color: grey;
-  padding: 0 2rem;
-  margin-top: 3rem;
+  padding: 0 32px;
+  margin-top: 48px;
   line-height: 1.7;
   word-break: keep-all;
 }
@@ -66,6 +66,6 @@
   justify-content: center;
   align-items: center;
   color: var(--gray-4);
-  font-size: 0.75rem;
-  margin: 1.313rem 0;
+  font-size: 12px;
+  margin: 21.008px 0;
 }

--- a/src/page/account/FoundIdPage/FoundIdPage.module.css
+++ b/src/page/account/FoundIdPage/FoundIdPage.module.css
@@ -8,24 +8,24 @@
 }
 
 .pageTopFrame {
-  padding: 0 1.25rem;
+  padding: 0 20px;
 }
 
 .pageTitle {
-  font-size: 1.25rem;
+  font-size: 20px;
   font-weight: 700;
-  margin-top: 3.2rem;
+  margin-top: 51.2px;
 }
 
 .pageExplanation {
-  font-size: 0.875rem;
+  font-size: 14px;
   font-weight: 500;
   color: var(--gray-4);
-  margin-top: 0.875rem;
+  margin-top: 14px;
 }
 
 .pageBottomFrame {
-  padding: 0 1.25rem;
+  padding: 0 20px;
   display: flex;
   flex-direction: column;
 }
@@ -40,22 +40,22 @@
 .resultFrame {
   display: flex;
   flex-direction: column;
-  margin-top: 1rem;
+  margin-top: 16px;
 }
 
 .result {
-  margin-top: 0.6rem;
-  font-size: 1.563rem;
+  margin-top: 9.6px;
+  font-size: 25.008px;
   font-weight: 700;
   color: var(--blue-4);
 }
 
 .dot {
-  height: 0.375rem;
-  width: 0.375rem;
+  height: 6px;
+  width: 6px;
   border-radius: 50%;
   display: inline-block;
-  margin-bottom: 0.438rem;
+  margin-bottom: 7.008px;
 }
 
 .first {
@@ -77,14 +77,14 @@
 }
 
 .loginButton {
-  margin-bottom: 1.125rem;
+  margin-bottom: 18px;
 }
 
 .findPWButton {
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-bottom: 2.875rem;
+  margin-bottom: 46px;
   color: var(--gray-4);
-  font-size: 0.75rem;
+  font-size: 12px;
 }

--- a/src/page/account/FoundIdPage/FoundIdPage.module.css
+++ b/src/page/account/FoundIdPage/FoundIdPage.module.css
@@ -8,24 +8,24 @@
 }
 
 .pageTopFrame {
-  padding: 0 20px;
+  padding: 0 2rem;
 }
 
 .pageTitle {
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: 700;
-  margin-top: 51.2px;
+  margin-top: 5.1rem;
 }
 
 .pageExplanation {
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 500;
   color: var(--gray-4);
-  margin-top: 14px;
+  margin-top: 1.4rem;
 }
 
 .pageBottomFrame {
-  padding: 0 20px;
+  padding: 0 2rem;
   display: flex;
   flex-direction: column;
 }
@@ -40,22 +40,22 @@
 .resultFrame {
   display: flex;
   flex-direction: column;
-  margin-top: 16px;
+  margin-top: 1.6rem;
 }
 
 .result {
-  margin-top: 9.6px;
-  font-size: 25.008px;
+  margin-top: 1;
+  font-size: 2.5rem;
   font-weight: 700;
   color: var(--blue-4);
 }
 
 .dot {
-  height: 6px;
-  width: 6px;
+  height: 0.6rem;
+  width: 0.6rem;
   border-radius: 50%;
   display: inline-block;
-  margin-bottom: 7.008px;
+  margin-bottom: 0.7rem;
 }
 
 .first {
@@ -77,14 +77,14 @@
 }
 
 .loginButton {
-  margin-bottom: 18px;
+  margin-bottom: 1.8rem;
 }
 
 .findPWButton {
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-bottom: 46px;
+  margin-bottom: 4.6rem;
   color: var(--gray-4);
-  font-size: 12px;
+  font-size: 1.2rem;
 }

--- a/src/page/account/FoundPwPage/FoundPwPage.module.css
+++ b/src/page/account/FoundPwPage/FoundPwPage.module.css
@@ -8,29 +8,29 @@
 }
 
 .pageTopFrame {
-  padding: 0 20px;
+  padding: 0 2rem;
   display: flex;
   flex-direction: column;
 }
 
 .pageTitle {
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: 700;
-  margin-top: 51.2px;
-  margin-bottom: 13.008px;
+  margin-top: 5.1rem;
+  margin-bottom: 1.3rem;
 }
 
 .pageSubtitle {
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 500;
   color: var(--gray-4);
-  margin-bottom: 13.008px;
+  margin-bottom: 1.3rem;
 }
 
 .pageExplanation {
-  font-size: 12px;
+  font-size: 1.2rem;
   color: var(--gray-3-1);
-  margin-bottom: 16px;
+  margin-bottom: 1.6rem;
 }
 
 .pageMiddleFrame {
@@ -40,7 +40,7 @@
 }
 
 .pageBottomFrame {
-  padding: 0 20px;
+  padding: 0 2rem;
   display: flex;
   flex-direction: column;
 }
@@ -53,22 +53,22 @@
 .result {
   display: flex;
   align-items: center;
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: 700;
   color: var(--blue-4);
-  margin-top: 8px;
+  margin-top: 0.8rem;
 }
 
 .result p {
-  margin-right: 10.192px;
+  margin-right: 1rem;
 }
 
 .dot {
-  height: 6px;
-  width: 6px;
+  height: 0.6rem;
+  width: 0.6rem;
   border-radius: 50%;
   display: inline-block;
-  margin-bottom: 7.008px;
+  margin-bottom: 0.7rem;
 }
 
 .first {
@@ -84,21 +84,21 @@
 }
 
 .img {
-  width: 239.008px;
-  height: 258px;
-  margin-bottom: 30px;
+  width: 24rem;
+  height: 25.8rem;
+  margin-bottom: 3rem;
   margin-left: auto;
 }
 
 .loginButton {
-  margin-bottom: 34px;
+  margin-bottom: 3.4rem;
 }
 
 .findPWButton {
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-bottom: 46px;
+  margin-bottom: 4.6rem;
   color: var(--gray-4);
-  font-size: 12px;
+  font-size: 1.2rem;
 }

--- a/src/page/account/FoundPwPage/FoundPwPage.module.css
+++ b/src/page/account/FoundPwPage/FoundPwPage.module.css
@@ -8,29 +8,29 @@
 }
 
 .pageTopFrame {
-  padding: 0 1.25rem;
+  padding: 0 20px;
   display: flex;
   flex-direction: column;
 }
 
 .pageTitle {
-  font-size: 1.25rem;
+  font-size: 20px;
   font-weight: 700;
-  margin-top: 3.2rem;
-  margin-bottom: 0.813rem;
+  margin-top: 51.2px;
+  margin-bottom: 13.008px;
 }
 
 .pageSubtitle {
-  font-size: 0.875rem;
+  font-size: 14px;
   font-weight: 500;
   color: var(--gray-4);
-  margin-bottom: 0.813rem;
+  margin-bottom: 13.008px;
 }
 
 .pageExplanation {
-  font-size: 0.75rem;
+  font-size: 12px;
   color: var(--gray-3-1);
-  margin-bottom: 1rem;
+  margin-bottom: 16px;
 }
 
 .pageMiddleFrame {
@@ -40,7 +40,7 @@
 }
 
 .pageBottomFrame {
-  padding: 0 1.25rem;
+  padding: 0 20px;
   display: flex;
   flex-direction: column;
 }
@@ -53,22 +53,22 @@
 .result {
   display: flex;
   align-items: center;
-  font-size: 1.25rem;
+  font-size: 20px;
   font-weight: 700;
   color: var(--blue-4);
-  margin-top: 0.5rem;
+  margin-top: 8px;
 }
 
 .result p {
-  margin-right: 0.637rem;
+  margin-right: 10.192px;
 }
 
 .dot {
-  height: 0.375rem;
-  width: 0.375rem;
+  height: 6px;
+  width: 6px;
   border-radius: 50%;
   display: inline-block;
-  margin-bottom: 0.438rem;
+  margin-bottom: 7.008px;
 }
 
 .first {
@@ -84,21 +84,21 @@
 }
 
 .img {
-  width: 14.938rem;
-  height: 16.125rem;
-  margin-bottom: 1.875rem;
+  width: 239.008px;
+  height: 258px;
+  margin-bottom: 30px;
   margin-left: auto;
 }
 
 .loginButton {
-  margin-bottom: 2.125rem;
+  margin-bottom: 34px;
 }
 
 .findPWButton {
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-bottom: 2.875rem;
+  margin-bottom: 46px;
   color: var(--gray-4);
-  font-size: 0.75rem;
+  font-size: 12px;
 }

--- a/src/page/account/LoginPage/LoginPage.module.css
+++ b/src/page/account/LoginPage/LoginPage.module.css
@@ -14,15 +14,15 @@ a:hover {
 }
 
 .back {
-  margin-top: 14px;
+  margin-top: 1.4rem;
 }
 .back:hover {
   cursor: pointer;
 }
 
 .loginBody {
-  padding: 0 20px;
-  font-size: 9px;
+  padding: 0 2rem;
+  font-size: 0.9rem;
   text-align: center;
   font-family: 'Noto Sans KR', sans-serif;
 }
@@ -30,30 +30,30 @@ a:hover {
 .logo {
   margin-left: auto;
   margin-right: auto;
-  margin-top: 102.672px;
-  margin-bottom: 24.608px;
+  margin-top: 10.3rem;
+  margin-bottom: 2.5rem;
 }
 
 .title {
-  font-size: 14px;
+  font-size: 1.4rem;
   font-style: normal;
-  margin-bottom: 57.232px;
+  margin-bottom: 5.7rem;
 }
 
 .input {
-  margin-bottom: 17.008px;
+  margin-bottom: 1.7rem;
 }
 
 .pwFrame {
   width: 100%;
   display: flex;
   align-items: center;
-  height: 41.008px;
-  border-radius: 6px;
-  border-top-right-radius: 6px;
-  border-bottom-right-radius: 6px;
-  padding-right: 10px;
-  margin-bottom: 16px;
+  height: 4.1rem;
+  border-radius: 0.6rem;
+  border-top-right-radius: 0.6rem;
+  border-bottom-right-radius: 0.6rem;
+  padding-right: 1rem;
+  margin-bottom: 1.6rem;
 }
 
 .ready {
@@ -80,31 +80,31 @@ a:hover {
 
 .button {
   display: block;
-  width: 180px;
-  height: 32px;
+  width: 18rem;
+  height: 3.2rem;
   background-color: var(--blue-4);
   color: var(--white);
-  margin: 18px auto;
-  border-radius: 7px;
+  margin: 1.8rem auto;
+  border-radius: 0.7rem;
 }
 
 .find {
   display: flex;
   justify-content: center;
   color: var(--gray-3-1);
-  font-size: 12px;
-  margin-top: 37.008px;
-  margin-bottom: 12px;
+  font-size: 1.2rem;
+  margin-top: 3.7rem;
+  margin-bottom: 1.2rem;
 }
 
 .divider {
-  margin: 0 11.008px;
+  margin: 0 1.1rem;
 }
 
 .signUp {
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 4px;
-  font-size: 14px;
+  gap: 0.4rem;
+  font-size: 1.4rem;
 }

--- a/src/page/account/LoginPage/LoginPage.module.css
+++ b/src/page/account/LoginPage/LoginPage.module.css
@@ -14,15 +14,15 @@ a:hover {
 }
 
 .back {
-  margin-top: 0.875rem;
+  margin-top: 14px;
 }
 .back:hover {
   cursor: pointer;
 }
 
 .loginBody {
-  padding: 0 1.25rem;
-  font-size: 0.5625rem;
+  padding: 0 20px;
+  font-size: 9px;
   text-align: center;
   font-family: 'Noto Sans KR', sans-serif;
 }
@@ -30,30 +30,30 @@ a:hover {
 .logo {
   margin-left: auto;
   margin-right: auto;
-  margin-top: 6.417rem;
-  margin-bottom: 1.538rem;
+  margin-top: 102.672px;
+  margin-bottom: 24.608px;
 }
 
 .title {
-  font-size: 0.875rem;
+  font-size: 14px;
   font-style: normal;
-  margin-bottom: 3.577rem;
+  margin-bottom: 57.232px;
 }
 
 .input {
-  margin-bottom: 1.063rem;
+  margin-bottom: 17.008px;
 }
 
 .pwFrame {
   width: 100%;
   display: flex;
   align-items: center;
-  height: 2.563rem;
-  border-radius: 0.375rem;
-  border-top-right-radius: 0.375rem;
-  border-bottom-right-radius: 0.375rem;
-  padding-right: 0.625rem;
-  margin-bottom: 1rem;
+  height: 41.008px;
+  border-radius: 6px;
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
+  padding-right: 10px;
+  margin-bottom: 16px;
 }
 
 .ready {
@@ -80,31 +80,31 @@ a:hover {
 
 .button {
   display: block;
-  width: 11.25rem;
-  height: 2rem;
+  width: 180px;
+  height: 32px;
   background-color: var(--blue-4);
   color: var(--white);
-  margin: 1.125rem auto;
-  border-radius: 0.4375rem;
+  margin: 18px auto;
+  border-radius: 7px;
 }
 
 .find {
   display: flex;
   justify-content: center;
   color: var(--gray-3-1);
-  font-size: 0.75rem;
-  margin-top: 2.313rem;
-  margin-bottom: 0.75rem;
+  font-size: 12px;
+  margin-top: 37.008px;
+  margin-bottom: 12px;
 }
 
 .divider {
-  margin: 0 0.688rem;
+  margin: 0 11.008px;
 }
 
 .signUp {
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 0.25rem;
-  font-size: 0.875rem;
+  gap: 4px;
+  font-size: 14px;
 }

--- a/src/page/account/LoginPage/LoginPage.module.css
+++ b/src/page/account/LoginPage/LoginPage.module.css
@@ -105,6 +105,6 @@ a:hover {
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 4px;
+  gap: 0.25rem;
   font-size: 0.875rem;
 }

--- a/src/page/account/NotFoundIdPage/NotFoundIdPage.module.css
+++ b/src/page/account/NotFoundIdPage/NotFoundIdPage.module.css
@@ -23,33 +23,33 @@
 
 .explanation {
   height: fit-content;
-  padding: 0 20px;
+  padding: 0 2rem;
 }
 
 .pageTitle {
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: 700;
-  margin-top: 51.2px;
+  margin-top: 5.1rem;
 }
 
 .pageExplanation {
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 500;
   color: var(--gray-4);
-  margin-top: 14px;
+  margin-top: 1.4rem;
 }
 
 .pageBottomFrame {
-  padding: 0 20px;
+  padding: 0 2rem;
   display: flex;
   flex-direction: column;
 }
 
 .goBackButton {
   display: block;
-  margin-bottom: 8px;
+  margin-bottom: 0.8rem;
 }
 
 .loginButton {
-  margin-bottom: 33.008px;
+  margin-bottom: 3.3rem;
 }

--- a/src/page/account/NotFoundIdPage/NotFoundIdPage.module.css
+++ b/src/page/account/NotFoundIdPage/NotFoundIdPage.module.css
@@ -23,33 +23,33 @@
 
 .explanation {
   height: fit-content;
-  padding: 0 1.25rem;
+  padding: 0 20px;
 }
 
 .pageTitle {
-  font-size: 1.25rem;
+  font-size: 20px;
   font-weight: 700;
-  margin-top: 3.2rem;
+  margin-top: 51.2px;
 }
 
 .pageExplanation {
-  font-size: 0.875rem;
+  font-size: 14px;
   font-weight: 500;
   color: var(--gray-4);
-  margin-top: 0.875rem;
+  margin-top: 14px;
 }
 
 .pageBottomFrame {
-  padding: 0 1.25rem;
+  padding: 0 20px;
   display: flex;
   flex-direction: column;
 }
 
 .goBackButton {
   display: block;
-  margin-bottom: 0.5rem;
+  margin-bottom: 8px;
 }
 
 .loginButton {
-  margin-bottom: 2.063rem;
+  margin-bottom: 33.008px;
 }

--- a/src/page/account/NotFoundPwPage/NotFoundPwPage.module.css
+++ b/src/page/account/NotFoundPwPage/NotFoundPwPage.module.css
@@ -15,40 +15,40 @@
 }
 
 .pageTopFrame {
-  padding: 0 1.25rem;
+  padding: 0 20px;
 }
 
 .pageTitle {
-  font-size: 1.25rem;
+  font-size: 20px;
   font-weight: 700;
-  margin-top: 3.2rem;
+  margin-top: 51.2px;
 }
 
 .pageExplanation {
-  font-size: 0.875rem;
+  font-size: 14px;
   font-weight: 500;
   color: var(--gray-4);
-  margin-top: 0.875rem;
+  margin-top: 14px;
 }
 
 .pageBottomFrame {
-  padding: 0 1.25rem;
+  padding: 0 20px;
   display: flex;
   flex-direction: column;
 }
 
 .img {
-  width: 13.25rem;
-  height: 14.5rem;
-  margin-bottom: 1.875rem;
+  width: 212px;
+  height: 232px;
+  margin-bottom: 30px;
   margin-left: auto;
 }
 
 .goBackButton {
   display: block;
-  margin-bottom: 0.5rem;
+  margin-bottom: 8px;
 }
 
 .loginButton {
-  margin-bottom: 2.063rem;
+  margin-bottom: 33.008px;
 }

--- a/src/page/account/NotFoundPwPage/NotFoundPwPage.module.css
+++ b/src/page/account/NotFoundPwPage/NotFoundPwPage.module.css
@@ -15,40 +15,40 @@
 }
 
 .pageTopFrame {
-  padding: 0 20px;
+  padding: 0 2rem;
 }
 
 .pageTitle {
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: 700;
-  margin-top: 51.2px;
+  margin-top: 5.1rem;
 }
 
 .pageExplanation {
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 500;
   color: var(--gray-4);
-  margin-top: 14px;
+  margin-top: 1.4rem;
 }
 
 .pageBottomFrame {
-  padding: 0 20px;
+  padding: 0 2rem;
   display: flex;
   flex-direction: column;
 }
 
 .img {
-  width: 212px;
-  height: 232px;
-  margin-bottom: 30px;
+  width: 21.2rem;
+  height: 23.2rem;
+  margin-bottom: 3rem;
   margin-left: auto;
 }
 
 .goBackButton {
   display: block;
-  margin-bottom: 8px;
+  margin-bottom: 0.8rem;
 }
 
 .loginButton {
-  margin-bottom: 33.008px;
+  margin-bottom: 3.3rem;
 }

--- a/src/page/account/SignUpFailure/SignUpFailurePage.module.css
+++ b/src/page/account/SignUpFailure/SignUpFailurePage.module.css
@@ -9,20 +9,20 @@
 }
 
 .pageTopFrame {
-  padding: 0 1.25rem;
+  padding: 0 20px;
 }
 
 .pageTitle {
-  font-size: 1.25rem;
+  font-size: 20px;
   font-weight: 700;
-  margin-top: 3.2rem;
+  margin-top: 51.2px;
 }
 
 .pageExplanation {
-  font-size: 0.875rem;
+  font-size: 14px;
   font-weight: 500;
   color: var(--gray-4);
-  margin-top: 0.875rem;
+  margin-top: 14px;
 }
 
 .pageMiddleFrame {
@@ -32,18 +32,18 @@
 }
 
 .pageBottomFrame {
-  padding: 0 1.25rem;
+  padding: 0 20px;
   display: flex;
   flex-direction: column;
 }
 
 .img {
-  width: 13.25rem;
-  height: 14.5rem;
-  margin-bottom: 1.875rem;
+  width: 212px;
+  height: 232px;
+  margin-bottom: 30px;
   margin-left: auto;
 }
 
 .loginButton {
-  margin-bottom: 2.063rem;
+  margin-bottom: 33.008px;
 }

--- a/src/page/account/SignUpFailure/SignUpFailurePage.module.css
+++ b/src/page/account/SignUpFailure/SignUpFailurePage.module.css
@@ -9,20 +9,20 @@
 }
 
 .pageTopFrame {
-  padding: 0 20px;
+  padding: 0 2rem;
 }
 
 .pageTitle {
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: 700;
-  margin-top: 51.2px;
+  margin-top: 5.1rem;
 }
 
 .pageExplanation {
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 500;
   color: var(--gray-4);
-  margin-top: 14px;
+  margin-top: 1.4rem;
 }
 
 .pageMiddleFrame {
@@ -32,18 +32,18 @@
 }
 
 .pageBottomFrame {
-  padding: 0 20px;
+  padding: 0 2rem;
   display: flex;
   flex-direction: column;
 }
 
 .img {
-  width: 212px;
-  height: 232px;
-  margin-bottom: 30px;
+  width: 21.2rem;
+  height: 23.2rem;
+  margin-bottom: 3rem;
   margin-left: auto;
 }
 
 .loginButton {
-  margin-bottom: 33.008px;
+  margin-bottom: 3.3rem;
 }

--- a/src/page/account/SignUpPage/SignUpPage.jsx
+++ b/src/page/account/SignUpPage/SignUpPage.jsx
@@ -35,9 +35,9 @@ export default function SignUpPage() {
           <StageDots
             quantity={3}
             current={stage}
-            width='50px'
-            size='10px'
-            gap='11.008px'
+            width='5rem'
+            size='1rem'
+            gap='1.1rem'
           />
         </div>
         {stage === 1 ? (

--- a/src/page/account/SignUpPage/SignUpPage.jsx
+++ b/src/page/account/SignUpPage/SignUpPage.jsx
@@ -35,9 +35,9 @@ export default function SignUpPage() {
           <StageDots
             quantity={3}
             current={stage}
-            width='3.125rem'
-            size='0.625rem'
-            gap='0.688rem'
+            width='50px'
+            size='10px'
+            gap='11.008px'
           />
         </div>
         {stage === 1 ? (

--- a/src/page/account/SignUpPage/SignUpPage.module.css
+++ b/src/page/account/SignUpPage/SignUpPage.module.css
@@ -1,6 +1,6 @@
 .pageFrame {
   width: 100%;
-  padding: 0 20px;
+  padding: 0 2rem;
   height: 100%;
   display: flex;
   justify-content: center;
@@ -17,16 +17,16 @@
 }
 
 .navFrame {
-  height: 44px;
+  height: 4.4rem;
   display: flex;
   align-items: center;
 }
 
 .stageDotsFrame {
-  margin-top: 13.008px;
-  margin-bottom: 29.008px;
+  margin-top: 1.3rem;
+  margin-bottom: 2.9rem;
 }
 
 .submit {
-  margin-bottom: 34px;
+  margin-bottom: 3.4rem;
 }

--- a/src/page/account/SignUpPage/SignUpPage.module.css
+++ b/src/page/account/SignUpPage/SignUpPage.module.css
@@ -1,6 +1,6 @@
 .pageFrame {
   width: 100%;
-  padding: 0 1.25rem;
+  padding: 0 20px;
   height: 100%;
   display: flex;
   justify-content: center;
@@ -17,16 +17,16 @@
 }
 
 .navFrame {
-  height: 2.75rem;
+  height: 44px;
   display: flex;
   align-items: center;
 }
 
 .stageDotsFrame {
-  margin-top: 0.813rem;
-  margin-bottom: 1.813rem;
+  margin-top: 13.008px;
+  margin-bottom: 29.008px;
 }
 
 .submit {
-  margin-bottom: 2.125rem;
+  margin-bottom: 34px;
 }

--- a/src/page/account/SignUpSuccessPage/SignUpSuccessPage.module.css
+++ b/src/page/account/SignUpSuccessPage/SignUpSuccessPage.module.css
@@ -1,20 +1,20 @@
 .pageFrame {
   height: 100%;
-  padding: 0 20px;
+  padding: 0 2rem;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
 }
 
 .icon {
-  margin-top: 53.008px;
-  margin-bottom: 19.008px;
+  margin-top: 5.3rem;
+  margin-bottom: 1.9rem;
 }
 
 .title {
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: 700;
-  margin-bottom: 8px;
+  margin-bottom: 0.8rem;
 }
 
 .img {
@@ -26,6 +26,6 @@
 }
 
 .submit {
-  margin-top: 30px;
-  margin-bottom: 34px;
+  margin-top: 3rem;
+  margin-bottom: 3.4rem;
 }

--- a/src/page/account/SignUpSuccessPage/SignUpSuccessPage.module.css
+++ b/src/page/account/SignUpSuccessPage/SignUpSuccessPage.module.css
@@ -1,20 +1,20 @@
 .pageFrame {
   height: 100%;
-  padding: 0 1.25rem;
+  padding: 0 20px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
 }
 
 .icon {
-  margin-top: 3.313rem;
-  margin-bottom: 1.188rem;
+  margin-top: 53.008px;
+  margin-bottom: 19.008px;
 }
 
 .title {
-  font-size: 1.25rem;
+  font-size: 20px;
   font-weight: 700;
-  margin-bottom: 0.5rem;
+  margin-bottom: 8px;
 }
 
 .img {
@@ -26,6 +26,6 @@
 }
 
 .submit {
-  margin-top: 1.875rem;
-  margin-bottom: 2.125rem;
+  margin-top: 30px;
+  margin-bottom: 34px;
 }

--- a/src/page/account/SnoroseVerifyPage/SnoroseVerifyPage.module.css
+++ b/src/page/account/SnoroseVerifyPage/SnoroseVerifyPage.module.css
@@ -5,7 +5,7 @@
 }
 
 .indicator {
-  margin: 0.5625rem var(--default-margin) 28px var(--default-margin);
+  margin: 0.5625rem var(--default-margin) 1.75rem var(--default-margin);
   display: flex;
   gap: 0.6875rem;
 }

--- a/src/page/account/SnoroseVerifyPage/SnoroseVerifyPage.module.css
+++ b/src/page/account/SnoroseVerifyPage/SnoroseVerifyPage.module.css
@@ -5,19 +5,19 @@
 }
 
 .indicator {
-  margin: 9px var(--default-margin) 28px var(--default-margin);
+  margin: 0.9rem var(--default-margin) 2.8rem var(--default-margin);
   display: flex;
-  gap: 11px;
+  gap: 1.1rem;
 }
 
 .check {
-  margin: 13px var(--default-margin) 19px
-    calc(var(--default-margin) - 3px);
+  margin: 1.3rem var(--default-margin) 1.9rem
+    calc(var(--default-margin) - 0.3rem);
 }
 
 .dot {
-  width: 9px;
-  height: 9px;
+  width: 0.9rem;
+  height: 0.9rem;
   border-radius: 100%;
   background-color: var(--gray-2);
 }
@@ -27,16 +27,16 @@
 }
 
 .title {
-  margin: 0 var(--default-margin) 16px var(--default-margin);
+  margin: 0 var(--default-margin) 1.6rem var(--default-margin);
   font-weight: 700;
-  font-size: 20px;
+  font-size: 2rem;
   white-space: pre-line;
 }
 
 .description {
-  margin: 0 var(--default-margin) 27px var(--default-margin);
+  margin: 0 var(--default-margin) 2.7rem var(--default-margin);
   font-weight: 500;
-  font-size: 14px;
+  font-size: 1.4rem;
   color: var(--gray-4);
   white-space: pre-line;
   word-break: keep-all;

--- a/src/page/account/SnoroseVerifyPage/SnoroseVerifyPage.module.css
+++ b/src/page/account/SnoroseVerifyPage/SnoroseVerifyPage.module.css
@@ -5,19 +5,19 @@
 }
 
 .indicator {
-  margin: 0.5625rem var(--default-margin) 1.75rem var(--default-margin);
+  margin: 9px var(--default-margin) 28px var(--default-margin);
   display: flex;
-  gap: 0.6875rem;
+  gap: 11px;
 }
 
 .check {
-  margin: 0.8125rem var(--default-margin) 1.1875rem
-    calc(var(--default-margin) - 0.1875rem);
+  margin: 13px var(--default-margin) 19px
+    calc(var(--default-margin) - 3px);
 }
 
 .dot {
-  width: 0.5625rem;
-  height: 0.5625rem;
+  width: 9px;
+  height: 9px;
   border-radius: 100%;
   background-color: var(--gray-2);
 }
@@ -27,16 +27,16 @@
 }
 
 .title {
-  margin: 0 var(--default-margin) 1rem var(--default-margin);
+  margin: 0 var(--default-margin) 16px var(--default-margin);
   font-weight: 700;
-  font-size: 1.25rem;
+  font-size: 20px;
   white-space: pre-line;
 }
 
 .description {
-  margin: 0 var(--default-margin) 1.6875rem var(--default-margin);
+  margin: 0 var(--default-margin) 27px var(--default-margin);
   font-weight: 500;
-  font-size: 0.875rem;
+  font-size: 14px;
   color: var(--gray-4);
   white-space: pre-line;
   word-break: keep-all;

--- a/src/page/alert/AlertPage/AlertPage.module.css
+++ b/src/page/alert/AlertPage/AlertPage.module.css
@@ -24,7 +24,7 @@
 }
 
 .title {
-  font-size: 20px;
+  font-size: 1.25rem;
   font-weight: 700;
 }
 

--- a/src/page/alert/AlertPage/AlertPage.module.css
+++ b/src/page/alert/AlertPage/AlertPage.module.css
@@ -5,14 +5,14 @@
 
 .menu {
   display: flex;
-  padding: 14px 20px;
+  padding: 1.4rem 2rem;
   justify-content: flex-end;
 }
 
 .contentWrapper {
   display: flex;
   flex-direction: column;
-  padding: 0 20px 100px 20px;
+  padding: 0 2rem 10rem 2rem;
   width: 100%;
 }
 
@@ -20,11 +20,11 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 14px 0;
+  padding: 1.4rem 0;
 }
 
 .title {
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: 700;
 }
 
@@ -32,27 +32,27 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 52px;
-  height: 18px;
-  border-radius: 3px;
+  width: 5.2rem;
+  height: 1.8rem;
+  border-radius: 0.3rem;
   background: var(--blue-0);
   color: var(--blue-3);
-  font-size: 9px;
+  font-size: 0.9rem;
 }
 
 .alertListContainer {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 1rem;
 }
 
 .alertBox {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-radius: 5px;
+  border-radius: 0.5rem;
   background: var(--gray-1-1);
-  padding: 15px;
+  padding: 1.5rem;
 }
 
 .alertBox.unread {
@@ -66,23 +66,23 @@
 .alertIconContentWrapper {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 1rem;
 }
 
 .alertIconContentWrapper svg {
-  width: 32px;
-  height: 32px;
+  width: 3.2rem;
+  height: 3.2rem;
 }
 
 .alertContent {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: 0.3rem;
 }
 
 .alertTitle {
   color: var(--gray-4);
-  font-size: 12px;
+  font-size: 1.2rem;
   font-weight: 500;
 }
 .alertTitle.unreadTitle {
@@ -94,7 +94,7 @@
 
 .alertDesc {
   color: var(--gray-4);
-  font-size: 11px;
+  font-size: 1.1rem;
   white-space: pre-line;
 }
 .alertDesc.unreadDesc {

--- a/src/page/alert/AlertPage/AlertPage.module.css
+++ b/src/page/alert/AlertPage/AlertPage.module.css
@@ -5,14 +5,14 @@
 
 .menu {
   display: flex;
-  padding: 0.875rem 1.25rem;
+  padding: 14px 20px;
   justify-content: flex-end;
 }
 
 .contentWrapper {
   display: flex;
   flex-direction: column;
-  padding: 0 1.25rem 6.25rem 1.25rem;
+  padding: 0 20px 100px 20px;
   width: 100%;
 }
 
@@ -20,11 +20,11 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.875rem 0;
+  padding: 14px 0;
 }
 
 .title {
-  font-size: 1.25rem;
+  font-size: 20px;
   font-weight: 700;
 }
 
@@ -32,27 +32,27 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 3.25rem;
-  height: 1.125rem;
-  border-radius: 0.1875rem;
+  width: 52px;
+  height: 18px;
+  border-radius: 3px;
   background: var(--blue-0);
   color: var(--blue-3);
-  font-size: 0.5625rem;
+  font-size: 9px;
 }
 
 .alertListContainer {
   display: flex;
   flex-direction: column;
-  gap: 0.625rem;
+  gap: 10px;
 }
 
 .alertBox {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-radius: 0.3125rem;
+  border-radius: 5px;
   background: var(--gray-1-1);
-  padding: 0.9375rem;
+  padding: 15px;
 }
 
 .alertBox.unread {
@@ -66,23 +66,23 @@
 .alertIconContentWrapper {
   display: flex;
   align-items: center;
-  gap: 0.625rem;
+  gap: 10px;
 }
 
 .alertIconContentWrapper svg {
-  width: 2rem;
-  height: 2rem;
+  width: 32px;
+  height: 32px;
 }
 
 .alertContent {
   display: flex;
   flex-direction: column;
-  gap: 0.1875rem;
+  gap: 3px;
 }
 
 .alertTitle {
   color: var(--gray-4);
-  font-size: 0.75rem;
+  font-size: 12px;
   font-weight: 500;
 }
 .alertTitle.unreadTitle {
@@ -94,7 +94,7 @@
 
 .alertDesc {
   color: var(--gray-4);
-  font-size: 0.6875rem;
+  font-size: 11px;
   white-space: pre-line;
 }
 .alertDesc.unreadDesc {

--- a/src/page/board/BoardCategoryPage/BoardCategoryPage.module.css
+++ b/src/page/board/BoardCategoryPage/BoardCategoryPage.module.css
@@ -4,15 +4,15 @@
 }
 
 .paddingContainer {
-  padding: 0 1.25rem;
+  padding: 0 20px;
   display: flex;
   flex-direction: column;
   align-items: baseline;
-  font-size: 0.5rem;
+  font-size: 8px;
 }
 
 .header {
-  height: 2.75rem;
+  height: 44px;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -22,25 +22,25 @@
 .searchbarBox {
   width: 100%;
   /* 양옆 여백 */
-  padding: 0.625rem 0 0 0;
+  padding: 10px 0 0 0;
 }
 
 .searchbar {
-  border-radius: 0.3125rem;
-  font-size: 0.75rem;
+  border-radius: 5px;
+  font-size: 12px;
   color: var(--gray-1-1);
   width: 100%;
-  height: 2.5rem;
+  height: 40px;
   display: flex;
   align-items: center;
   justify-content: space-between;
   background: var(--gray-1);
-  padding: 0 0.8125rem;
+  padding: 0 13px;
 
   input {
     width: 100%;
-    padding: 0 0.625rem 0.125rem 0.625rem;
-    border-radius: 0.625rem;
+    padding: 0 10px 2px 10px;
+    border-radius: 10px;
     border: transparent;
     background: var(--gray-1);
   }
@@ -51,14 +51,14 @@
 }
 
 .boardBox {
-  padding: 1.625rem 0;
+  padding: 26px 0;
   width: 100%;
 }
 
 .boardTitle {
   box-sizing: border-box;
-  padding: 0 0 0.5rem 0;
-  font-size: 1rem;
+  padding: 0 0 8px 0;
+  font-size: 16px;
   font-weight: 700;
 }
 
@@ -66,8 +66,8 @@
   display: grid;
   grid-template-columns: repeat(2, 2fr);
   grid-row: auto auto;
-  grid-column-gap: 0.625rem;
-  grid-row-gap: 0.625rem;
+  grid-column-gap: 10px;
+  grid-row-gap: 10px;
 }
 
 .moreBoardBox {
@@ -75,12 +75,12 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 1.875rem 0;
-  min-height: 18.75rem;
+  padding: 30px 0;
+  min-height: 300px;
   background: linear-gradient(180deg, #f9f9f9 0%, var(--white) 100%);
-  font-size: 0.75rem;
+  font-size: 12px;
 }
 
 .iconLogo {
-  margin-bottom: 0.625rem;
+  margin-bottom: 10px;
 }

--- a/src/page/board/BoardCategoryPage/BoardCategoryPage.module.css
+++ b/src/page/board/BoardCategoryPage/BoardCategoryPage.module.css
@@ -4,15 +4,15 @@
 }
 
 .paddingContainer {
-  padding: 0 20px;
+  padding: 0 2rem;
   display: flex;
   flex-direction: column;
   align-items: baseline;
-  font-size: 8px;
+  font-size: 0.8rem;
 }
 
 .header {
-  height: 44px;
+  height: 4.4rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -22,25 +22,25 @@
 .searchbarBox {
   width: 100%;
   /* 양옆 여백 */
-  padding: 10px 0 0 0;
+  padding: 1rem 0 0 0;
 }
 
 .searchbar {
-  border-radius: 5px;
-  font-size: 12px;
+  border-radius: 0.5rem;
+  font-size: 1.2rem;
   color: var(--gray-1-1);
   width: 100%;
-  height: 40px;
+  height: 4rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
   background: var(--gray-1);
-  padding: 0 13px;
+  padding: 0 1.3rem;
 
   input {
     width: 100%;
-    padding: 0 10px 2px 10px;
-    border-radius: 10px;
+    padding: 0 1rem 0.2rem 1rem;
+    border-radius: 1rem;
     border: transparent;
     background: var(--gray-1);
   }
@@ -51,14 +51,14 @@
 }
 
 .boardBox {
-  padding: 26px 0;
+  padding: 2.6rem 0;
   width: 100%;
 }
 
 .boardTitle {
   box-sizing: border-box;
-  padding: 0 0 8px 0;
-  font-size: 16px;
+  padding: 0 0 0.8rem 0;
+  font-size: 1.6rem;
   font-weight: 700;
 }
 
@@ -66,8 +66,8 @@
   display: grid;
   grid-template-columns: repeat(2, 2fr);
   grid-row: auto auto;
-  grid-column-gap: 10px;
-  grid-row-gap: 10px;
+  grid-column-gap: 1rem;
+  grid-row-gap: 1rem;
 }
 
 .moreBoardBox {
@@ -75,12 +75,12 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 30px 0;
-  min-height: 300px;
+  padding: 3rem 0;
+  min-height: 30rem;
   background: linear-gradient(180deg, #f9f9f9 0%, var(--white) 100%);
-  font-size: 12px;
+  font-size: 1.2rem;
 }
 
 .iconLogo {
-  margin-bottom: 10px;
+  margin-bottom: 1rem;
 }

--- a/src/page/board/EditPostPage/EditPostPage.module.css
+++ b/src/page/board/EditPostPage/EditPostPage.module.css
@@ -6,11 +6,11 @@
 
 .top {
   width: 100%;
-  padding-top: 3.25rem;
+  padding-top: 52px;
 }
 
 .center {
-  padding: 0 1.25rem 2.5rem 1.25rem;
+  padding: 0 20px 40px 20px;
   background-color: var(--blue-0);
 }
 
@@ -18,19 +18,19 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.625rem 0 0.9375rem 0;
-  border-bottom: 0.0313rem solid var(--gray-3-1);
-  stroke-width: 0.0313rem;
+  padding: 10px 0 15px 0;
+  border-bottom: 0.5008px solid var(--gray-3-1);
+  stroke-width: 0.5008px;
 }
 
 .categorySelectContainer {
   display: flex;
   align-items: center;
-  gap: 0.875rem;
+  gap: 14px;
 }
 
 .categorySelectText {
-  font-size: 1rem;
+  font-size: 16px;
   font-weight: 500;
 }
 
@@ -38,21 +38,21 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1.375rem 0 1.125rem 0;
+  padding: 22px 0 18px 0;
   color: var(--gray-3-1);
-  font-size: 0.75rem;
+  font-size: 12px;
 }
 
 .profileBoxLeft {
   display: flex;
   align-items: center;
-  gap: 0.4375rem;
+  gap: 7px;
 }
 
 .profileBoxRight {
   display: flex;
   align-items: center;
-  gap: 0.125rem;
+  gap: 2px;
   color: var(--black);
 }
 
@@ -61,8 +61,8 @@
 }
 
 .dot {
-  width: 0.1875rem;
-  height: 0.1875rem;
+  width: 3px;
+  height: 3px;
   border-radius: 50%;
   background-color: var(--gray-3-1);
 }
@@ -70,12 +70,12 @@
 .content {
   display: flex;
   flex-direction: column;
-  row-gap: 2.25rem;
+  row-gap: 36px;
 }
 
 .title {
   color: var(--gray-4);
-  font-size: 1.25rem;
+  font-size: 20px;
   font-weight: 700;
   outline: none;
   border: none;
@@ -87,13 +87,13 @@
 
 .text {
   color: var(--gray-4);
-  font-size: 0.875rem;
+  font-size: 14px;
   outline: none;
   border: none;
   background-color: transparent;
   display: block;
   width: 100%;
-  min-height: 6.25rem;
+  min-height: 100px;
   resize: none;
   white-space: pre-wrap; /* 줄바꿈과 공백을 유지 */
 }

--- a/src/page/board/EditPostPage/EditPostPage.module.css
+++ b/src/page/board/EditPostPage/EditPostPage.module.css
@@ -6,11 +6,11 @@
 
 .top {
   width: 100%;
-  padding-top: 52px;
+  padding-top: 5.2rem;
 }
 
 .center {
-  padding: 0 20px 40px 20px;
+  padding: 0 2rem 4rem 2rem;
   background-color: var(--blue-0);
 }
 
@@ -18,19 +18,19 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 0 15px 0;
-  border-bottom: 0.5008px solid var(--gray-3-1);
-  stroke-width: 0.5008px;
+  padding: 1rem 0 1.5rem 0;
+  border-bottom: 0.05rem solid var(--gray-3-1);
+  stroke-width: 0.05rem;
 }
 
 .categorySelectContainer {
   display: flex;
   align-items: center;
-  gap: 14px;
+  gap: 1.4rem;
 }
 
 .categorySelectText {
-  font-size: 16px;
+  font-size: 1.6rem;
   font-weight: 500;
 }
 
@@ -38,21 +38,21 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 22px 0 18px 0;
+  padding: 2.2rem 0 1.8rem 0;
   color: var(--gray-3-1);
-  font-size: 12px;
+  font-size: 1.2rem;
 }
 
 .profileBoxLeft {
   display: flex;
   align-items: center;
-  gap: 7px;
+  gap: 0.7rem;
 }
 
 .profileBoxRight {
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: 0.2rem;
   color: var(--black);
 }
 
@@ -61,8 +61,8 @@
 }
 
 .dot {
-  width: 3px;
-  height: 3px;
+  width: 0.3rem;
+  height: 0.3rem;
   border-radius: 50%;
   background-color: var(--gray-3-1);
 }
@@ -70,12 +70,12 @@
 .content {
   display: flex;
   flex-direction: column;
-  row-gap: 36px;
+  row-gap: 3.6rem;
 }
 
 .title {
   color: var(--gray-4);
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: 700;
   outline: none;
   border: none;
@@ -87,13 +87,13 @@
 
 .text {
   color: var(--gray-4);
-  font-size: 14px;
+  font-size: 1.4rem;
   outline: none;
   border: none;
   background-color: transparent;
   display: block;
   width: 100%;
-  min-height: 100px;
+  min-height: 10rem;
   resize: none;
   white-space: pre-wrap; /* 줄바꿈과 공백을 유지 */
 }

--- a/src/page/board/EditPostPage/EditPostPage.module.css
+++ b/src/page/board/EditPostPage/EditPostPage.module.css
@@ -19,8 +19,8 @@
   align-items: center;
   justify-content: space-between;
   padding: 0.625rem 0 0.9375rem 0;
-  border-bottom: 0.5px solid var(--gray-3-1);
-  stroke-width: 0.5px;
+  border-bottom: 0.0313rem solid var(--gray-3-1);
+  stroke-width: 0.0313rem;
 }
 
 .categorySelectContainer {

--- a/src/page/board/NoticeListPage/NoticeListPage.module.css
+++ b/src/page/board/NoticeListPage/NoticeListPage.module.css
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  font-size: 8px;
+  font-size: 0.8rem;
   overflow-y: auto;
 }
 
@@ -13,10 +13,10 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  font-size: 8px;
+  font-size: 0.8rem;
   /* 양옆 여백 */
-  padding: 64px 16px 192px 16px;
-  row-gap: 8px;
+  padding: 6.4rem 1.6rem 19.2rem 1.6rem;
+  row-gap: 0.8rem;
 }
 
 .empty {
@@ -24,5 +24,5 @@
 }
 
 .writeButton {
-  bottom: 19px;
+  bottom: 1.9rem;
 }

--- a/src/page/board/NoticeListPage/NoticeListPage.module.css
+++ b/src/page/board/NoticeListPage/NoticeListPage.module.css
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  font-size: 0.5rem;
+  font-size: 8px;
   overflow-y: auto;
 }
 
@@ -13,10 +13,10 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  font-size: 0.5rem;
+  font-size: 8px;
   /* 양옆 여백 */
-  padding: 4rem 1rem 12rem 1rem;
-  row-gap: 0.5rem;
+  padding: 64px 16px 192px 16px;
+  row-gap: 8px;
 }
 
 .empty {
@@ -24,5 +24,5 @@
 }
 
 .writeButton {
-  bottom: 1.1875rem;
+  bottom: 19px;
 }

--- a/src/page/board/PostListPage/PostListPage.module.css
+++ b/src/page/board/PostListPage/PostListPage.module.css
@@ -1,32 +1,32 @@
 .container {
-  padding-top: 3.375rem;
+  padding-top: 54px;
   width: 100%;
   height: 100vh;
   display: flex;
   flex-direction: column;
-  font-size: 0.5rem;
+  font-size: 8px;
   overflow-y: auto;
 }
 
 .top {
   width: 100%;
-  padding: 0.625rem var(--default-margin);
+  padding: 10px var(--default-margin);
 }
 
 .notificationBar {
-  padding: 0.688rem 0.938rem;
+  padding: 11.008px 15.008px;
   width: 100%;
   display: flex;
   align-items: center;
-  gap: 0.861rem;
-  border-radius: 0.3125rem;
+  gap: 13.776px;
+  border-radius: 5px;
   background-color: var(--pink-1);
-  font-size: 0.8125rem;
+  font-size: 13px;
   color: var(--pink-3);
   box-sizing: border-box;
   cursor: pointer;
 }
 
 .writeButton {
-  bottom: 1.1875rem;
+  bottom: 19px;
 }

--- a/src/page/board/PostListPage/PostListPage.module.css
+++ b/src/page/board/PostListPage/PostListPage.module.css
@@ -1,32 +1,32 @@
 .container {
-  padding-top: 54px;
+  padding-top: 5.4rem;
   width: 100%;
   height: 100vh;
   display: flex;
   flex-direction: column;
-  font-size: 8px;
+  font-size: 0.8rem;
   overflow-y: auto;
 }
 
 .top {
   width: 100%;
-  padding: 10px var(--default-margin);
+  padding: 1rem var(--default-margin);
 }
 
 .notificationBar {
-  padding: 11.008px 15.008px;
+  padding: 1.1rem 1.5rem;
   width: 100%;
   display: flex;
   align-items: center;
-  gap: 13.776px;
-  border-radius: 5px;
+  gap: 1.4rem;
+  border-radius: 0.5rem;
   background-color: var(--pink-1);
-  font-size: 13px;
+  font-size: 1.3rem;
   color: var(--pink-3);
   box-sizing: border-box;
   cursor: pointer;
 }
 
 .writeButton {
-  bottom: 19px;
+  bottom: 1.9rem;
 }

--- a/src/page/board/PostPage/PostPage.module.css
+++ b/src/page/board/PostPage/PostPage.module.css
@@ -94,10 +94,9 @@
 /* post content */
 
 .contentText {
-  font-size: 0.75rem;
+  font-size: 1.4rem;
   color: var(--gray-4);
-  font-size: 0.875rem;
-  padding: 0 0.8125rem 0.9375rem 0;
+  padding: 0 1.3rem 1.5rem 0;
   white-space: pre-wrap;
   word-break: keep-all;
 

--- a/src/page/board/PostPage/PostPage.module.css
+++ b/src/page/board/PostPage/PostPage.module.css
@@ -88,7 +88,7 @@
 .whiteBox {
   background-color: #fff;
   width: 100%;
-  height: 50px;
+  height: 3.125rem;
 }
 
 /* post content */

--- a/src/page/board/PostPage/PostPage.module.css
+++ b/src/page/board/PostPage/PostPage.module.css
@@ -14,10 +14,10 @@
   width: 100%;
   display: flex;
   flex-direction: column;
-  font-size: 0.5rem;
+  font-size: 8px;
   /* 양옆 여백 */
-  padding: 3.438rem 0.6875rem 0.6875rem 1.3125rem;
-  border-radius: 0 0 0.9375rem 0.9375rem;
+  padding: 55.008px 11px 11px 21px;
+  border-radius: 0 0 15px 15px;
   background-color: var(--blue-0);
 }
 
@@ -27,13 +27,13 @@
   justify-content: space-between;
   align-items: center;
   color: var(--gray-3-1);
-  font-size: 0.75rem;
+  font-size: 12px;
 }
 
 .contentTopLeft {
   display: flex;
   align-items: center;
-  gap: 0.4375rem;
+  gap: 7px;
 }
 
 .dot {
@@ -41,15 +41,15 @@
 }
 
 .dot3 {
-  padding: 0.625rem;
+  padding: 10px;
   cursor: pointer;
 }
 
 .title {
   display: flex;
   align-items: end;
-  padding: 0.5rem 0.625rem 1.625rem 0;
-  font-size: 1.25rem;
+  padding: 8px 10px 26px 0;
+  font-size: 20px;
   font-weight: 700;
   color: var(--gray-4);
 }
@@ -57,15 +57,15 @@
 .views {
   white-space: nowrap;
   color: var(--blue-3);
-  font-size: 0.6875rem;
-  padding-left: 0.125rem;
+  font-size: 11px;
+  padding-left: 2px;
   font-weight: 400;
 }
 
 .post_bottom {
   display: flex;
   justify-content: end;
-  padding: 0 0.625rem 0 0;
+  padding: 0 10px 0 0;
 
   div:nth-of-type(2):hover,
   div:nth-of-type(3):hover {
@@ -78,17 +78,17 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0.25rem 0.5rem;
-  border-radius: 0.3125rem;
-  gap: 0.375rem;
+  padding: 4px 8px;
+  border-radius: 5px;
+  gap: 6px;
   color: var(--gray-3-1);
-  font-size: 0.6875rem;
+  font-size: 11px;
 }
 
 .whiteBox {
   background-color: #fff;
   width: 100%;
-  height: 3.125rem;
+  height: 50px;
 }
 
 /* post content */

--- a/src/page/board/PostPage/PostPage.module.css
+++ b/src/page/board/PostPage/PostPage.module.css
@@ -14,10 +14,10 @@
   width: 100%;
   display: flex;
   flex-direction: column;
-  font-size: 8px;
+  font-size: 0.8rem;
   /* 양옆 여백 */
-  padding: 55.008px 11px 11px 21px;
-  border-radius: 0 0 15px 15px;
+  padding: 5.5rem 1.1rem 1.1rem 2.1rem;
+  border-radius: 0 0 1.5rem 1.5rem;
   background-color: var(--blue-0);
 }
 
@@ -27,13 +27,13 @@
   justify-content: space-between;
   align-items: center;
   color: var(--gray-3-1);
-  font-size: 12px;
+  font-size: 1.2rem;
 }
 
 .contentTopLeft {
   display: flex;
   align-items: center;
-  gap: 7px;
+  gap: 0.7rem;
 }
 
 .dot {
@@ -41,15 +41,15 @@
 }
 
 .dot3 {
-  padding: 10px;
+  padding: 1rem;
   cursor: pointer;
 }
 
 .title {
   display: flex;
   align-items: end;
-  padding: 8px 10px 26px 0;
-  font-size: 20px;
+  padding: 0.8rem 1rem 2.6rem 0;
+  font-size: 2rem;
   font-weight: 700;
   color: var(--gray-4);
 }
@@ -57,15 +57,15 @@
 .views {
   white-space: nowrap;
   color: var(--blue-3);
-  font-size: 11px;
-  padding-left: 2px;
+  font-size: 1.1rem;
+  padding-left: 0.2rem;
   font-weight: 400;
 }
 
 .post_bottom {
   display: flex;
   justify-content: end;
-  padding: 0 10px 0 0;
+  padding: 0 1rem 0 0;
 
   div:nth-of-type(2):hover,
   div:nth-of-type(3):hover {
@@ -78,17 +78,17 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 4px 8px;
-  border-radius: 5px;
-  gap: 6px;
+  padding: 0.4rem 0.8rem;
+  border-radius: 0.5rem;
+  gap: 0.6rem;
   color: var(--gray-3-1);
-  font-size: 11px;
+  font-size: 1.1rem;
 }
 
 .whiteBox {
   background-color: #fff;
   width: 100%;
-  height: 50px;
+  height: 5rem;
 }
 
 /* post content */

--- a/src/page/board/WritePostPage/WritePostPage.module.css
+++ b/src/page/board/WritePostPage/WritePostPage.module.css
@@ -6,11 +6,11 @@
 
 .top {
   width: 100%;
-  padding-top: 52px;
+  padding-top: 5.2rem;
 }
 
 .center {
-  padding: 0 20px;
+  padding: 0 2rem;
   background-color: var(--blue-0);
 }
 
@@ -18,20 +18,20 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 0 15px 0;
-  border-bottom: 0.5008px solid var(--gray-3-1);
-  stroke-width: 0.5008px;
+  padding: 1rem 0 1.5rem 0;
+  border-bottom: 0.05rem solid var(--gray-3-1);
+  stroke-width: 0.05rem;
   cursor: pointer;
 }
 
 .categorySelectContainer {
   display: flex;
   align-items: center;
-  gap: 14px;
+  gap: 1.4rem;
 }
 
 .categorySelectText {
-  font-size: 16px;
+  font-size: 1.6rem;
   font-weight: 500;
 }
 
@@ -39,21 +39,21 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 22px 0 18px 0;
+  padding: 2.2rem 0 1.8rem 0;
   color: var(--gray-3-1);
-  font-size: 12px;
+  font-size: 1.2rem;
 }
 
 .profileBoxLeft {
   display: flex;
   align-items: center;
-  gap: 7px;
+  gap: 0.7rem;
 }
 
 .profileBoxRight {
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: 0.2rem;
   color: var(--black);
   cursor: pointer;
 }
@@ -64,8 +64,8 @@
 }
 
 .dot {
-  width: 3px;
-  height: 3px;
+  width: 0.3rem;
+  height: 0.3rem;
   border-radius: 50%;
   background-color: var(--gray-3-1);
 }
@@ -73,13 +73,13 @@
 .content {
   display: flex;
   flex-direction: column;
-  row-gap: 36px;
-  padding-bottom: 110px;
+  row-gap: 3.6rem;
+  padding-bottom: 11rem;
 }
 
 .title {
   color: var(--gray-4);
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: 700;
   outline: none;
   border: none;
@@ -91,13 +91,13 @@
 
 .text {
   color: var(--gray-4);
-  font-size: 14px;
+  font-size: 1.4rem;
   outline: none;
   border: none;
   background-color: transparent;
   display: block;
   width: 100%;
-  min-height: 100px;
+  min-height: 10rem;
   resize: none;
 }
 

--- a/src/page/board/WritePostPage/WritePostPage.module.css
+++ b/src/page/board/WritePostPage/WritePostPage.module.css
@@ -19,8 +19,8 @@
   align-items: center;
   justify-content: space-between;
   padding: 0.625rem 0 0.9375rem 0;
-  border-bottom: 0.5px solid var(--gray-3-1);
-  stroke-width: 0.5px;
+  border-bottom: 0.0313rem solid var(--gray-3-1);
+  stroke-width: 0.0313rem;
   cursor: pointer;
 }
 

--- a/src/page/board/WritePostPage/WritePostPage.module.css
+++ b/src/page/board/WritePostPage/WritePostPage.module.css
@@ -6,11 +6,11 @@
 
 .top {
   width: 100%;
-  padding-top: 3.25rem;
+  padding-top: 52px;
 }
 
 .center {
-  padding: 0 1.25rem;
+  padding: 0 20px;
   background-color: var(--blue-0);
 }
 
@@ -18,20 +18,20 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.625rem 0 0.9375rem 0;
-  border-bottom: 0.0313rem solid var(--gray-3-1);
-  stroke-width: 0.0313rem;
+  padding: 10px 0 15px 0;
+  border-bottom: 0.5008px solid var(--gray-3-1);
+  stroke-width: 0.5008px;
   cursor: pointer;
 }
 
 .categorySelectContainer {
   display: flex;
   align-items: center;
-  gap: 0.875rem;
+  gap: 14px;
 }
 
 .categorySelectText {
-  font-size: 1rem;
+  font-size: 16px;
   font-weight: 500;
 }
 
@@ -39,21 +39,21 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1.375rem 0 1.125rem 0;
+  padding: 22px 0 18px 0;
   color: var(--gray-3-1);
-  font-size: 0.75rem;
+  font-size: 12px;
 }
 
 .profileBoxLeft {
   display: flex;
   align-items: center;
-  gap: 0.4375rem;
+  gap: 7px;
 }
 
 .profileBoxRight {
   display: flex;
   align-items: center;
-  gap: 0.125rem;
+  gap: 2px;
   color: var(--black);
   cursor: pointer;
 }
@@ -64,8 +64,8 @@
 }
 
 .dot {
-  width: 0.1875rem;
-  height: 0.1875rem;
+  width: 3px;
+  height: 3px;
   border-radius: 50%;
   background-color: var(--gray-3-1);
 }
@@ -73,13 +73,13 @@
 .content {
   display: flex;
   flex-direction: column;
-  row-gap: 2.25rem;
-  padding-bottom: 6.875rem;
+  row-gap: 36px;
+  padding-bottom: 110px;
 }
 
 .title {
   color: var(--gray-4);
-  font-size: 1.25rem;
+  font-size: 20px;
   font-weight: 700;
   outline: none;
   border: none;
@@ -91,13 +91,13 @@
 
 .text {
   color: var(--gray-4);
-  font-size: 0.875rem;
+  font-size: 14px;
   outline: none;
   border: none;
   background-color: transparent;
   display: block;
   width: 100%;
-  min-height: 6.25rem;
+  min-height: 100px;
   resize: none;
 }
 

--- a/src/page/etc/NotFoundPage/NotFoundPage.module.css
+++ b/src/page/etc/NotFoundPage/NotFoundPage.module.css
@@ -7,13 +7,13 @@
 }
 
 .error {
-  font-size: 5rem;
+  font-size: 80px;
   color: var(--blue-4);
   font-weight: 700;
 }
 
 .text {
-  margin-bottom: 1.25rem;
+  margin-bottom: 20px;
 }
 
 .button {

--- a/src/page/etc/NotFoundPage/NotFoundPage.module.css
+++ b/src/page/etc/NotFoundPage/NotFoundPage.module.css
@@ -7,13 +7,13 @@
 }
 
 .error {
-  font-size: 80px;
+  font-size: 8rem;
   color: var(--blue-4);
   font-weight: 700;
 }
 
 .text {
-  margin-bottom: 20px;
+  margin-bottom: 2rem;
 }
 
 .button {

--- a/src/page/exam/EditExamReviewPage/EditExamReviewPage.module.css
+++ b/src/page/exam/EditExamReviewPage/EditExamReviewPage.module.css
@@ -1,3 +1,3 @@
 .container {
-  padding-top: 62px;
+  padding-top: 6.2rem;
 }

--- a/src/page/exam/EditExamReviewPage/EditExamReviewPage.module.css
+++ b/src/page/exam/EditExamReviewPage/EditExamReviewPage.module.css
@@ -1,3 +1,3 @@
 .container {
-  padding-top: 3.875rem;
+  padding-top: 62px;
 }

--- a/src/page/exam/ExamReviewListPage/ExamReviewListPage.module.css
+++ b/src/page/exam/ExamReviewListPage/ExamReviewListPage.module.css
@@ -1,5 +1,5 @@
 .container {
-  padding-bottom: 112px;
+  padding-bottom: 11.2rem;
   width: 100%;
   height: 100vh;
   display: flex;
@@ -9,25 +9,25 @@
 
 .notification {
   width: 100%;
-  padding: 10px var(--default-margin);
-  padding-top: 64px;
+  padding: 1rem var(--default-margin);
+  padding-top: 6.4rem;
 }
 
 .notificationBar {
   width: 100%;
-  padding: 11.008px 15.008px;
+  padding: 1.1rem 1.5rem;
   display: flex;
   align-items: center;
-  gap: 13.776px;
-  border-radius: 5px;
+  gap: 1.4rem;
+  border-radius: 0.5rem;
   background-color: var(--pink-1);
-  font-size: 11.008px;
+  font-size: 1.1rem;
   color: var(--pink-3);
   box-sizing: border-box;
   cursor: pointer;
 }
 
 .search {
-  width: calc(100% - 20px * 2);
-  margin: 0 20px 10px 20px;
+  width: calc(100% - 2rem * 2);
+  margin: 0 2rem 1rem 2rem;
 }

--- a/src/page/exam/ExamReviewListPage/ExamReviewListPage.module.css
+++ b/src/page/exam/ExamReviewListPage/ExamReviewListPage.module.css
@@ -1,5 +1,5 @@
 .container {
-  padding-bottom: 7rem;
+  padding-bottom: 112px;
   width: 100%;
   height: 100vh;
   display: flex;
@@ -9,25 +9,25 @@
 
 .notification {
   width: 100%;
-  padding: 0.625rem var(--default-margin);
-  padding-top: 4rem;
+  padding: 10px var(--default-margin);
+  padding-top: 64px;
 }
 
 .notificationBar {
   width: 100%;
-  padding: 0.688rem 0.938rem;
+  padding: 11.008px 15.008px;
   display: flex;
   align-items: center;
-  gap: 0.861rem;
-  border-radius: 0.3125rem;
+  gap: 13.776px;
+  border-radius: 5px;
   background-color: var(--pink-1);
-  font-size: 0.688rem;
+  font-size: 11.008px;
   color: var(--pink-3);
   box-sizing: border-box;
   cursor: pointer;
 }
 
 .search {
-  width: calc(100% - 1.25rem * 2);
-  margin: 0 1.25rem 0.625rem 1.25rem;
+  width: calc(100% - 20px * 2);
+  margin: 0 20px 10px 20px;
 }

--- a/src/page/exam/ExamReviewPage/ExamReviewPage.module.css
+++ b/src/page/exam/ExamReviewPage/ExamReviewPage.module.css
@@ -1,19 +1,19 @@
 .top {
   width: 100%;
-  padding-bottom: 1.4375rem;
-  padding-top: 2.813rem;
+  padding-bottom: 23px;
+  padding-top: 45.008px;
   display: flex;
   flex-direction: column;
   background-color: var(--blue-0);
-  border-radius: 0 0 0.9375rem 0.9375rem;
+  border-radius: 0 0 15px 15px;
 }
 
 .displayBox {
-  margin: 0.75rem var(--default-margin) 0.25rem var(--default-margin);
+  margin: 12px var(--default-margin) 4px var(--default-margin);
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-size: 0.75rem;
+  font-size: 12px;
   color: var(--gray-3-1);
 }
 
@@ -23,42 +23,42 @@
 }
 
 .cloudIcon {
-  margin-right: 0.4375rem;
+  margin-right: 7px;
 }
 
 .checkCircleIcon {
-  margin-left: 0.25rem;
+  margin-left: 4px;
 }
 
 .dot {
-  width: 0.1875rem;
-  height: 0.1875rem;
-  margin: 0 0.5rem;
+  width: 3px;
+  height: 3px;
+  margin: 0 8px;
   background: var(--gray-3-1);
   border-radius: 100%;
 }
 
 .more {
-  padding: 0 0.25rem;
+  padding: 0 4px;
   cursor: pointer;
 }
 
 .title {
   margin: 0 var(--default-margin);
   font-weight: 700;
-  font-size: 1rem;
+  font-size: 16px;
 }
 
 .info {
-  padding: 0.125rem 0.8125rem;
-  margin: 1.4375rem var(--default-margin);
+  padding: 2px 13px;
+  margin: 23px var(--default-margin);
   background: var(--white);
-  border-radius: 0.3125rem;
+  border-radius: 5px;
 }
 
 .content {
-  margin: 0 var(--default-margin) 1.4375rem var(--default-margin);
-  font-size: 0.875rem;
+  margin: 0 var(--default-margin) 23px var(--default-margin);
+  font-size: 14px;
   word-break: keep-all;
 }
 
@@ -67,11 +67,11 @@
 }
 
 .actions {
-  margin: 0.9375rem var(--default-margin) 0 0;
+  margin: 15px var(--default-margin) 0 0;
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  font-size: 0.6875rem;
+  font-size: 11px;
   color: var(--gray-3-1);
 
   div:nth-of-type(2):hover {
@@ -81,13 +81,13 @@
 }
 
 .action {
-  padding: 0.25rem 0.5rem;
+  padding: 4px 8px;
   display: flex;
   align-items: center;
-  gap: 0.375rem;
-  border-radius: 0.3125rem;
+  gap: 6px;
+  border-radius: 5px;
 }
 
 .comment {
-  margin-top: 0.0625rem;
+  margin-top: 1px;
 }

--- a/src/page/exam/ExamReviewPage/ExamReviewPage.module.css
+++ b/src/page/exam/ExamReviewPage/ExamReviewPage.module.css
@@ -89,5 +89,5 @@
 }
 
 .comment {
-  margin-top: 1px;
+  margin-top: 0.0625rem;
 }

--- a/src/page/exam/ExamReviewPage/ExamReviewPage.module.css
+++ b/src/page/exam/ExamReviewPage/ExamReviewPage.module.css
@@ -1,19 +1,19 @@
 .top {
   width: 100%;
-  padding-bottom: 23px;
-  padding-top: 45.008px;
+  padding-bottom: 2.3rem;
+  padding-top: 4.5rem;
   display: flex;
   flex-direction: column;
   background-color: var(--blue-0);
-  border-radius: 0 0 15px 15px;
+  border-radius: 0 0 1.5rem 1.5rem;
 }
 
 .displayBox {
-  margin: 12px var(--default-margin) 4px var(--default-margin);
+  margin: 1.2rem var(--default-margin) 0.4rem var(--default-margin);
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-size: 12px;
+  font-size: 1.2rem;
   color: var(--gray-3-1);
 }
 
@@ -23,42 +23,42 @@
 }
 
 .cloudIcon {
-  margin-right: 7px;
+  margin-right: 0.7rem;
 }
 
 .checkCircleIcon {
-  margin-left: 4px;
+  margin-left: 0.4rem;
 }
 
 .dot {
-  width: 3px;
-  height: 3px;
-  margin: 0 8px;
+  width: 0.3rem;
+  height: 0.3rem;
+  margin: 0 0.8rem;
   background: var(--gray-3-1);
   border-radius: 100%;
 }
 
 .more {
-  padding: 0 4px;
+  padding: 0 0.4rem;
   cursor: pointer;
 }
 
 .title {
   margin: 0 var(--default-margin);
   font-weight: 700;
-  font-size: 16px;
+  font-size: 1.6rem;
 }
 
 .info {
-  padding: 2px 13px;
-  margin: 23px var(--default-margin);
+  padding: 0.2rem 1.3rem;
+  margin: 2.3rem var(--default-margin);
   background: var(--white);
-  border-radius: 5px;
+  border-radius: 0.5rem;
 }
 
 .content {
-  margin: 0 var(--default-margin) 23px var(--default-margin);
-  font-size: 14px;
+  margin: 0 var(--default-margin) 2.3rem var(--default-margin);
+  font-size: 1.4rem;
   word-break: keep-all;
 }
 
@@ -67,11 +67,11 @@
 }
 
 .actions {
-  margin: 15px var(--default-margin) 0 0;
+  margin: 1.5rem var(--default-margin) 0 0;
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  font-size: 11px;
+  font-size: 1.1rem;
   color: var(--gray-3-1);
 
   div:nth-of-type(2):hover {
@@ -81,13 +81,13 @@
 }
 
 .action {
-  padding: 4px 8px;
+  padding: 0.4rem 0.8rem;
   display: flex;
   align-items: center;
-  gap: 6px;
-  border-radius: 5px;
+  gap: 0.6rem;
+  border-radius: 0.5rem;
 }
 
 .comment {
-  margin-top: 1px;
+  margin-top: 0.1rem;
 }

--- a/src/page/exam/WriteExamReviewPage/WriteExamReviewPage.module.css
+++ b/src/page/exam/WriteExamReviewPage/WriteExamReviewPage.module.css
@@ -1,37 +1,37 @@
 .main {
-  margin-bottom: 3.125rem;
-  padding-top: 3.875rem;
+  margin-bottom: 50px;
+  padding-top: 62px;
 }
 
 .file {
-  margin: 0 1.25rem;
+  margin: 0 20px;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 1rem;
+  gap: 16px;
 }
 
 .left {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 8px;
   position: relative;
 }
 
 .left .required {
-  width: 0.3125rem;
-  height: 0.3125rem;
+  width: 5px;
+  height: 5px;
   display: inline-block;
   position: absolute;
-  top: 0.125rem;
-  right: -0.625rem;
-  border-radius: 0.625rem;
+  top: 2px;
+  right: -10px;
+  border-radius: 10px;
   background-color: var(--pink-3);
 }
 
 .tag {
   font-weight: 500;
-  font-size: 0.875rem;
+  font-size: 14px;
   color: var(--gray-4);
 }
 
@@ -40,11 +40,11 @@
 }
 
 label[for='file'] {
-  padding: 0.5rem 1rem;
+  padding: 8px 16px;
   display: block;
   background: var(--gray-2);
-  border-radius: 0.3125rem;
-  font-size: 0.8125rem;
+  border-radius: 5px;
+  font-size: 13px;
   color: var(--gray-3-1);
   cursor: pointer;
 }

--- a/src/page/exam/WriteExamReviewPage/WriteExamReviewPage.module.css
+++ b/src/page/exam/WriteExamReviewPage/WriteExamReviewPage.module.css
@@ -1,37 +1,37 @@
 .main {
-  margin-bottom: 50px;
-  padding-top: 62px;
+  margin-bottom: 5rem;
+  padding-top: 6.2rem;
 }
 
 .file {
-  margin: 0 20px;
+  margin: 0 2rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 16px;
+  gap: 1.6rem;
 }
 
 .left {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 0.8rem;
   position: relative;
 }
 
 .left .required {
-  width: 5px;
-  height: 5px;
+  width: 0.5rem;
+  height: 0.5rem;
   display: inline-block;
   position: absolute;
-  top: 2px;
-  right: -10px;
-  border-radius: 10px;
+  top: 0.2rem;
+  right: -1rem;
+  border-radius: 1rem;
   background-color: var(--pink-3);
 }
 
 .tag {
   font-weight: 500;
-  font-size: 14px;
+  font-size: 1.4rem;
   color: var(--gray-4);
 }
 
@@ -40,11 +40,11 @@
 }
 
 label[for='file'] {
-  padding: 8px 16px;
+  padding: 0.8rem 1.6rem;
   display: block;
   background: var(--gray-2);
-  border-radius: 5px;
-  font-size: 13px;
+  border-radius: 0.5rem;
+  font-size: 1.3rem;
   color: var(--gray-3-1);
   cursor: pointer;
 }

--- a/src/page/home/AttendancePage/AttendancePage.module.css
+++ b/src/page/home/AttendancePage/AttendancePage.module.css
@@ -4,13 +4,13 @@
   display: flex;
   flex-direction: column;
   background-color: var(--blue-4);
-  border-radius: 0 0 15px 15px;
+  border-radius: 0 0 1.5rem 1.5rem;
 }
 
 .title {
-  margin-bottom: 30px;
+  margin-bottom: 3rem;
   font-weight: 700;
-  font-size: 20px;
+  font-size: 2rem;
   text-align: center;
   color: var(--white);
   white-space: pre-line;
@@ -22,12 +22,12 @@
 }
 
 .attendanceButton {
-  margin: 26px var(--default-margin);
-  padding: 13px 0;
+  margin: 2.6rem var(--default-margin);
+  padding: 1.3rem 0;
   background: var(--blue-0);
-  border-radius: 5px;
+  border-radius: 0.5rem;
   font-weight: 500;
-  font-size: 14px;
+  font-size: 1.4rem;
   text-align: center;
   color: var(--blue-4);
 }
@@ -44,35 +44,35 @@
 /* bottom */
 
 .bottom {
-  margin: 17px 0 50px 0;
+  margin: 1.7rem 0 5rem 0;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 1rem;
 }
 
 .item {
   margin: 0 var(--default-margin);
-  padding: 14px 20px;
+  padding: 1.4rem 2rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
   background: var(--blue-0);
-  border-radius: 5px;
+  border-radius: 0.5rem;
 }
 
 .itemLeft {
   display: flex;
   flex-direction: column;
-  gap: 1px;
+  gap: 0.1rem;
 }
 
 .label {
   font-weight: 500;
-  font-size: 14px;
+  font-size: 1.4rem;
   color: var(--blue-4);
 }
 
 .description {
-  font-size: 13px;
+  font-size: 1.3rem;
   color: var(--gray-4);
 }

--- a/src/page/home/AttendancePage/AttendancePage.module.css
+++ b/src/page/home/AttendancePage/AttendancePage.module.css
@@ -4,13 +4,13 @@
   display: flex;
   flex-direction: column;
   background-color: var(--blue-4);
-  border-radius: 0 0 0.9375rem 0.9375rem;
+  border-radius: 0 0 15px 15px;
 }
 
 .title {
-  margin-bottom: 1.875rem;
+  margin-bottom: 30px;
   font-weight: 700;
-  font-size: 1.25rem;
+  font-size: 20px;
   text-align: center;
   color: var(--white);
   white-space: pre-line;
@@ -22,12 +22,12 @@
 }
 
 .attendanceButton {
-  margin: 1.625rem var(--default-margin);
-  padding: 0.8125rem 0;
+  margin: 26px var(--default-margin);
+  padding: 13px 0;
   background: var(--blue-0);
-  border-radius: 0.3125rem;
+  border-radius: 5px;
   font-weight: 500;
-  font-size: 0.875rem;
+  font-size: 14px;
   text-align: center;
   color: var(--blue-4);
 }
@@ -44,35 +44,35 @@
 /* bottom */
 
 .bottom {
-  margin: 1.0625rem 0 3.125rem 0;
+  margin: 17px 0 50px 0;
   display: flex;
   flex-direction: column;
-  gap: 0.625rem;
+  gap: 10px;
 }
 
 .item {
   margin: 0 var(--default-margin);
-  padding: 0.875rem 1.25rem;
+  padding: 14px 20px;
   display: flex;
   justify-content: space-between;
   align-items: center;
   background: var(--blue-0);
-  border-radius: 0.3125rem;
+  border-radius: 5px;
 }
 
 .itemLeft {
   display: flex;
   flex-direction: column;
-  gap: 0.0625rem;
+  gap: 1px;
 }
 
 .label {
   font-weight: 500;
-  font-size: 0.875rem;
+  font-size: 14px;
   color: var(--blue-4);
 }
 
 .description {
-  font-size: 0.8125rem;
+  font-size: 13px;
   color: var(--gray-4);
 }

--- a/src/page/home/AttendancePage/AttendancePage.module.css
+++ b/src/page/home/AttendancePage/AttendancePage.module.css
@@ -63,7 +63,7 @@
 .itemLeft {
   display: flex;
   flex-direction: column;
-  gap: 1px;
+  gap: 0.0625rem;
 }
 
 .label {

--- a/src/page/home/MainPage/MainPage.module.css
+++ b/src/page/home/MainPage/MainPage.module.css
@@ -1,11 +1,11 @@
 .header {
-  margin-bottom: 1.25rem;
+  margin-bottom: 20px;
 }
 
 .carousel {
-  margin-bottom: 2.5625rem;
+  margin-bottom: 41px;
 }
 
 .community {
-  margin-bottom: 1.5625rem;
+  margin-bottom: 25px;
 }

--- a/src/page/home/MainPage/MainPage.module.css
+++ b/src/page/home/MainPage/MainPage.module.css
@@ -7,5 +7,5 @@
 }
 
 .community {
-  margin-bottom: 25px;
+  margin-bottom: 1.5625rem;
 }

--- a/src/page/home/MainPage/MainPage.module.css
+++ b/src/page/home/MainPage/MainPage.module.css
@@ -1,11 +1,11 @@
 .header {
-  margin-bottom: 20px;
+  margin-bottom: 2rem;
 }
 
 .carousel {
-  margin-bottom: 41px;
+  margin-bottom: 4.1rem;
 }
 
 .community {
-  margin-bottom: 25px;
+  margin-bottom: 2.5rem;
 }

--- a/src/page/search/SearchPage/SearchPage.module.css
+++ b/src/page/search/SearchPage/SearchPage.module.css
@@ -1,6 +1,6 @@
 .container {
-  padding-top: 4rem;
-  padding-bottom: 5rem;
+  padding-top: 64px;
+  padding-bottom: 80px;
   width: 100%;
   height: 100%;
   display: flex;

--- a/src/page/search/SearchPage/SearchPage.module.css
+++ b/src/page/search/SearchPage/SearchPage.module.css
@@ -1,6 +1,6 @@
 .container {
-  padding-top: 64px;
-  padding-bottom: 80px;
+  padding-top: 6.4rem;
+  padding-bottom: 8rem;
   width: 100%;
   height: 100%;
   display: flex;

--- a/src/page/snorose/AboutPage/AboutPage.module.css
+++ b/src/page/snorose/AboutPage/AboutPage.module.css
@@ -1,12 +1,12 @@
 .logo {
-  margin: 64px var(--default-margin) 26px var(--default-margin);
+  margin: 6.4rem var(--default-margin) 2.6rem var(--default-margin);
 }
 
 .container {
-  margin: 0 var(--default-margin) 100px var(--default-margin);
-  padding: 0 14px;
+  margin: 0 var(--default-margin) 10rem var(--default-margin);
+  padding: 0 1.4rem;
   background: var(--blue-0);
-  border-radius: 5px;
+  border-radius: 0.5rem;
 }
 
 /* 스노로즈 소개 */
@@ -20,7 +20,7 @@
 
 .hallOfFame {
   background: var(--blue-1);
-  border-radius: 5px;
+  border-radius: 0.5rem;
 }
 
 .hallOfFame img {
@@ -29,14 +29,14 @@
 }
 
 .hallOfFame .tags {
-  margin: 0 8px;
-  padding-bottom: 20.48px;
+  margin: 0 0.8rem;
+  padding-bottom: 20rem;
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
-  gap: 6.4px;
+  gap: 0.6rem;
 }
 
 .apply {
-  margin-top: 10px;
+  margin-top: 1rem;
 }

--- a/src/page/snorose/AboutPage/AboutPage.module.css
+++ b/src/page/snorose/AboutPage/AboutPage.module.css
@@ -3,7 +3,7 @@
 }
 
 .container {
-  margin: 0 var(--default-margin) 100px var(--default-margin);
+  margin: 0 var(--default-margin) 6.25rem var(--default-margin);
   padding: 0 0.875rem;
   background: var(--blue-0);
   border-radius: 0.3125rem;
@@ -38,5 +38,5 @@
 }
 
 .apply {
-  margin-top: 10px;
+  margin-top: 0.625rem;
 }

--- a/src/page/snorose/AboutPage/AboutPage.module.css
+++ b/src/page/snorose/AboutPage/AboutPage.module.css
@@ -1,12 +1,12 @@
 .logo {
-  margin: 4rem var(--default-margin) 1.625rem var(--default-margin);
+  margin: 64px var(--default-margin) 26px var(--default-margin);
 }
 
 .container {
-  margin: 0 var(--default-margin) 6.25rem var(--default-margin);
-  padding: 0 0.875rem;
+  margin: 0 var(--default-margin) 100px var(--default-margin);
+  padding: 0 14px;
   background: var(--blue-0);
-  border-radius: 0.3125rem;
+  border-radius: 5px;
 }
 
 /* 스노로즈 소개 */
@@ -20,7 +20,7 @@
 
 .hallOfFame {
   background: var(--blue-1);
-  border-radius: 0.3125rem;
+  border-radius: 5px;
 }
 
 .hallOfFame img {
@@ -29,14 +29,14 @@
 }
 
 .hallOfFame .tags {
-  margin: 0 0.5rem;
-  padding-bottom: 1.28rem;
+  margin: 0 8px;
+  padding-bottom: 20.48px;
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
-  gap: 0.4rem;
+  gap: 6.4px;
 }
 
 .apply {
-  margin-top: 0.625rem;
+  margin-top: 10px;
 }

--- a/src/page/snorose/PolicyPage/PolicyPage.module.css
+++ b/src/page/snorose/PolicyPage/PolicyPage.module.css
@@ -6,43 +6,43 @@
 .contentWrapper {
   display: flex;
   flex-direction: column;
-  padding: 0 20px 54px 20px;
+  padding: 0 1.25rem 3.375rem 1.25rem;
   width: 100%;
-  gap: 14px;
-  padding-top: 50px;
+  gap: 0.875rem;
+  padding-top: 3.125rem;
 }
 .contentWrapper section {
-  margin-bottom: 20px;
+  margin-bottom: 1.25rem;
 }
 .contentWrapper h2 {
-  padding: 3px 2px;
-  font-size: 16px;
+  padding: 0.1875rem 0.125rem;
+  font-size: 1rem;
   font-weight: bold;
 }
 .contentWrapper p {
-  padding: 4px 2px;
+  padding: 0.25rem 0.125rem;
 }
 .contentWrapper ul {
   list-style-type: disc;
-  padding-left: 20px;
+  padding-left: 1.25rem;
 }
 .contentWrapper ol {
   list-style-type: decimal;
-  padding-left: 22px;
+  padding-left: 1.375rem;
 }
 
 .title {
-  font-size: 20px;
+  font-size: 1.25rem;
   font-weight: 700;
 }
 
 .content {
-  padding: 16px 13px;
-  border-radius: 5px;
+  padding: 1rem 0.8125rem;
+  border-radius: 0.3125rem;
   background: var(--Miscellaneous-_Kit-Section-Fill, #f5f5f5);
   color: var(--Grey-4, var(--grey-3, #484848));
-  font-size: 14px;
+  font-size: 0.875rem;
   line-height: 1.6;
-  letter-spacing: -0.5px;
+  letter-spacing: -0.0313rem;
   white-space: pre-line;
 }

--- a/src/page/snorose/PolicyPage/PolicyPage.module.css
+++ b/src/page/snorose/PolicyPage/PolicyPage.module.css
@@ -6,43 +6,43 @@
 .contentWrapper {
   display: flex;
   flex-direction: column;
-  padding: 0 20px 54px 20px;
+  padding: 0 2rem 5.4rem 2rem;
   width: 100%;
-  gap: 14px;
-  padding-top: 50px;
+  gap: 1.4rem;
+  padding-top: 5rem;
 }
 .contentWrapper section {
-  margin-bottom: 20px;
+  margin-bottom: 2rem;
 }
 .contentWrapper h2 {
-  padding: 3px 2px;
-  font-size: 16px;
+  padding: 0.3rem 0.2rem;
+  font-size: 1.6rem;
   font-weight: bold;
 }
 .contentWrapper p {
-  padding: 4px 2px;
+  padding: 0.4rem 0.2rem;
 }
 .contentWrapper ul {
   list-style-type: disc;
-  padding-left: 20px;
+  padding-left: 2rem;
 }
 .contentWrapper ol {
   list-style-type: decimal;
-  padding-left: 22px;
+  padding-left: 2.2rem;
 }
 
 .title {
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: 700;
 }
 
 .content {
-  padding: 16px 13px;
-  border-radius: 5px;
+  padding: 1.6rem 1.3rem;
+  border-radius: 0.5rem;
   background: var(--Miscellaneous-_Kit-Section-Fill, #f5f5f5);
   color: var(--Grey-4, var(--grey-3, #484848));
-  font-size: 14px;
+  font-size: 1.4rem;
   line-height: 1.6;
-  letter-spacing: -0.5008px;
+  letter-spacing: -0.05rem;
   white-space: pre-line;
 }

--- a/src/page/snorose/PolicyPage/PolicyPage.module.css
+++ b/src/page/snorose/PolicyPage/PolicyPage.module.css
@@ -6,43 +6,43 @@
 .contentWrapper {
   display: flex;
   flex-direction: column;
-  padding: 0 1.25rem 3.375rem 1.25rem;
+  padding: 0 20px 54px 20px;
   width: 100%;
-  gap: 0.875rem;
-  padding-top: 3.125rem;
+  gap: 14px;
+  padding-top: 50px;
 }
 .contentWrapper section {
-  margin-bottom: 1.25rem;
+  margin-bottom: 20px;
 }
 .contentWrapper h2 {
-  padding: 0.1875rem 0.125rem;
-  font-size: 1rem;
+  padding: 3px 2px;
+  font-size: 16px;
   font-weight: bold;
 }
 .contentWrapper p {
-  padding: 0.25rem 0.125rem;
+  padding: 4px 2px;
 }
 .contentWrapper ul {
   list-style-type: disc;
-  padding-left: 1.25rem;
+  padding-left: 20px;
 }
 .contentWrapper ol {
   list-style-type: decimal;
-  padding-left: 1.375rem;
+  padding-left: 22px;
 }
 
 .title {
-  font-size: 1.25rem;
+  font-size: 20px;
   font-weight: 700;
 }
 
 .content {
-  padding: 1rem 0.8125rem;
-  border-radius: 0.3125rem;
+  padding: 16px 13px;
+  border-radius: 5px;
   background: var(--Miscellaneous-_Kit-Section-Fill, #f5f5f5);
   color: var(--Grey-4, var(--grey-3, #484848));
-  font-size: 0.875rem;
+  font-size: 14px;
   line-height: 1.6;
-  letter-spacing: -0.0313rem;
+  letter-spacing: -0.5008px;
   white-space: pre-line;
 }

--- a/src/page/user/ActivityPage/ActivityPage.module.css
+++ b/src/page/user/ActivityPage/ActivityPage.module.css
@@ -7,7 +7,7 @@
 
 .contentWrapper {
   flex: 1;
-  padding: 45.008px 20px 54px 20px;
+  padding: 4.5rem 2rem 5.4rem 2rem;
   width: 100%;
   display: flex;
   flex-direction: column;
@@ -16,10 +16,10 @@
 .topContainer {
   display: flex;
   justify-content: space-between;
-  padding: 14px 0;
+  padding: 1.4rem 0;
 }
 
 .title {
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: 700;
 }

--- a/src/page/user/ActivityPage/ActivityPage.module.css
+++ b/src/page/user/ActivityPage/ActivityPage.module.css
@@ -7,7 +7,7 @@
 
 .contentWrapper {
   flex: 1;
-  padding: 2.813rem 1.25rem 3.375rem 1.25rem;
+  padding: 45.008px 20px 54px 20px;
   width: 100%;
   display: flex;
   flex-direction: column;
@@ -16,10 +16,10 @@
 .topContainer {
   display: flex;
   justify-content: space-between;
-  padding: 0.875rem 0;
+  padding: 14px 0;
 }
 
 .title {
-  font-size: 1.25rem;
+  font-size: 20px;
   font-weight: 700;
 }

--- a/src/page/user/ChangePwPage/ChangePwPage.module.css
+++ b/src/page/user/ChangePwPage/ChangePwPage.module.css
@@ -11,13 +11,13 @@
 
 .submitBtn {
   background-color: transparent;
-  padding: 0.875rem 1.25rem;
-  font-size: 1rem;
+  padding: 14px 20px;
+  font-size: 16px;
 }
 
 .contentContainer {
   display: flex;
   flex-direction: column;
-  padding: 0.875rem 1.25rem;
-  gap: 1.75rem;
+  padding: 14px 20px;
+  gap: 28px;
 }

--- a/src/page/user/ChangePwPage/ChangePwPage.module.css
+++ b/src/page/user/ChangePwPage/ChangePwPage.module.css
@@ -11,13 +11,13 @@
 
 .submitBtn {
   background-color: transparent;
-  padding: 14px 20px;
-  font-size: 16px;
+  padding: 1.4rem 2rem;
+  font-size: 1.6rem;
 }
 
 .contentContainer {
   display: flex;
   flex-direction: column;
-  padding: 14px 20px;
-  gap: 28px;
+  padding: 1.4rem 2rem;
+  gap: 2.8rem;
 }

--- a/src/page/user/DeleteAccountPage/DeleteAccountPage.module.css
+++ b/src/page/user/DeleteAccountPage/DeleteAccountPage.module.css
@@ -14,14 +14,14 @@
 .titleDescWrapper {
   display: flex;
   flex-direction: column;
-  padding: 1.25rem;
-  gap: 0.875rem;
+  padding: 20px;
+  gap: 14px;
   flex-grow: 1;
 }
 
 .title {
   color: var(--black);
-  font-size: 1.25rem;
+  font-size: 20px;
   font-weight: 700;
 }
 
@@ -29,13 +29,13 @@
   display: flex;
   flex-direction: column;
   justify-content: start;
-  gap: 0.3125rem;
-  padding-bottom: 0.8125rem;
+  gap: 5px;
+  padding-bottom: 13px;
 }
 
 .desc {
   color: var(--gray-4);
-  font-size: 0.875rem;
+  font-size: 14px;
   font-weight: 500;
 }
 
@@ -45,8 +45,8 @@
   flex-direction: column;
   bottom: 0;
   width: 100%;
-  gap: 0.5rem;
-  padding: 1.25rem 1.25rem 3.375rem;
+  gap: 8px;
+  padding: 20px 20px 54px;
 }
 
 .goBackButton {
@@ -54,11 +54,11 @@
   justify-content: center;
   align-items: center;
   width: 100%;
-  height: 2.9375rem;
-  border-radius: 0.3125rem;
+  height: 47px;
+  border-radius: 5px;
   background: var(--blue-1);
   color: var(--blue-3);
-  font-size: 0.875rem;
+  font-size: 14px;
   font-weight: 500;
 }
 
@@ -67,11 +67,11 @@
   justify-content: center;
   align-items: center;
   width: 100%;
-  height: 2.9375rem;
-  border-radius: 0.3125rem;
+  height: 47px;
+  border-radius: 5px;
   background: var(--blue-4);
   color: var(--white);
   text-align: center;
-  font-size: 0.875rem;
+  font-size: 14px;
   font-weight: 500;
 }

--- a/src/page/user/DeleteAccountPage/DeleteAccountPage.module.css
+++ b/src/page/user/DeleteAccountPage/DeleteAccountPage.module.css
@@ -14,14 +14,14 @@
 .titleDescWrapper {
   display: flex;
   flex-direction: column;
-  padding: 20px;
-  gap: 14px;
+  padding: 2rem;
+  gap: 1.4rem;
   flex-grow: 1;
 }
 
 .title {
   color: var(--black);
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: 700;
 }
 
@@ -29,13 +29,13 @@
   display: flex;
   flex-direction: column;
   justify-content: start;
-  gap: 5px;
-  padding-bottom: 13px;
+  gap: 0.5rem;
+  padding-bottom: 1.3rem;
 }
 
 .desc {
   color: var(--gray-4);
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 500;
 }
 
@@ -45,8 +45,8 @@
   flex-direction: column;
   bottom: 0;
   width: 100%;
-  gap: 8px;
-  padding: 20px 20px 54px;
+  gap: 0.8rem;
+  padding: 2rem 2rem 5.4rem;
 }
 
 .goBackButton {
@@ -54,11 +54,11 @@
   justify-content: center;
   align-items: center;
   width: 100%;
-  height: 47px;
-  border-radius: 5px;
+  height: 4.7rem;
+  border-radius: 0.5rem;
   background: var(--blue-1);
   color: var(--blue-3);
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 500;
 }
 
@@ -67,11 +67,11 @@
   justify-content: center;
   align-items: center;
   width: 100%;
-  height: 47px;
-  border-radius: 5px;
+  height: 4.7rem;
+  border-radius: 0.5rem;
   background: var(--blue-4);
   color: var(--white);
   text-align: center;
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 500;
 }

--- a/src/page/user/EditProfilePage/EditProfilePage.module.css
+++ b/src/page/user/EditProfilePage/EditProfilePage.module.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  margin-bottom: 100px;
+  margin-bottom: 10rem;
 }
 
 .topContainer {
@@ -12,8 +12,8 @@
 
 .submitBtn {
   background-color: transparent;
-  padding: 14px 20px;
-  font-size: 16px;
+  padding: 1.4rem 2rem;
+  font-size: 1.6rem;
 }
 
 /* 프로필 */
@@ -21,7 +21,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding: 0 20px;
+  padding: 0 2rem;
 }
 
 .profileImgContainer {
@@ -30,11 +30,11 @@
 }
 
 .profileImg {
-  --size: 104px;
+  --size: 10.4rem;
 
   width: var(--size);
   height: var(--size);
-  padding: 12px;
+  padding: 1.2rem;
   display: flex;
   flex-shrink: 0;
   position: relative;
@@ -49,40 +49,40 @@
 
 .blueCamera {
   position: absolute;
-  bottom: 15px;
-  right: 15px;
+  bottom: 1.5rem;
+  right: 1.5rem;
 }
 
 .contentContainer {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 2.4rem;
 }
 
 .infoWrapper {
   display: flex;
   position: relative;
   flex-direction: column;
-  gap: 6px;
+  gap: 0.6rem;
 }
 
 .title {
   color: var(--gray-4);
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 500;
 }
 
 .inputText {
   display: flex;
   width: 100%;
-  height: 40px;
-  border-radius: 5px;
-  padding: 0 12px;
+  height: 4rem;
+  border-radius: 0.5rem;
+  padding: 0 1.2rem;
   border: none;
   background: var(--gray-1-1);
   outline: none;
   color: var(--black);
-  font-size: 12px;
+  font-size: 1.2rem;
 
   &:disabled {
     background: var(--gray-3);
@@ -92,11 +92,11 @@
 .errorMessage {
   position: absolute;
   color: var(--pink-3);
-  font-size: 11px;
-  top: 71px;
+  font-size: 1.1rem;
+  top: 7.1rem;
 }
 
 .errorInputText {
   background: var(--pink-1);
-  border-radius: 5px;
+  border-radius: 0.5rem;
 }

--- a/src/page/user/EditProfilePage/EditProfilePage.module.css
+++ b/src/page/user/EditProfilePage/EditProfilePage.module.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  margin-bottom: 6.25rem;
+  margin-bottom: 100px;
 }
 
 .topContainer {
@@ -12,8 +12,8 @@
 
 .submitBtn {
   background-color: transparent;
-  padding: 0.875rem 1.25rem;
-  font-size: 1rem;
+  padding: 14px 20px;
+  font-size: 16px;
 }
 
 /* 프로필 */
@@ -21,7 +21,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding: 0 1.25rem;
+  padding: 0 20px;
 }
 
 .profileImgContainer {
@@ -30,11 +30,11 @@
 }
 
 .profileImg {
-  --size: 6.5rem;
+  --size: 104px;
 
   width: var(--size);
   height: var(--size);
-  padding: 0.75rem;
+  padding: 12px;
   display: flex;
   flex-shrink: 0;
   position: relative;
@@ -49,40 +49,40 @@
 
 .blueCamera {
   position: absolute;
-  bottom: 0.9375rem;
-  right: 0.9375rem;
+  bottom: 15px;
+  right: 15px;
 }
 
 .contentContainer {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 24px;
 }
 
 .infoWrapper {
   display: flex;
   position: relative;
   flex-direction: column;
-  gap: 0.375rem;
+  gap: 6px;
 }
 
 .title {
   color: var(--gray-4);
-  font-size: 0.875rem;
+  font-size: 14px;
   font-weight: 500;
 }
 
 .inputText {
   display: flex;
   width: 100%;
-  height: 2.5rem;
-  border-radius: 0.3125rem;
-  padding: 0 0.75rem;
+  height: 40px;
+  border-radius: 5px;
+  padding: 0 12px;
   border: none;
   background: var(--gray-1-1);
   outline: none;
   color: var(--black);
-  font-size: 0.75rem;
+  font-size: 12px;
 
   &:disabled {
     background: var(--gray-3);
@@ -92,11 +92,11 @@
 .errorMessage {
   position: absolute;
   color: var(--pink-3);
-  font-size: 0.6875rem;
-  top: 4.4375rem;
+  font-size: 11px;
+  top: 71px;
 }
 
 .errorInputText {
   background: var(--pink-1);
-  border-radius: 0.3125rem;
+  border-radius: 5px;
 }

--- a/src/page/user/MyPage/MyPage.module.css
+++ b/src/page/user/MyPage/MyPage.module.css
@@ -15,31 +15,31 @@
 .myPageLower {
   width: 100%;
   flex-shrink: 0;
-  border-radius: 15px 15px 0 0;
+  border-radius: 1.5rem 1.5rem 0 0;
   background: var(--white);
   z-index: 1;
-  padding-bottom: 100px;
+  padding-bottom: 10rem;
 }
 
 /* 탭 메뉴 */
 .tabMenu {
   display: flex;
-  margin: 29px 20px 14px;
-  border-top: 1px solid var(--gray-3);
+  margin: 2.9rem 2rem 1.4rem;
+  border-top: 0.1rem solid var(--gray-3);
 }
 
 .tab {
   width: 100%;
-  padding: 15px;
+  padding: 1.5rem;
   color: var(--gray-3-1);
   text-align: center;
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 500;
   cursor: pointer;
 }
 
 .tab.active {
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 500;
-  border-top: 2px solid var(--blue-4);
+  border-top: 0.2rem solid var(--blue-4);
 }

--- a/src/page/user/MyPage/MyPage.module.css
+++ b/src/page/user/MyPage/MyPage.module.css
@@ -15,31 +15,31 @@
 .myPageLower {
   width: 100%;
   flex-shrink: 0;
-  border-radius: 15px 15px 0 0;
+  border-radius: 0.9375rem 0.9375rem 0 0;
   background: var(--white);
   z-index: 1;
-  padding-bottom: 100px;
+  padding-bottom: 6.25rem;
 }
 
 /* 탭 메뉴 */
 .tabMenu {
   display: flex;
-  margin: 29px 20px 14px;
-  border-top: 1px solid var(--gray-3);
+  margin: 1.8125rem 1.25rem 0.875rem;
+  border-top: 0.0625rem solid var(--gray-3);
 }
 
 .tab {
   width: 100%;
-  padding: 15px;
+  padding: 0.9375rem;
   color: var(--gray-3-1);
   text-align: center;
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: 500;
   cursor: pointer;
 }
 
 .tab.active {
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: 500;
-  border-top: 2px solid var(--blue-4);
+  border-top: 0.125rem solid var(--blue-4);
 }

--- a/src/page/user/MyPage/MyPage.module.css
+++ b/src/page/user/MyPage/MyPage.module.css
@@ -15,31 +15,31 @@
 .myPageLower {
   width: 100%;
   flex-shrink: 0;
-  border-radius: 0.9375rem 0.9375rem 0 0;
+  border-radius: 15px 15px 0 0;
   background: var(--white);
   z-index: 1;
-  padding-bottom: 6.25rem;
+  padding-bottom: 100px;
 }
 
 /* 탭 메뉴 */
 .tabMenu {
   display: flex;
-  margin: 1.8125rem 1.25rem 0.875rem;
-  border-top: 0.0625rem solid var(--gray-3);
+  margin: 29px 20px 14px;
+  border-top: 1px solid var(--gray-3);
 }
 
 .tab {
   width: 100%;
-  padding: 0.9375rem;
+  padding: 15px;
   color: var(--gray-3-1);
   text-align: center;
-  font-size: 0.875rem;
+  font-size: 14px;
   font-weight: 500;
   cursor: pointer;
 }
 
 .tab.active {
-  font-size: 0.875rem;
+  font-size: 14px;
   font-weight: 500;
-  border-top: 0.125rem solid var(--blue-4);
+  border-top: 2px solid var(--blue-4);
 }

--- a/src/page/user/PointLogListPage/PointLogListPage.module.css
+++ b/src/page/user/PointLogListPage/PointLogListPage.module.css
@@ -8,19 +8,19 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  padding: 0 1.25rem 3.375rem 1.25rem;
+  padding: 0 20px 54px 20px;
   width: 100%;
-  padding-top: 2.813rem;
+  padding-top: 45.008px;
 }
 
 .topContainer {
   display: flex;
   justify-content: space-between;
-  padding: 0.875rem 0;
+  padding: 14px 0;
 }
 
 .title {
-  font-size: 1.25rem;
+  font-size: 20px;
   font-weight: 700;
 }
 
@@ -28,16 +28,16 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 0.25rem;
+  gap: 4px;
 
   svg {
-    width: 1rem;
-    height: 1rem;
+    width: 16px;
+    height: 16px;
   }
 }
 
 .totalPoint {
   color: var(--blue-4);
-  font-size: 0.875rem;
+  font-size: 14px;
   font-weight: 500;
 }

--- a/src/page/user/PointLogListPage/PointLogListPage.module.css
+++ b/src/page/user/PointLogListPage/PointLogListPage.module.css
@@ -8,19 +8,19 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  padding: 0 20px 54px 20px;
+  padding: 0 2rem 5.4rem 2rem;
   width: 100%;
-  padding-top: 45.008px;
+  padding-top: 4.5rem;
 }
 
 .topContainer {
   display: flex;
   justify-content: space-between;
-  padding: 14px 0;
+  padding: 1.4rem 0;
 }
 
 .title {
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: 700;
 }
 
@@ -28,16 +28,16 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 4px;
+  gap: 0.4rem;
 
   svg {
-    width: 16px;
-    height: 16px;
+    width: 1.6rem;
+    height: 1.6rem;
   }
 }
 
 .totalPoint {
   color: var(--blue-4);
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 500;
 }

--- a/src/pages/PostPage/PostPage/PostContent.module.css
+++ b/src/pages/PostPage/PostPage/PostContent.module.css
@@ -1,0 +1,16 @@
+.content {
+  font-size: 0.75rem;
+  color: var(--gray-4);
+  font-size: 0.875rem;
+  padding: 0 0.8125rem 0.9375rem 0;
+  white-space: pre-wrap;
+  word-break: keep-all;
+}
+
+.content a {
+  color: var(--blue-3);
+}
+
+.content a:hover {
+  text-decoration: underline;
+}

--- a/src/pages/PostPage/PostPage/PostContent.module.css
+++ b/src/pages/PostPage/PostPage/PostContent.module.css
@@ -1,8 +1,8 @@
 .content {
-  font-size: 0.75rem;
+  font-size: 1.2rem;
   color: var(--gray-4);
-  font-size: 0.875rem;
-  padding: 0 0.8125rem 0.9375rem 0;
+  font-size: 1.4rem;
+  padding: 0 1.3rem 1.5rem 0;
   white-space: pre-wrap;
   word-break: keep-all;
 }

--- a/src/shared/component/Dropdown/Dropdown.module.css
+++ b/src/shared/component/Dropdown/Dropdown.module.css
@@ -1,14 +1,14 @@
 .dropdown {
-  padding: 0.6rem 0;
+  padding: 9.6px 0;
   background: var(--gray-2);
-  border-radius: 0.3125rem;
+  border-radius: 5px;
   border: none;
-  font-size: 0.8125rem;
+  font-size: 13px;
   color: var(--gray-4);
 }
 
 .select {
-  padding: 0 1rem;
+  padding: 0 16px;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -34,15 +34,15 @@
 }
 
 .open .list {
-  max-height: 16rem;
-  margin-top: 0.375rem;
+  max-height: 256px;
+  margin-top: 6px;
   overflow: auto;
 }
 
 .option {
-  padding: 0.5rem 0.625rem;
-  margin: 0 0.375rem;
-  border-radius: 0.25rem;
+  padding: 8px 10px;
+  margin: 0 6px;
+  border-radius: 4px;
 }
 
 .option:hover {

--- a/src/shared/component/Dropdown/Dropdown.module.css
+++ b/src/shared/component/Dropdown/Dropdown.module.css
@@ -1,14 +1,14 @@
 .dropdown {
-  padding: 9.6px 0;
+  padding: 1rem 0;
   background: var(--gray-2);
-  border-radius: 5px;
+  border-radius: 0.5rem;
   border: none;
-  font-size: 13px;
+  font-size: 1.3rem;
   color: var(--gray-4);
 }
 
 .select {
-  padding: 0 16px;
+  padding: 0 1.6rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -34,15 +34,15 @@
 }
 
 .open .list {
-  max-height: 256px;
-  margin-top: 6px;
+  max-height: 26rem;
+  margin-top: 0.6rem;
   overflow: auto;
 }
 
 .option {
-  padding: 8px 10px;
-  margin: 0 6px;
-  border-radius: 4px;
+  padding: 0.8rem 1rem;
+  margin: 0 0.6rem;
+  border-radius: 0.4rem;
 }
 
 .option:hover {

--- a/src/shared/component/List/List.module.css
+++ b/src/shared/component/List/List.module.css
@@ -1,8 +1,8 @@
 .list {
-  padding: 4px var(--default-margin) 0 var(--default-margin);
+  padding: 0.4rem var(--default-margin) 0 var(--default-margin);
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
+  gap: 0.8rem;
   overflow-y: auto;
 }

--- a/src/shared/component/List/List.module.css
+++ b/src/shared/component/List/List.module.css
@@ -1,8 +1,8 @@
 .list {
-  padding: 0.25rem var(--default-margin) 0 var(--default-margin);
+  padding: 4px var(--default-margin) 0 var(--default-margin);
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.5rem;
+  gap: 8px;
   overflow-y: auto;
 }

--- a/src/shared/component/PullToRefresh/PullToRefresh.jsx
+++ b/src/shared/component/PullToRefresh/PullToRefresh.jsx
@@ -39,7 +39,7 @@ export default function PullToRefresh({ children, onRefresh }) {
           if (pullDistance > 80) {
             ptrTouchZone.style.pointerEvents = 'none'; // 클릭 이벤트 차단
             event.preventDefault(); // 스크롤을 막습니다.
-            containerRef.current.style.transform = 'translate(0, 1.875rem)';
+            containerRef.current.style.transform = 'translate(0, 30px)';
             containerRef.current.style.transition = '0.3s';
             setRefreshing(true);
           }

--- a/src/shared/component/PullToRefresh/PullToRefresh.jsx
+++ b/src/shared/component/PullToRefresh/PullToRefresh.jsx
@@ -39,7 +39,7 @@ export default function PullToRefresh({ children, onRefresh }) {
           if (pullDistance > 80) {
             ptrTouchZone.style.pointerEvents = 'none'; // 클릭 이벤트 차단
             event.preventDefault(); // 스크롤을 막습니다.
-            containerRef.current.style.transform = 'translate(0, 30px)';
+            containerRef.current.style.transform = 'translate(0, 3rem)';
             containerRef.current.style.transition = '0.3s';
             setRefreshing(true);
           }

--- a/src/shared/component/PullToRefresh/PullToRefresh.jsx
+++ b/src/shared/component/PullToRefresh/PullToRefresh.jsx
@@ -39,7 +39,7 @@ export default function PullToRefresh({ children, onRefresh }) {
           if (pullDistance > 80) {
             ptrTouchZone.style.pointerEvents = 'none'; // 클릭 이벤트 차단
             event.preventDefault(); // 스크롤을 막습니다.
-            containerRef.current.style.transform = 'translate(0, 30px)';
+            containerRef.current.style.transform = 'translate(0, 1.875rem)';
             containerRef.current.style.transition = '0.3s';
             setRefreshing(true);
           }

--- a/src/shared/component/PullToRefresh/PullToRefresh.module.css
+++ b/src/shared/component/PullToRefresh/PullToRefresh.module.css
@@ -6,7 +6,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding-bottom: 30px;
+  padding-bottom: 3rem;
 }
 
 .refreshIcon {
@@ -15,7 +15,7 @@
 
 .ptrTouchZone {
   width: 100%;
-  height: 300px;
+  height: 30rem;
   position: absolute;
   z-index: 1;
   user-select: none;

--- a/src/shared/component/PullToRefresh/PullToRefresh.module.css
+++ b/src/shared/component/PullToRefresh/PullToRefresh.module.css
@@ -6,7 +6,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding-bottom: 1.875rem;
+  padding-bottom: 30px;
 }
 
 .refreshIcon {
@@ -15,7 +15,7 @@
 
 .ptrTouchZone {
   width: 100%;
-  height: 18.75rem;
+  height: 300px;
   position: absolute;
   z-index: 1;
   user-select: none;

--- a/src/shared/component/Toast/Toast.module.css
+++ b/src/shared/component/Toast/Toast.module.css
@@ -1,7 +1,7 @@
 .toast {
-  padding: 0.8125rem 2rem;
+  padding: 13px 32px;
   background: rgba(var(--gray-4-rgb), 0.8);
-  border-radius: 0.375rem;
+  border-radius: 6px;
   transition: 500ms opacity ease-in-out;
 }
 
@@ -9,7 +9,7 @@
   text-align: center;
   word-break: keep-all;
   font-weight: 500;
-  font-size: 0.75rem;
+  font-size: 12px;
   white-space: pre-wrap;
   color: var(--white);
 }

--- a/src/shared/component/Toast/Toast.module.css
+++ b/src/shared/component/Toast/Toast.module.css
@@ -1,7 +1,7 @@
 .toast {
-  padding: 13px 32px;
+  padding: 1.3rem 3.2rem;
   background: rgba(var(--gray-4-rgb), 0.8);
-  border-radius: 6px;
+  border-radius: 0.6rem;
   transition: 500ms opacity ease-in-out;
 }
 
@@ -9,7 +9,7 @@
   text-align: center;
   word-break: keep-all;
   font-weight: 500;
-  font-size: 12px;
+  font-size: 1.2rem;
   white-space: pre-wrap;
   color: var(--white);
 }

--- a/src/shared/component/button/ActionButton/ActionButton.module.css
+++ b/src/shared/component/button/ActionButton/ActionButton.module.css
@@ -1,6 +1,6 @@
 .button {
   background-color: transparent;
-  font-size: 16px;
+  font-size: 1.6rem;
 }
 
 .button:disabled {

--- a/src/shared/component/button/ActionButton/ActionButton.module.css
+++ b/src/shared/component/button/ActionButton/ActionButton.module.css
@@ -1,6 +1,6 @@
 .button {
   background-color: transparent;
-  font-size: 1rem;
+  font-size: 16px;
 }
 
 .button:disabled {

--- a/src/shared/component/button/Button/Button.module.css
+++ b/src/shared/component/button/Button/Button.module.css
@@ -1,9 +1,9 @@
 .submitBtn {
   width: 100%;
-  height: 47.008px;
+  height: 4.7rem;
   font-weight: 500;
-  font-size: 14px;
-  border-radius: 5px;
+  font-size: 1.4rem;
+  border-radius: 0.5rem;
 }
 
 .ready,

--- a/src/shared/component/button/Button/Button.module.css
+++ b/src/shared/component/button/Button/Button.module.css
@@ -1,9 +1,9 @@
 .submitBtn {
   width: 100%;
-  height: 2.938rem;
+  height: 47.008px;
   font-weight: 500;
-  font-size: 0.875rem;
-  border-radius: 0.3125rem;
+  font-size: 14px;
+  border-radius: 5px;
 }
 
 .ready,

--- a/src/shared/component/button/PrimaryButton/PrimaryButton.module.css
+++ b/src/shared/component/button/PrimaryButton/PrimaryButton.module.css
@@ -1,9 +1,9 @@
 .button {
   width: 100%;
-  padding: 0.8125rem 0;
-  border-radius: 0.3125rem;
+  padding: 13px 0;
+  border-radius: 5px;
   background: var(--blue-4);
   color: var(--white);
-  font-size: 0.875rem;
+  font-size: 14px;
   font-weight: 500;
 }

--- a/src/shared/component/button/PrimaryButton/PrimaryButton.module.css
+++ b/src/shared/component/button/PrimaryButton/PrimaryButton.module.css
@@ -1,9 +1,9 @@
 .button {
   width: 100%;
-  padding: 13px 0;
-  border-radius: 5px;
+  padding: 1.3rem 0;
+  border-radius: 0.5rem;
   background: var(--blue-4);
   color: var(--white);
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 500;
 }

--- a/src/shared/component/button/ResetButton/ResetButton.module.css
+++ b/src/shared/component/button/ResetButton/ResetButton.module.css
@@ -1,6 +1,6 @@
 .retry {
-  padding: 10px;
-  font-size: 20px;
+  padding: 1rem;
+  font-size: 2rem;
   transition: 400ms all ease;
   border-radius: 100%;
   cursor: pointer;

--- a/src/shared/component/button/ResetButton/ResetButton.module.css
+++ b/src/shared/component/button/ResetButton/ResetButton.module.css
@@ -1,6 +1,6 @@
 .retry {
-  padding: 0.625rem;
-  font-size: 1.25rem;
+  padding: 10px;
+  font-size: 20px;
   transition: 400ms all ease;
   border-radius: 100%;
   cursor: pointer;

--- a/src/shared/component/button/ResetButton/ResetButton.module.css
+++ b/src/shared/component/button/ResetButton/ResetButton.module.css
@@ -1,6 +1,6 @@
 .retry {
-  padding: 10px;
-  font-size: 20px;
+  padding: 0.625rem;
+  font-size: 1.25rem;
   transition: 400ms all ease;
   border-radius: 100%;
   cursor: pointer;

--- a/src/shared/component/button/WriteButton/WriteButton.module.css
+++ b/src/shared/component/button/WriteButton/WriteButton.module.css
@@ -1,21 +1,21 @@
 .button {
-  width: 4.5rem;
-  height: 4.5rem;
+  width: 72px;
+  height: 72px;
   display: flex;
   justify-content: center;
   align-items: center;
   position: fixed;
-  right: 0.9375rem;
-  bottom: 5.625rem;
+  right: 15px;
+  bottom: 90px;
   border-radius: 100%;
   background: rgba(var(--white-rgb), 0.7);
-  box-shadow: 0.25rem 0.25rem 1.1875rem rgba(var(--black-rgb), 0.15);
-  backdrop-filter: blur(0.4375rem);
+  box-shadow: 4px 4px 19px rgba(var(--black-rgb), 0.15);
+  backdrop-filter: blur(7px);
   z-index: 1;
 }
 
-@media only screen and (min-width: 37.5rem) {
+@media only screen and (min-width: 600px) {
   .button {
-    right: calc(100vw / 2 - 37.5rem / 2 + 0.9375rem);
+    right: calc(100vw / 2 - 600px / 2 + 15px);
   }
 }

--- a/src/shared/component/button/WriteButton/WriteButton.module.css
+++ b/src/shared/component/button/WriteButton/WriteButton.module.css
@@ -14,9 +14,8 @@
   z-index: 1;
 }
 
-@media only screen and (min-width: 600px) {
-  /* (100vw  - 600px) / 2 - 0.9375rem */
+@media only screen and (min-width: 37.5rem) {
   .button {
-    right: calc(100vw / 2 - 600px / 2 + 0.9375rem);
+    right: calc(100vw / 2 - 37.5rem / 2 + 0.9375rem);
   }
 }

--- a/src/shared/component/button/WriteButton/WriteButton.module.css
+++ b/src/shared/component/button/WriteButton/WriteButton.module.css
@@ -1,21 +1,21 @@
 .button {
-  width: 72px;
-  height: 72px;
+  width: 7.2rem;
+  height: 7.2rem;
   display: flex;
   justify-content: center;
   align-items: center;
   position: fixed;
-  right: 15px;
-  bottom: 90px;
+  right: 1.5rem;
+  bottom: 9rem;
   border-radius: 100%;
   background: rgba(var(--white-rgb), 0.7);
-  box-shadow: 4px 4px 19px rgba(var(--black-rgb), 0.15);
-  backdrop-filter: blur(7px);
+  box-shadow: 0.4rem 0.4rem 1.9rem rgba(var(--black-rgb), 0.15);
+  backdrop-filter: blur(0.7rem);
   z-index: 1;
 }
 
-@media only screen and (min-width: 600px) {
+@media only screen and (min-width: 60rem) {
   .button {
-    right: calc(100vw / 2 - 600px / 2 + 15px);
+    right: calc(100vw / 2 - 60rem / 2 + 1.5rem);
   }
 }

--- a/src/shared/component/input/Input/Input.module.css
+++ b/src/shared/component/input/Input/Input.module.css
@@ -1,22 +1,22 @@
 .title {
   font-weight: 500;
-  font-size: 14px;
-  margin-bottom: 5.584px;
+  font-size: 1.4rem;
+  margin-bottom: 0.6rem;
 }
 
 .input {
   width: 100%;
-  height: 41.008px;
-  border-radius: 6px;
-  padding-left: 16px;
-  padding-right: 10px;
-  font-size: 12px;
+  height: 4.1rem;
+  border-radius: 0.6rem;
+  padding-left: 1.6rem;
+  padding-right: 1rem;
+  font-size: 1.2rem;
   outline: 0;
 }
 
 .input [type='date']::-webkit-calendar-picker-indicator {
-  width: 160px;
-  height: 19.008px;
+  width: 16rem;
+  height: 1.9rem;
   background-color: var(--blue-4);
 }
 
@@ -42,6 +42,6 @@
 }
 
 .errMsg {
-  font-size: 11.008px;
+  font-size: 1.1rem;
   color: var(--pink-3);
 }

--- a/src/shared/component/input/Input/Input.module.css
+++ b/src/shared/component/input/Input/Input.module.css
@@ -1,22 +1,22 @@
 .title {
   font-weight: 500;
-  font-size: 0.875rem;
-  margin-bottom: 0.349rem;
+  font-size: 14px;
+  margin-bottom: 5.584px;
 }
 
 .input {
   width: 100%;
-  height: 2.563rem;
-  border-radius: 0.375rem;
-  padding-left: 1rem;
-  padding-right: 0.625rem;
-  font-size: 0.75rem;
+  height: 41.008px;
+  border-radius: 6px;
+  padding-left: 16px;
+  padding-right: 10px;
+  font-size: 12px;
   outline: 0;
 }
 
 .input [type='date']::-webkit-calendar-picker-indicator {
-  width: 10rem;
-  height: 1.188rem;
+  width: 160px;
+  height: 19.008px;
   background-color: var(--blue-4);
 }
 
@@ -42,6 +42,6 @@
 }
 
 .errMsg {
-  font-size: 0.688rem;
+  font-size: 11.008px;
   color: var(--pink-3);
 }

--- a/src/shared/component/input/Input/SpecialInput.module.css
+++ b/src/shared/component/input/Input/SpecialInput.module.css
@@ -1,15 +1,15 @@
 .title {
   font-weight: 500;
-  font-size: 14px;
-  margin-bottom: 5.584px;
+  font-size: 1.4rem;
+  margin-bottom: 0.6rem;
 }
 
 .input {
   width: 100%;
-  height: 41.008px;
-  border-radius: 6px;
-  padding-left: 16px;
-  font-size: 12px;
+  height: 4.1rem;
+  border-radius: 0.6rem;
+  padding-left: 1.6rem;
+  font-size: 1.2rem;
   outline: 0;
   border: 0;
 }
@@ -18,11 +18,11 @@
   width: 100%;
   display: flex;
   align-items: center;
-  height: 41.008px;
-  border-radius: 6px;
-  border-top-right-radius: 6px;
-  border-bottom-right-radius: 6px;
-  padding-right: 10px;
+  height: 4.1rem;
+  border-radius: 0.6rem;
+  border-top-right-radius: 0.6rem;
+  border-bottom-right-radius: 0.6rem;
+  padding-right: 1rem;
 }
 
 .ready {
@@ -53,6 +53,6 @@
 
 .error {
   color: var(--pink-3);
-  font-size: 11.008px;
-  margin-top: 3.008px;
+  font-size: 1.1rem;
+  margin-top: 0.3rem;
 }

--- a/src/shared/component/input/Input/SpecialInput.module.css
+++ b/src/shared/component/input/Input/SpecialInput.module.css
@@ -1,15 +1,15 @@
 .title {
   font-weight: 500;
-  font-size: 0.875rem;
-  margin-bottom: 0.349rem;
+  font-size: 14px;
+  margin-bottom: 5.584px;
 }
 
 .input {
   width: 100%;
-  height: 2.563rem;
-  border-radius: 0.375rem;
-  padding-left: 1rem;
-  font-size: 0.75rem;
+  height: 41.008px;
+  border-radius: 6px;
+  padding-left: 16px;
+  font-size: 12px;
   outline: 0;
   border: 0;
 }
@@ -18,11 +18,11 @@
   width: 100%;
   display: flex;
   align-items: center;
-  height: 2.563rem;
-  border-radius: 0.375rem;
-  border-top-right-radius: 0.375rem;
-  border-bottom-right-radius: 0.375rem;
-  padding-right: 0.625rem;
+  height: 41.008px;
+  border-radius: 6px;
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
+  padding-right: 10px;
 }
 
 .ready {
@@ -53,6 +53,6 @@
 
 .error {
   color: var(--pink-3);
-  font-size: 0.688rem;
-  margin-top: 0.188rem;
+  font-size: 11.008px;
+  margin-top: 3.008px;
 }

--- a/src/shared/component/input/PwInput/PwInput.module.css
+++ b/src/shared/component/input/PwInput/PwInput.module.css
@@ -2,12 +2,12 @@
   display: flex;
   position: relative;
   flex-direction: column;
-  gap: 0.375rem;
+  gap: 6px;
 }
 
 .title {
   color: var(--gray-4);
-  font-size: 0.875rem;
+  font-size: 14px;
   font-weight: 500;
 }
 
@@ -16,14 +16,14 @@
   justify-content: center;
   align-items: center;
   width: 100%;
-  height: 2.5rem;
-  border-radius: 0.3125rem;
+  height: 40px;
+  border-radius: 5px;
   background: var(--gray-1-1);
-  padding: 0.6875rem 0.8125rem;
+  padding: 11px 13px;
 
   svg {
-    width: 1.5rem;
-    height: 1.5rem;
+    width: 24px;
+    height: 24px;
   }
 }
 
@@ -33,7 +33,7 @@
   background-color: transparent;
   outline: none;
   color: var(--black);
-  font-size: 0.75rem;
+  font-size: 12px;
 
   &:focus {
     outline: none;
@@ -47,8 +47,8 @@
 .errorMessage {
   position: absolute;
   color: var(--pink-3);
-  font-size: 0.6875rem;
-  top: 4.4375rem;
+  font-size: 11px;
+  top: 71px;
 }
 
 .errorInputWrapper {

--- a/src/shared/component/input/PwInput/PwInput.module.css
+++ b/src/shared/component/input/PwInput/PwInput.module.css
@@ -2,12 +2,12 @@
   display: flex;
   position: relative;
   flex-direction: column;
-  gap: 6px;
+  gap: 0.6rem;
 }
 
 .title {
   color: var(--gray-4);
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 500;
 }
 
@@ -16,14 +16,14 @@
   justify-content: center;
   align-items: center;
   width: 100%;
-  height: 40px;
-  border-radius: 5px;
+  height: 4rem;
+  border-radius: 0.5rem;
   background: var(--gray-1-1);
-  padding: 11px 13px;
+  padding: 1.1rem 1.3rem;
 
   svg {
-    width: 24px;
-    height: 24px;
+    width: 2.4rem;
+    height: 2.4rem;
   }
 }
 
@@ -33,7 +33,7 @@
   background-color: transparent;
   outline: none;
   color: var(--black);
-  font-size: 12px;
+  font-size: 1.2rem;
 
   &:focus {
     outline: none;
@@ -47,8 +47,8 @@
 .errorMessage {
   position: absolute;
   color: var(--pink-3);
-  font-size: 11px;
-  top: 71px;
+  font-size: 1.1rem;
+  top: 7.1rem;
 }
 
 .errorInputWrapper {

--- a/src/shared/component/input/Textarea/Textarea.module.css
+++ b/src/shared/component/input/Textarea/Textarea.module.css
@@ -1,13 +1,13 @@
 .textarea {
-  height: 132px;
-  padding: 14.4px 16px;
+  height: 13.2rem;
+  padding: 1.4rem 1.6rem;
   grid-column: span 2;
   background: var(--gray-2);
-  border-radius: 5px;
+  border-radius: 0.5rem;
   border: none;
   outline: none;
   resize: none;
-  font-size: 13px;
+  font-size: 1.3rem;
 }
 
 .textarea::placeholder {

--- a/src/shared/component/input/Textarea/Textarea.module.css
+++ b/src/shared/component/input/Textarea/Textarea.module.css
@@ -1,13 +1,13 @@
 .textarea {
-  height: 8.25rem;
-  padding: 0.9rem 1rem;
+  height: 132px;
+  padding: 14.4px 16px;
   grid-column: span 2;
   background: var(--gray-2);
-  border-radius: 0.3125rem;
+  border-radius: 5px;
   border: none;
   outline: none;
   resize: none;
-  font-size: 0.8125rem;
+  font-size: 13px;
 }
 
 .textarea::placeholder {

--- a/src/shared/component/layout/AppBar/AppBar.module.css
+++ b/src/shared/component/layout/AppBar/AppBar.module.css
@@ -1,7 +1,7 @@
 .appBar {
   padding: 0.875rem 1.25rem;
   width: 100%;
-  max-width: 600px;
+  max-width: 37.5rem;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/src/shared/component/layout/AppBar/AppBar.module.css
+++ b/src/shared/component/layout/AppBar/AppBar.module.css
@@ -1,7 +1,7 @@
 .appBar {
-  padding: 0.875rem 1.25rem;
+  padding: 14px 20px;
   width: 100%;
-  max-width: 37.5rem;
+  max-width: 600px;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -13,5 +13,5 @@
 
 .title {
   font-weight: 700;
-  font-size: 1.25rem;
+  font-size: 20px;
 }

--- a/src/shared/component/layout/AppBar/AppBar.module.css
+++ b/src/shared/component/layout/AppBar/AppBar.module.css
@@ -1,7 +1,7 @@
 .appBar {
-  padding: 14px 20px;
+  padding: 1.4rem 2rem;
   width: 100%;
-  max-width: 600px;
+  max-width: 60rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -13,5 +13,5 @@
 
 .title {
   font-weight: 700;
-  font-size: 20px;
+  font-size: 2rem;
 }

--- a/src/shared/component/layout/BackAppBar/BackAppBar.module.css
+++ b/src/shared/component/layout/BackAppBar/BackAppBar.module.css
@@ -1,7 +1,7 @@
 .appBar {
   padding: 0.875rem 1.25rem;
   width: 100%;
-  max-width: 600px;
+  max-width: 37.5rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -14,7 +14,7 @@
 .hasGap {
   /* padding: 0.875rem 1.25rem;
   width: 100%;
-  max-width: 600px;
+  max-width: 37.5rem;
   display: flex;
   justify-content: space-between; */
   gap: 0.75rem;

--- a/src/shared/component/layout/BackAppBar/BackAppBar.module.css
+++ b/src/shared/component/layout/BackAppBar/BackAppBar.module.css
@@ -1,7 +1,7 @@
 .appBar {
-  padding: 14px 20px;
+  padding: 1.4rem 2rem;
   width: 100%;
-  max-width: 600px;
+  max-width: 60rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -12,18 +12,18 @@
 }
 
 .hasGap {
-  /* padding: 14px 20px;
+  /* padding: 1.4rem 2rem;
   width: 100%;
-  max-width: 600px;
+  max-width: 60rem;
   display: flex;
   justify-content: space-between; */
-  gap: 12px;
+  gap: 1.2rem;
 }
 
 .backDiv {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 1.2rem;
 }
 
 .back {
@@ -32,18 +32,18 @@
 
 .title {
   font-weight: 700;
-  font-size: 20px;
+  font-size: 2rem;
 }
 
 .actions {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 1.6rem;
 }
 
 .hasWideWidth {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 1.6rem;
   width: 100%;
 }

--- a/src/shared/component/layout/BackAppBar/BackAppBar.module.css
+++ b/src/shared/component/layout/BackAppBar/BackAppBar.module.css
@@ -1,7 +1,7 @@
 .appBar {
-  padding: 0.875rem 1.25rem;
+  padding: 14px 20px;
   width: 100%;
-  max-width: 37.5rem;
+  max-width: 600px;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -12,18 +12,18 @@
 }
 
 .hasGap {
-  /* padding: 0.875rem 1.25rem;
+  /* padding: 14px 20px;
   width: 100%;
-  max-width: 37.5rem;
+  max-width: 600px;
   display: flex;
   justify-content: space-between; */
-  gap: 0.75rem;
+  gap: 12px;
 }
 
 .backDiv {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 12px;
 }
 
 .back {
@@ -32,18 +32,18 @@
 
 .title {
   font-weight: 700;
-  font-size: 1.25rem;
+  font-size: 20px;
 }
 
 .actions {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 16px;
 }
 
 .hasWideWidth {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 16px;
   width: 100%;
 }

--- a/src/shared/component/layout/CloseAppBar/CloseAppBar.module.css
+++ b/src/shared/component/layout/CloseAppBar/CloseAppBar.module.css
@@ -4,7 +4,7 @@
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  max-width: 600px;
+  max-width: 37.5rem;
   background-color: var(--white);
   position: fixed;
   top: 0;

--- a/src/shared/component/layout/CloseAppBar/CloseAppBar.module.css
+++ b/src/shared/component/layout/CloseAppBar/CloseAppBar.module.css
@@ -1,10 +1,10 @@
 .appBar {
-  padding: 14px 20px;
+  padding: 1.4rem 2rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  max-width: 600px;
+  max-width: 60rem;
   background-color: var(--white);
   position: fixed;
   top: 0;
@@ -18,6 +18,6 @@
 .actions {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 0.4rem;
   cursor: pointer;
 }

--- a/src/shared/component/layout/CloseAppBar/CloseAppBar.module.css
+++ b/src/shared/component/layout/CloseAppBar/CloseAppBar.module.css
@@ -1,10 +1,10 @@
 .appBar {
-  padding: 0.875rem 1.25rem;
+  padding: 14px 20px;
   display: flex;
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  max-width: 37.5rem;
+  max-width: 600px;
   background-color: var(--white);
   position: fixed;
   top: 0;
@@ -18,6 +18,6 @@
 .actions {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 4px;
   cursor: pointer;
 }

--- a/src/shared/component/layout/Footer/Footer.module.css
+++ b/src/shared/component/layout/Footer/Footer.module.css
@@ -11,15 +11,15 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 6px;
+  gap: 0.375rem;
   margin-top: 0.875rem;
-  font-size: 10px;
+  font-size: 0.625rem;
   text-align: center;
   color: #6a6a6a;
 }
 
 .email {
-  font-size: 11px;
+  font-size: 0.6875rem;
 }
 
 .menu {
@@ -30,5 +30,5 @@
 
 .link {
   display: flex;
-  padding: 0 6px;
+  padding: 0 0.375rem;
 }

--- a/src/shared/component/layout/Footer/Footer.module.css
+++ b/src/shared/component/layout/Footer/Footer.module.css
@@ -2,24 +2,24 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin: 44px 0 112px;
+  margin: 4.4rem 0 11.2rem;
   background: linear-gradient(180deg, #f9f9f9 0%, var(--white) 100%);
-  padding-top: 28px;
+  padding-top: 2.8rem;
 }
 
 .info {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 6px;
-  margin-top: 14px;
-  font-size: 10px;
+  gap: 0.6rem;
+  margin-top: 1.4rem;
+  font-size: 1rem;
   text-align: center;
   color: #6a6a6a;
 }
 
 .email {
-  font-size: 11px;
+  font-size: 1.1rem;
 }
 
 .menu {
@@ -30,5 +30,5 @@
 
 .link {
   display: flex;
-  padding: 0 6px;
+  padding: 0 0.6rem;
 }

--- a/src/shared/component/layout/Footer/Footer.module.css
+++ b/src/shared/component/layout/Footer/Footer.module.css
@@ -2,24 +2,24 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin: 2.75rem 0 7rem;
+  margin: 44px 0 112px;
   background: linear-gradient(180deg, #f9f9f9 0%, var(--white) 100%);
-  padding-top: 1.75rem;
+  padding-top: 28px;
 }
 
 .info {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.375rem;
-  margin-top: 0.875rem;
-  font-size: 0.625rem;
+  gap: 6px;
+  margin-top: 14px;
+  font-size: 10px;
   text-align: center;
   color: #6a6a6a;
 }
 
 .email {
-  font-size: 0.6875rem;
+  font-size: 11px;
 }
 
 .menu {
@@ -30,5 +30,5 @@
 
 .link {
   display: flex;
-  padding: 0 0.375rem;
+  padding: 0 6px;
 }

--- a/src/shared/component/layout/Header/Header.module.css
+++ b/src/shared/component/layout/Header/Header.module.css
@@ -1,6 +1,6 @@
 .header {
   width: 100%;
-  padding: 8px 20px;
+  padding: 0.8rem 2rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -9,13 +9,13 @@
 .action {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 1.6rem;
 }
 
 .button {
   background-color: var(--white);
   font-weight: bold;
   font-weight: 500;
-  font-size: 13px;
+  font-size: 1.3rem;
   color: var(--blue-4);
 }

--- a/src/shared/component/layout/Header/Header.module.css
+++ b/src/shared/component/layout/Header/Header.module.css
@@ -1,6 +1,6 @@
 .header {
   width: 100%;
-  padding: 0.5rem 1.25rem;
+  padding: 8px 20px;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -9,13 +9,13 @@
 .action {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 16px;
 }
 
 .button {
   background-color: var(--white);
   font-weight: bold;
   font-weight: 500;
-  font-size: 0.8125rem;
+  font-size: 13px;
   color: var(--blue-4);
 }

--- a/src/shared/component/layout/Navbar/Navbar.module.css
+++ b/src/shared/component/layout/Navbar/Navbar.module.css
@@ -1,13 +1,13 @@
 .nav {
   width: 100%;
   max-width: var(--default-width);
-  padding: 0.8rem 2.25rem;
-  border-radius: 0.625rem 0.625rem 0 0;
+  padding: 12.8px 36px;
+  border-radius: 10px 10px 0 0;
   position: fixed;
   bottom: 0;
   z-index: 1;
   background-color: var(--white);
-  filter: drop-shadow(0 -0.25rem 0.4375rem var(--blue-1));
+  filter: drop-shadow(0 -4px 7px var(--blue-1));
 }
 
 .menus {
@@ -20,10 +20,10 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.25rem;
+  gap: 4px;
 }
 
 .menu span {
-  font-size: 0.5625rem;
+  font-size: 9px;
   color: var(--blue-2);
 }

--- a/src/shared/component/layout/Navbar/Navbar.module.css
+++ b/src/shared/component/layout/Navbar/Navbar.module.css
@@ -1,13 +1,13 @@
 .nav {
   width: 100%;
   max-width: var(--default-width);
-  padding: 12.8px 36px;
-  border-radius: 10px 10px 0 0;
+  padding: 1.3rem 3.6rem;
+  border-radius: 1rem 1rem 0 0;
   position: fixed;
   bottom: 0;
   z-index: 1;
   background-color: var(--white);
-  filter: drop-shadow(0 -4px 7px var(--blue-1));
+  filter: drop-shadow(0 -0.4rem 0.7rem var(--blue-1));
 }
 
 .menus {
@@ -20,10 +20,10 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
+  gap: 0.4rem;
 }
 
 .menu span {
-  font-size: 9px;
+  font-size: 0.9rem;
   color: var(--blue-2);
 }

--- a/src/shared/component/layout/Sidebar/Sidebar.module.css
+++ b/src/shared/component/layout/Sidebar/Sidebar.module.css
@@ -8,29 +8,29 @@
   transform: translateX(-50%);
   z-index: 1;
   background: rgba(228, 228, 228, 0.6);
-  backdrop-filter: blur(10px);
+  backdrop-filter: blur(1rem);
   /* Note: backdrop-filter has minimal browser support */
 }
 
 .sidebar {
   width: 80%;
   height: 100%;
-  padding: 20px 0 0 30px;
+  padding: 2rem 0 0 3rem;
   position: absolute;
   right: 0;
-  border-radius: 16px 0 0 0;
+  border-radius: 1.6rem 0 0 0;
   background-color: var(--white);
 }
 
 .logo {
   display: inline-block;
-  margin-bottom: 20px;
+  margin-bottom: 2rem;
 }
 
 .title {
-  margin: 16px 0;
+  margin: 1.6rem 0;
   font-weight: 700;
-  font-size: 16px;
+  font-size: 1.6rem;
   color: var(--gray-4);
 }
 
@@ -39,14 +39,14 @@
 }
 
 .menuList {
-  font-size: 14px;
+  font-size: 1.4rem;
   color: var(--gray-4);
 }
 
 /* menu list */
 .list {
-  padding-left: 16px;
-  margin-bottom: 12px;
+  padding-left: 1.6rem;
+  margin-bottom: 1.2rem;
   display: flex;
   flex-direction: column;
 }
@@ -56,7 +56,7 @@
 }
 
 .item li {
-  padding: 6px 0;
+  padding: 0.6rem 0;
 }
 
 .item > li:hover {

--- a/src/shared/component/layout/Sidebar/Sidebar.module.css
+++ b/src/shared/component/layout/Sidebar/Sidebar.module.css
@@ -8,29 +8,29 @@
   transform: translateX(-50%);
   z-index: 1;
   background: rgba(228, 228, 228, 0.6);
-  backdrop-filter: blur(0.625rem);
+  backdrop-filter: blur(10px);
   /* Note: backdrop-filter has minimal browser support */
 }
 
 .sidebar {
   width: 80%;
   height: 100%;
-  padding: 1.25rem 0 0 1.875rem;
+  padding: 20px 0 0 30px;
   position: absolute;
   right: 0;
-  border-radius: 1rem 0 0 0;
+  border-radius: 16px 0 0 0;
   background-color: var(--white);
 }
 
 .logo {
   display: inline-block;
-  margin-bottom: 1.25rem;
+  margin-bottom: 20px;
 }
 
 .title {
-  margin: 1rem 0;
+  margin: 16px 0;
   font-weight: 700;
-  font-size: 1rem;
+  font-size: 16px;
   color: var(--gray-4);
 }
 
@@ -39,14 +39,14 @@
 }
 
 .menuList {
-  font-size: 0.875rem;
+  font-size: 14px;
   color: var(--gray-4);
 }
 
 /* menu list */
 .list {
-  padding-left: 1rem;
-  margin-bottom: 0.75rem;
+  padding-left: 16px;
+  margin-bottom: 12px;
   display: flex;
   flex-direction: column;
 }
@@ -56,7 +56,7 @@
 }
 
 .item li {
-  padding: 0.375rem 0;
+  padding: 6px 0;
 }
 
 .item > li:hover {

--- a/src/shared/component/loading/FetchLoading/FetchLoading.module.css
+++ b/src/shared/component/loading/FetchLoading/FetchLoading.module.css
@@ -6,12 +6,12 @@
 }
 
 .centerBox {
-  padding: 30px 0;
+  padding: 3rem 0;
   display: flex;
   flex-direction: column;
   align-items: center;
-  row-gap: 10px;
-  font-size: 13px;
+  row-gap: 1rem;
+  font-size: 1.3rem;
 }
 
 .icon {

--- a/src/shared/component/loading/FetchLoading/FetchLoading.module.css
+++ b/src/shared/component/loading/FetchLoading/FetchLoading.module.css
@@ -6,12 +6,12 @@
 }
 
 .centerBox {
-  padding: 1.875rem 0;
+  padding: 30px 0;
   display: flex;
   flex-direction: column;
   align-items: center;
-  row-gap: 0.625rem;
-  font-size: 0.8125rem;
+  row-gap: 10px;
+  font-size: 13px;
 }
 
 .icon {

--- a/src/shared/component/loading/FetchLoadingOverlay/FetchLoadingOverlay.module.css
+++ b/src/shared/component/loading/FetchLoadingOverlay/FetchLoadingOverlay.module.css
@@ -11,6 +11,6 @@
 }
 
 .loading .text {
-  font-size: 16px;
+  font-size: 1.6rem;
   color: var(--white);
 }

--- a/src/shared/component/loading/FetchLoadingOverlay/FetchLoadingOverlay.module.css
+++ b/src/shared/component/loading/FetchLoadingOverlay/FetchLoadingOverlay.module.css
@@ -11,6 +11,6 @@
 }
 
 .loading .text {
-  font-size: 1rem;
+  font-size: 16px;
   color: var(--white);
 }

--- a/src/shared/component/modal/ConfirmModal/ConfirmModal.module.css
+++ b/src/shared/component/modal/ConfirmModal/ConfirmModal.module.css
@@ -12,17 +12,17 @@
   align-items: center;
   justify-content: center;
   background: rgba(228, 228, 228, 0.6);
-  backdrop-filter: blur(0.625rem);
+  backdrop-filter: blur(10px);
 }
 
 .container {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.75rem;
-  width: 18rem;
-  padding: 1.25rem 0.625rem 0.625rem;
-  border-radius: 0.625rem;
+  gap: 12px;
+  width: 288px;
+  padding: 20px 10px 10px;
+  border-radius: 10px;
   background: var(--white);
 }
 
@@ -33,7 +33,7 @@
 
 .title {
   text-align: center;
-  font-size: 1rem;
+  font-size: 16px;
   font-weight: 500;
   color: var(--black);
   white-space: pre-line;
@@ -43,13 +43,13 @@
   width: 80%;
   text-align: center;
   color: var(--gray-4);
-  font-size: 0.75rem;
+  font-size: 12px;
   white-space: pre-line;
 }
 
 .primaryButton {
   width: 100%;
-  padding: 0.625rem 0.75rem;
+  padding: 10px 12px;
   background-color: transparent;
   font-weight: 500;
   color: var(--pink-3);
@@ -57,7 +57,7 @@
 
 .secondaryButton {
   width: 100%;
-  padding: 0.625rem 0.75rem;
+  padding: 10px 12px;
   background-color: transparent;
   font-weight: 500;
   color: var(--gray-3-1);

--- a/src/shared/component/modal/ConfirmModal/ConfirmModal.module.css
+++ b/src/shared/component/modal/ConfirmModal/ConfirmModal.module.css
@@ -12,17 +12,17 @@
   align-items: center;
   justify-content: center;
   background: rgba(228, 228, 228, 0.6);
-  backdrop-filter: blur(10px);
+  backdrop-filter: blur(1rem);
 }
 
 .container {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 12px;
-  width: 288px;
-  padding: 20px 10px 10px;
-  border-radius: 10px;
+  gap: 1.2rem;
+  width: 28.8rem;
+  padding: 2rem 1rem 1rem;
+  border-radius: 1rem;
   background: var(--white);
 }
 
@@ -33,7 +33,7 @@
 
 .title {
   text-align: center;
-  font-size: 16px;
+  font-size: 1.6rem;
   font-weight: 500;
   color: var(--black);
   white-space: pre-line;
@@ -43,13 +43,13 @@
   width: 80%;
   text-align: center;
   color: var(--gray-4);
-  font-size: 12px;
+  font-size: 1.2rem;
   white-space: pre-line;
 }
 
 .primaryButton {
   width: 100%;
-  padding: 10px 12px;
+  padding: 1rem 1.2rem;
   background-color: transparent;
   font-weight: 500;
   color: var(--pink-3);
@@ -57,7 +57,7 @@
 
 .secondaryButton {
   width: 100%;
-  padding: 10px 12px;
+  padding: 1rem 1.2rem;
   background-color: transparent;
   font-weight: 500;
   color: var(--gray-3-1);

--- a/src/shared/component/modal/Modal.module.css
+++ b/src/shared/component/modal/Modal.module.css
@@ -26,7 +26,7 @@
   display: flex;
   justify-content: center;
   padding: 1rem 0;
-  border-bottom: 0.5px solid var(--gray-2);
+  border-bottom: 0.0313rem solid var(--gray-2);
 }
 
 /* OptionModal: 옵션이 있는 모달 스타일 */

--- a/src/shared/component/modal/Modal.module.css
+++ b/src/shared/component/modal/Modal.module.css
@@ -12,45 +12,45 @@
   justify-content: center;
   transform: translateX(-50%);
   background: rgba(228, 228, 228, 0.6);
-  backdrop-filter: blur(10px);
+  backdrop-filter: blur(1rem);
   /* Note: backdrop-filter has minimal browser support */
 }
 
 .container {
-  width: 288px;
-  border-radius: 10px;
+  width: 29rem;
+  border-radius: 1rem;
   background: var(--white);
 }
 
 .top {
   display: flex;
   justify-content: center;
-  padding: 16px 0;
-  border-bottom: 0.5008px solid var(--gray-2);
+  padding: 1.6rem 0;
+  border-bottom: 0.05rem solid var(--gray-2);
 }
 
 /* OptionModal: 옵션이 있는 모달 스타일 */
 
 .title {
   color: var(--pink-3);
-  font-size: 16px;
+  font-size: 1.6rem;
   font-weight: 500;
 }
 
 .center {
-  padding-top: 24px;
+  padding-top: 2.4rem;
 }
 
 .bottom {
   display: flex;
   justify-content: end;
-  padding: 6px 28px 10px 28px;
+  padding: 0.6rem 2.8rem 1rem 2.8rem;
 }
 
 .leftCloseBtn {
-  padding: 10px;
+  padding: 1rem;
   color: var(--gray-3-1);
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 500;
   cursor: pointer;
 }
@@ -58,14 +58,14 @@
 .options {
   display: flex;
   flex-direction: column;
-  row-gap: 8px;
-  padding: 0 30px;
+  row-gap: 0.8rem;
+  padding: 0 3rem;
 }
 
 .optionBar {
   display: flex;
-  gap: 15px;
-  padding: 4px 0;
+  gap: 1.5rem;
+  padding: 0.4rem 0;
   cursor: pointer;
 }
 
@@ -73,12 +73,12 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 30px;
+  width: 3rem;
 }
 
 .optionText {
   color: var(--gray-4);
-  font-size: 14px;
+  font-size: 1.4rem;
 }
 
 /* DeleteModal: 삭제 모달 스타일 */
@@ -86,7 +86,7 @@
 .noBottomLineTop {
   display: flex;
   justify-content: center;
-  padding: 16px 0 0 0;
+  padding: 1.6rem 0 0 0;
 }
 
 .deleteCenter {
@@ -94,8 +94,8 @@
   color: var(--gray-4);
   justify-content: center;
   color: var(--gray-4);
-  font-size: 13px;
-  padding-bottom: 10px;
+  font-size: 1.3rem;
+  padding-bottom: 1rem;
 }
 
 .deleteOrBack {
@@ -103,19 +103,19 @@
   align-items: center;
   justify-content: center;
   color: var(--gray-3-1);
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 500;
-  gap: 80px;
-  padding: 2px 0 10px 0;
+  gap: 8rem;
+  padding: 0.2rem 0 1rem 0;
 }
 
 .redBtn {
   color: var(--pink-3);
-  padding: 10px;
+  padding: 1rem;
   cursor: pointer;
 }
 
 .greyBtn {
-  padding: 10px;
+  padding: 1rem;
   cursor: pointer;
 }

--- a/src/shared/component/modal/Modal.module.css
+++ b/src/shared/component/modal/Modal.module.css
@@ -12,45 +12,45 @@
   justify-content: center;
   transform: translateX(-50%);
   background: rgba(228, 228, 228, 0.6);
-  backdrop-filter: blur(0.625rem);
+  backdrop-filter: blur(10px);
   /* Note: backdrop-filter has minimal browser support */
 }
 
 .container {
-  width: 18rem;
-  border-radius: 0.625rem;
+  width: 288px;
+  border-radius: 10px;
   background: var(--white);
 }
 
 .top {
   display: flex;
   justify-content: center;
-  padding: 1rem 0;
-  border-bottom: 0.0313rem solid var(--gray-2);
+  padding: 16px 0;
+  border-bottom: 0.5008px solid var(--gray-2);
 }
 
 /* OptionModal: 옵션이 있는 모달 스타일 */
 
 .title {
   color: var(--pink-3);
-  font-size: 1rem;
+  font-size: 16px;
   font-weight: 500;
 }
 
 .center {
-  padding-top: 1.5rem;
+  padding-top: 24px;
 }
 
 .bottom {
   display: flex;
   justify-content: end;
-  padding: 0.375rem 1.75rem 0.625rem 1.75rem;
+  padding: 6px 28px 10px 28px;
 }
 
 .leftCloseBtn {
-  padding: 0.625rem;
+  padding: 10px;
   color: var(--gray-3-1);
-  font-size: 0.875rem;
+  font-size: 14px;
   font-weight: 500;
   cursor: pointer;
 }
@@ -58,14 +58,14 @@
 .options {
   display: flex;
   flex-direction: column;
-  row-gap: 0.5rem;
-  padding: 0 1.875rem;
+  row-gap: 8px;
+  padding: 0 30px;
 }
 
 .optionBar {
   display: flex;
-  gap: 0.9375rem;
-  padding: 0.25rem 0;
+  gap: 15px;
+  padding: 4px 0;
   cursor: pointer;
 }
 
@@ -73,12 +73,12 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 1.875rem;
+  width: 30px;
 }
 
 .optionText {
   color: var(--gray-4);
-  font-size: 0.875rem;
+  font-size: 14px;
 }
 
 /* DeleteModal: 삭제 모달 스타일 */
@@ -86,7 +86,7 @@
 .noBottomLineTop {
   display: flex;
   justify-content: center;
-  padding: 1rem 0 0 0;
+  padding: 16px 0 0 0;
 }
 
 .deleteCenter {
@@ -94,8 +94,8 @@
   color: var(--gray-4);
   justify-content: center;
   color: var(--gray-4);
-  font-size: 0.8125rem;
-  padding-bottom: 0.625rem;
+  font-size: 13px;
+  padding-bottom: 10px;
 }
 
 .deleteOrBack {
@@ -103,19 +103,19 @@
   align-items: center;
   justify-content: center;
   color: var(--gray-3-1);
-  font-size: 0.875rem;
+  font-size: 14px;
   font-weight: 500;
-  gap: 5rem;
-  padding: 0.125rem 0 0.625rem 0;
+  gap: 80px;
+  padding: 2px 0 10px 0;
 }
 
 .redBtn {
   color: var(--pink-3);
-  padding: 0.625rem;
+  padding: 10px;
   cursor: pointer;
 }
 
 .greyBtn {
-  padding: 0.625rem;
+  padding: 10px;
   cursor: pointer;
 }

--- a/src/shared/component/suspense/ServerErrorFallback/ServerErrorFallback.module.css
+++ b/src/shared/component/suspense/ServerErrorFallback/ServerErrorFallback.module.css
@@ -1,15 +1,15 @@
 .serverError {
   flex: 1;
   margin: 0 var(--default-margin);
-  padding: 32px;
+  padding: 3.2rem;
   aspect-ratio: 3.5;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  gap: 16px;
-  border-radius: 5px;
-  font-size: 16px;
+  gap: 1.6rem;
+  border-radius: 0.5rem;
+  font-size: 1.6rem;
   color: var(--gray-4);
 }
 
@@ -17,14 +17,14 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
+  gap: 0.4rem;
 }
 
 .errorMessage > span:nth-child(1) {
-  font-size: 17.6px;
+  font-size: 1.8rem;
   font-weight: 500;
 }
 
 .errorMessage > span:nth-child(2) {
-  font-size: 12px;
+  font-size: 1.2rem;
 }

--- a/src/shared/component/suspense/ServerErrorFallback/ServerErrorFallback.module.css
+++ b/src/shared/component/suspense/ServerErrorFallback/ServerErrorFallback.module.css
@@ -1,15 +1,15 @@
 .serverError {
   flex: 1;
   margin: 0 var(--default-margin);
-  padding: 2rem;
+  padding: 32px;
   aspect-ratio: 3.5;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  gap: 1rem;
-  border-radius: 0.3125rem;
-  font-size: 1rem;
+  gap: 16px;
+  border-radius: 5px;
+  font-size: 16px;
   color: var(--gray-4);
 }
 
@@ -17,14 +17,14 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.25rem;
+  gap: 4px;
 }
 
 .errorMessage > span:nth-child(1) {
-  font-size: 1.1rem;
+  font-size: 17.6px;
   font-weight: 500;
 }
 
 .errorMessage > span:nth-child(2) {
-  font-size: 0.75rem;
+  font-size: 12px;
 }

--- a/src/stories/Accordion.stories.jsx
+++ b/src/stories/Accordion.stories.jsx
@@ -33,9 +33,9 @@ const Template = (args) => <Accordion {...args} />;
 const StyledTemplate = (args) => (
   <div
     style={{
-      padding: '0 0.875rem',
+      padding: '0 14px',
       backgroundColor: 'var(--blue-0)',
-      borderRadius: '0.3125rem',
+      borderRadius: '5px',
     }}
   >
     <Accordion {...args} />

--- a/src/stories/Accordion.stories.jsx
+++ b/src/stories/Accordion.stories.jsx
@@ -33,9 +33,9 @@ const Template = (args) => <Accordion {...args} />;
 const StyledTemplate = (args) => (
   <div
     style={{
-      padding: '0 14px',
+      padding: '0 1.4rem',
       backgroundColor: 'var(--blue-0)',
-      borderRadius: '5px',
+      borderRadius: '0.5rem',
     }}
   >
     <Accordion {...args} />


### PR DESCRIPTION
## 🎯 관련 이슈

close #860 

<br />

## 🚀 작업 내용
- 스노로즈에서는 rem단위를 사용하고 있는데, 현재 웹 사이트의 기본 단위인 16px을 그대로 기준으로 사용하고 있습니다.
- 하지만 이렇게 되면, 코드를 작성할 때 일일히 16px에 해당하는 rem값을 찾아서 넣어야 하며, 긴 소수점 단위로 나오게 되어 가독성 및 코드효율이 떨어지게 됩니다.
- 해결을 위해, 기본 단위를 16px에서 10px로 변경하면, 18px -> 1.8rem과 같이 소수점 하나만 넣는 방식으로 rem값을 계산할 수 있게 됩니다.

📝 작업 목록
1. px로 되어있는 부분을 전부 rem으로 통일 (우선 16px 기준으로)
2. 전체 파일에서 rem -> px로 일괄 변경 (우선 16px 기준으로)
3. globalStyle을 지정하고 있는 index.css' 파일에 html { font-size: 62.5% }`를 설정함으로써, 기본 단위를 16px에서 10px로 변경
4. 전체 파일에서 px -> rem으로 일괄 변경 (10px 기준으로)

<br />

<!--
## 📸 스크린샷

| (스크린샷을 넣어주세요) |
| :---------------------: |

<br />
-->

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
-->
 
<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->

## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?
- 작업하다가 깨달은 사실인데, `index.css` 파일에 width가 400px 이하면 rem 기준을 2px 줄이는 설정이 되어있더라고요. 그런데 디자인 작업이 `width: 395px`인 모바일을 기준으로 되어있어, 굳이 400px 이하일 때 폰트 사이즈를 줄일 필요가 없어 보입니다. 오히려 이 부분 때문에 모바일 화면이 작게 느껴졌던 게 아닌가 싶네요..! 해당 코드 주석 처리해뒀으니 배포 버전과 비교해보시고 괜찮으면 이렇게 수정하는 건 어떨까 싶습니다. 의견 주시면 감사하겠습니다!
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/fd84c870-75ca-48f8-ad1a-280e38a96417" />

- px과 rem을 사용하는 거의 모든 파일을 수정하였기 때문에 `file changed`가 매우매우 많습니다! 리뷰 시에는 사이트 화면에서 크게 깨지는 부분이 있는지 위주로 확인해주시면 될 것 같습니다.

- 단위 변경을 하면서 소수점으로 떨어지는 부분들에 대해서는 최대 소수점 아래 첫 번째 자리까지만 나오도록 반올림 처리하였습니다. 추후에도 소수점 아래 두 자리 이상 나오지 않도록 코드 작성 부탁드립니다 👍

- 스토리북 쪽에도 10px 단위가 되도록 `font-size: 62.5%` 적용해두었습니다! 다만 스토리북 쪽은 제가 체크를 하긴 했으나 정확하게 아는 게 아니라서, 코드와 웹 화면에 대해 다시 한 번 체크 부탁드립니다! ✅ 

- 해당 pr로 인해, 진행 중인 작업(브랜치)에 어려움이 있을 경우, 진행 중인 모든 작업이 끝난 후에 rebase하여 머지하도록 하겠습니다. 영향이 있으신 분들은 코멘트 남겨주시기 바랍니다!





<br />
