### PR TITLE
#926 [SNO-121] 시험후기 작성 페이지 undefined 참조 오류 해결

### DIFF
--- a/src/feature/exam/lib/CheckExamPeriodRoute.jsx
+++ b/src/feature/exam/lib/CheckExamPeriodRoute.jsx
@@ -11,6 +11,8 @@ export default function CheckExamPeriodRoute({ children }) {
   const navigate = useNavigate();
 
   useEffect(() => {
+    if (!userInfo) return;
+
     if (userInfo.userRoleId === ROLE.admin) {
       return;
     }
@@ -23,7 +25,7 @@ export default function CheckExamPeriodRoute({ children }) {
 
     alert('시험후기 작성 기간이 아닙니다.');
     navigate('/', { replace: true });
-  }, []);
+  }, [userInfo]);
 
   return children;
 }

--- a/src/page/exam/WriteExamReviewPage/WriteExamReviewPage.jsx
+++ b/src/page/exam/WriteExamReviewPage/WriteExamReviewPage.jsx
@@ -107,16 +107,17 @@ export default function WriteExamReviewPage() {
     file;
 
   // navigation guard
-  const isBlock =
+  const isBlock = !!(
     lectureName.trim() ||
     professor.trim() ||
-    lectureType ||
-    examType ||
-    lectureYear ||
-    semester ||
+    Object.keys(lectureType).length > 0 ||
+    Object.keys(examType).length > 0 ||
+    Object.keys(lectureYear).length > 0 ||
+    Object.keys(semester).length > 0 ||
     classNumber ||
     questionDetail.trim() ||
-    file;
+    file
+  );
 
   useBlocker(isBlock);
 


### PR DESCRIPTION
## 🔎 What is this PR?

Close #926

## 🎯 변경 사항

- CheckExamPeriodRoute의 useEffect 의존성 배열에 `userInfo`를 추가하고, `userInfo`가 undefined인 경우 ealry return 하도록 수정했습니다.
  ```jsx
  useEffect(() => {
    if (!userInfo) return;
  
    // ...
  
  }, [userInfo]);
  ```

- 시험후기 작성 페이지에서 변경된 내용이 없는 경우에도 페이지 이탈 방지 모달이 노출되는 버그가 있어 수정했습니다.
  - `lectureType`, `examType`, `lectureYear`, `semester`의 경우 아무것도 선택되지 않았음에도 `{}` 빈 객체가 기본값으로 세팅되기 때문에 `isBlock`이 default로 Truthy가 되는 문제 수정
    ```jsx
    const isBlock = !!(
      lectureName.trim() ||
      professor.trim() ||
      Object.keys(lectureType).length > 0 ||
      Object.keys(examType).length > 0 ||
      Object.keys(lectureYear).length > 0 ||
      Object.keys(semester).length > 0 ||
      classNumber ||
      questionDetail.trim() ||
      file
    );
    ```

## 📸 스크린샷 (선택 사항)

| Before | After |
| :----: | :---: |
|        |       |

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
