### PR TITLE
#1027 [FIX] 게시글 목록 조회 페이지에서 불필요한 세미콜론 제거

### DIFF
--- a/src/feature/board/component/PostList/PostListSuspense.jsx
+++ b/src/feature/board/component/PostList/PostListSuspense.jsx
@@ -17,7 +17,7 @@ export default function PostListSuspense({ saveScrollPosition }) {
           <Suspense
             fallback={<FetchLoading>게시글 불러오는 중...</FetchLoading>}
           >
-            <PostList saveScrollPosition={saveScrollPosition} />;
+            <PostList saveScrollPosition={saveScrollPosition} />
           </Suspense>
         </ErrorBoundary>
       )}


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1027

## 🎯 변경 사항

- PostListSuspense 컴포넌트에 있는 불필요한 세미콜론을 제거했습니다.

## 📸 스크린샷 (선택 사항)

| Before | After |
| :----: | :---: |
|      <img width="780" alt="스크린샷 2025-06-06 오후 9 27 48" src="https://github.com/user-attachments/assets/16931278-2bfe-4141-8b00-46b6b22166c0" />        |     <img width="768" alt="스크린샷 2025-06-06 오후 9 28 20" src="https://github.com/user-attachments/assets/d6cf6736-56a4-40e2-86c2-b1bd019a9499" />    |   
