### PR TITLE
#891 [FIX] 홈 화면 베숙트 시간 - 절대시각으로 변경

### DIFF
--- a/src/feature/home/component/MainPageListItem/MainPageListItem.jsx
+++ b/src/feature/home/component/MainPageListItem/MainPageListItem.jsx
@@ -1,8 +1,8 @@
 import { Link } from 'react-router-dom';
 
-import { Icon, Badge } from '@/shared/component';
-import { timeAgo, getBoardTextId } from '@/shared/lib';
+import { Badge, Icon } from '@/shared/component';
 import { ROLE } from '@/shared/constant';
+import { getBoardTextId, postBarDateFormat } from '@/shared/lib';
 
 import styles from './MainPageListItem.module.css';
 
@@ -41,7 +41,7 @@ export default function MainPageListItem({
                 )}
               </span>
               <span className={styles.dot}></span>
-              <span>{timeAgo(createdAt)}</span>
+              <span>{postBarDateFormat(createdAt)}</span>
             </p>
           </div>
           <div className={styles.bottom}>


### PR DESCRIPTION
## 🎯 관련 이슈

close #891

<br />

## 🚀 작업 내용

- 홈 화면 베숙트 시간 - 절대시각으로 변경

<br />


## 📸 스크린샷
| <img width="600" alt="스크린샷 2025-04-22 오후 6 10 50" src="https://github.com/user-attachments/assets/633b899e-8390-4832-81cd-1b9a2616d075" /> |
| :---------------------: |

<br />


<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
-->
 
<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
