### PR TITLE
#913 [CHORE] 시험후기 작성 연도 옵션에 2025 추가

### DIFF
--- a/src/feature/exam/constant/exam.js
+++ b/src/feature/exam/constant/exam.js
@@ -34,6 +34,7 @@ export const SEMESTERS = Object.freeze([
 
 export const YEARS = Object.freeze(
   [
+    { id: 2025, name: '2025' },
     { id: 2024, name: '2024' },
     { id: 2023, name: '2023' },
     { id: 2022, name: '2022' },


### PR DESCRIPTION
## 🎯 관련 이슈

close #913

<br />

## 🚀 작업 내용

- 시험후기 작성 페이지에서 연도 옵션에 2025를 추가합니다.

<br />

<!--
## 📸 스크린샷

| (스크린샷을 넣어주세요) |
| :---------------------: |

<br />
-->

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
-->
 
<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
