### PR TITLE
#1006 [SNO-103] 공지글 아이콘 안 뜨는 오류 해결

### DIFF
--- a/src/assets/icon.svg
+++ b/src/assets/icon.svg
@@ -283,6 +283,14 @@
   <symbol id="blue-triangle" viewBox="0 0 20 20" fill="none" stroke="none">
     <path d="M10 16L3.93782 5.5L16.0622 5.5L10 16Z" fill="#00368E"/>
   </symbol>
+  <symbol id="check-circle-grey" width="22" height="22" viewBox="0 0 22 22" fill="none" stroke="none">
+   <circle cx="10.5332" cy="10.8418" r="10.5" fill="white"/>
+   <path d="M5.5332 12.2032L9.34846 16.1419L16.7332 7.34186" stroke="#D9D9D9" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+  <symbol id="check-circle-blue" width="21" height="22" viewBox="0 0 21 22" fill="none" stroke="none">
+    <circle cx="10.5" cy="11.3418" r="10.5" fill="#BFD7EC"/>
+    <path d="M5 12.4031L8.81526 16.3418L16.2 7.54181" stroke="#5F86BF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
 
 
   <!-- fill icon -->


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1006

- [Figma]()
- [Notion]()

## 🎯 변경 사항

- 게시글 작성/수정 페이지에서 공지글 아이콘이 잘 안 뜨는 오류 있었음
- 안쓰는 `toggle-on`, `toggle-off` 아이콘 삭제
- 누락되었던 `check-circle-grey`,  `check-circle-blue` 두 아이콘 복원

## 📸 스크린샷 (선택 사항)

| Before | After |
| :----: | :---: |
|      <img width="611" alt="image" src="https://github.com/user-attachments/assets/08e10eb6-c36c-4ac1-a3f2-eadf8fee6465" />  | <img width="547" alt="image" src="https://github.com/user-attachments/assets/676c6630-62ff-4b15-8280-1e0d8e033c01" /> |

