### PR TITLE
[FIX] 뷰포트 높이가 작아지는 경우 사이드바 내용이 화면 밖으로 넘치는 문제 해결

### DIFF
--- a/src/shared/component/layout/Sidebar/Sidebar.module.css
+++ b/src/shared/component/layout/Sidebar/Sidebar.module.css
@@ -13,9 +13,11 @@
 }
 
 .sidebar {
+  overflow-y: auto;
+
   width: 80%;
   height: 100%;
-  padding: 2rem 0 0 3rem;
+  padding-left: 3rem;
   position: absolute;
   right: 0;
   border-radius: 1.6rem 0 0 0;
@@ -23,8 +25,14 @@
 }
 
 .logo {
+  position: sticky;
+  top: 0;
+
   display: inline-block;
-  margin-bottom: 2rem;
+  width: 100%;
+  padding: 2rem 0;
+
+  background-color: white;
 }
 
 .title {


### PR DESCRIPTION
## 🎯 관련 이슈

close #917

<br />

## 🚀 작업 내용

- sidebar에 `overflow-y: auto` 적용해서 스크롤 가능하게 변경했습니다.
- logo에 `position: sticky; top: 0` 적용해서 로고는 상단에 고정하도록 수정했습니다.
- 사이드바 상단 padding을 로고 padding-top으로 옮기고, logo 하단 margin을 padding으로 변경하여 로고 뒤로 스크롤 되는 메뉴들을 여유있게 가려주었습니다.

<br />

<!--
## 📸 스크린샷

| (스크린샷을 넣어주세요) |
| :---------------------: |

<br />
-->

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
-->
 
<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
