### PR TITLE
#1016 [SNO-89] 게시글 수정 API 스펙 변동으로 인한 400 에러 해결 

### DIFF
--- a/src/apis/post.js
+++ b/src/apis/post.js
@@ -58,13 +58,13 @@ export const patchPost = async ({
   finalAttachments = [],
 }) => {
   const editedPost = {
-    postId: postId,
+    postId,
     category: null,
-    title: title,
-    content: content,
-    isNotice: isNotice,
-    deleteAttachments: deleteAttachments,
-    finalAttachments: finalAttachments,
+    title,
+    content,
+    isNotice,
+    deleteAttachments,
+    finalAttachments,
   };
 
   const response = await authAxios.patch(

--- a/src/apis/post.js
+++ b/src/apis/post.js
@@ -55,7 +55,7 @@ export const patchPost = async ({
   content,
   isNotice,
   deleteAttachments = [],
-  createAttachments = [],
+  finalAttachments = [],
 }) => {
   const editedPost = {
     postId: postId,
@@ -63,8 +63,8 @@ export const patchPost = async ({
     title: title,
     content: content,
     isNotice: isNotice,
-    deleteAttachments,
-    createAttachments,
+    deleteAttachments: deleteAttachments,
+    finalAttachments: finalAttachments,
   };
 
   const response = await authAxios.patch(


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1016 

## 🎯 변경 사항
- 게시글 수정 API 스펙 변동됨
  - request body에 `createAttachment` -> `finalAttachment` 속성명 변경됨
  - 이로 인해 현재 게시글 수정에서 400에러가 나고 있었음
  - 속성명 변경해서 오류 해결 완
