### PR TITLE
#996 [SNO-101] PostPage에서 내가 쓴 게시물에 점 세 개 아이콘 안 뜨는 오류 해결

### DIFF
--- a/src/assets/icon.svg
+++ b/src/assets/icon.svg
@@ -267,6 +267,11 @@
     <circle cx="9" cy="2" r="2" fill="#898989"/>
     <circle cx="17" cy="2" r="2" fill="#898989"/>
   </symbol>
+  <symbol id="meat-ball" width="18" height="4" viewBox="0 0 18 4" fill="none">
+    <circle cx="2" cy="2" r="2" transform="rotate(-90 2 2)" fill="#898989"/>
+    <circle cx="9" cy="2" r="2" transform="rotate(-90 9 2)" fill="#898989"/>
+    <circle cx="16" cy="2" r="2" transform="rotate(-90 16 2)" fill="#898989"/>
+  </symbol>
   <symbol id="ellipsis-vertical" viewBox="0 0 3 12" fill="none" stroke="none">
     <circle cx="1.7065" cy="1.79341" r="1.29341" fill="#898989"/>
     <circle cx="1.7065" cy="6.14107" r="1.29341" fill="#898989"/>


### PR DESCRIPTION
## 🔎 What is this PR?

Close #996

## 🎯 변경 사항

- icon.svg에 meat-ball 아이콘 추가

## 📸 스크린샷 

| Before | After |
| :----: | :---: |
|   <img width="607" alt="스크린샷 2025-05-22 오후 11 15 43" src="https://github.com/user-attachments/assets/0b7c4bbc-65fd-475b-a97a-918c88dcd882" />     |    <img width="547" alt="스크린샷 2025-05-22 오후 11 13 59" src="https://github.com/user-attachments/assets/2268f015-c66d-4886-b40f-d7b036d6845e" />   |

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요?
- 예전에 PostPage 작업할 때 icon.svg에 meat-ball 아이콘도 추가했었는데
- 작업 중간에 누락되거나, conflict 해결 과정에서 날라간 것 같네요.
- 다시 추가해서 오류 해결했습니다.
