### PR TITLE
#1004 [SNO-102] 시험후기 목록 조회/검색 API 통합

### DIFF
--- a/src/apis/examReview.js
+++ b/src/apis/examReview.js
@@ -8,8 +8,14 @@ export const getExamReview = async (postId, fileName) => {
   return response;
 };
 
-export const getReviews = async (page = 0) => {
-  const response = await authAxios.get(`/v1/reviews/32/list/${page}`);
+export const getExamReviewList = async ({ page, params }) => {
+  const response = await authAxios.get('/v1/reviews', {
+    params: {
+      page,
+      ...params,
+    },
+  });
+
   return response?.data.result;
 };
 

--- a/src/feature/search/component/SearchExamReviewList/SearchExamReviewList.jsx
+++ b/src/feature/search/component/SearchExamReviewList/SearchExamReviewList.jsx
@@ -1,26 +1,43 @@
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 
-import { FetchLoading, List, PullToRefresh } from '@/shared/component';
+import { getExamReviewList } from '@/apis';
+
+import { useSuspensePagination } from '@/shared/hook';
 import { deduplicatePaginatedData, flatPaginationCache } from '@/shared/lib';
+import { FetchLoading, List, PullToRefresh } from '@/shared/component';
+import { QUERY_KEY, STALE_TIME } from '@/shared/constant';
 
 import { PostBar } from '@/feature/board/component';
-import { useSearch } from '@/feature/search/hook';
 
 import styles from './SearchExamReviewList.module.css';
 
 export default function SearchExamReviewList({ saveScrollPosition }) {
-  const { data, ref, isFetching, refetch } = useSearch({ boardId: 32 });
-  const searchList = deduplicatePaginatedData(flatPaginationCache(data));
+  const [searchParams] = useSearchParams();
+  const params = Object.fromEntries(searchParams.entries());
+  const paramsLength = Object.keys(params).length;
+
+  const { data, ref, isFetching, refetch } = useSuspensePagination({
+    queryKey: [QUERY_KEY.reviews, JSON.stringify(params)],
+    queryFn: ({ pageParam }) =>
+      getExamReviewList({
+        page: pageParam,
+        params,
+      }),
+    staleTime: STALE_TIME.searchList,
+    enabled: paramsLength > 0,
+  });
+
+  const examList = deduplicatePaginatedData(flatPaginationCache(data));
 
   return (
     <PullToRefresh
       onRefresh={() => refetch().then(() => console.log('Refreshed!'))}
     >
       <List>
-        {searchList.map((post, index) => (
+        {examList.map((post, index) => (
           <Link
             className={styles.to}
-            ref={index === searchList.length - 1 ? ref : undefined}
+            ref={index === examList.length - 1 ? ref : undefined}
             key={post.postId}
             to={`/board/exam-review/post/${post.postId}`}
             onClick={saveScrollPosition}

--- a/src/shared/constant/reactQuery.js
+++ b/src/shared/constant/reactQuery.js
@@ -5,6 +5,8 @@ export const QUERY_KEY = Object.freeze({
   search: 'search',
   post: 'post',
   posts: 'posts',
+  review: 'review',
+  reviews: 'reviews',
   comments: 'comments',
   noticeLine: 'noticeLine',
   notices: 'notices',


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1004

- [시험 후기 목록 조회 (+검색) API 명세](https://www.notion.so/snorose/311837f79c0e458abb46124e37cb979c?pvs=4)

## 🎯 변경 사항

- 시험후기 목록 조회와 검색을 `searchByBoard` 대신 `getExamReviewList`을 호출하여 구현했습니다. 

## 📸 스크린샷 (선택 사항)

| Before | After |
| :----: | :---: |
|        |       |

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
