### PR TITLE
#1032 [SNO-110] 접근 권한에 따른 리다이렉트 제어

### DIFF
--- a/src/ProtectedRoute.jsx
+++ b/src/ProtectedRoute.jsx
@@ -1,31 +1,45 @@
-import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useContext, useEffect } from 'react';
+import { Navigate, useNavigate } from 'react-router-dom';
 
+import { ModalContext } from '@/shared/context/ModalContext';
 import { useAuth } from '@/shared/hook';
 import { USER_STATUS } from '@/shared/constant';
 
 // 토큰이 유효한지 확인하는 로직 필요
 export default function ProtectedRoute({ roles, message, children }) {
-  const navigate = useNavigate();
   const { status, userInfo } = useAuth();
 
-  useEffect(() => {
-    if (status === USER_STATUS.isLogout) {
-      alert('로그인이 필요합니다.');
-      navigate('/login', { replace: true });
-      return;
-    }
+  if (status === USER_STATUS.loading) {
+    return null;
+  }
 
-    if (status === USER_STATUS.loading) {
-      return;
-    }
+  if (status === USER_STATUS.isLogout) {
+    alert('로그인이 필요합니다.');
 
-    if (roles && !roles.includes(userInfo?.userRoleId)) {
-      alert(message);
-      navigate('/verify', { replace: true });
-      return;
-    }
-  }, [status, roles, userInfo, navigate, message]);
+    return <Navigate to='/login' replace />;
+  }
+
+  if (roles && !roles.includes(userInfo?.userRoleId)) {
+    return <AccessDeniedModal message={message} />;
+  }
 
   return children;
+}
+
+function AccessDeniedModal({ message }) {
+  const { open } = useContext(ModalContext);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    open('confirm', {
+      title: message,
+      description: `등업 페이지로 이동할까요?`,
+      primaryText: '네',
+      secondaryText: '아니요',
+      onPrimary: () => navigate('/verify', { replace: true }),
+      onSecondary: () => navigate(-1),
+    });
+  }, []);
+
+  return null;
 }

--- a/src/router.js
+++ b/src/router.js
@@ -119,7 +119,7 @@ const boardRoutes = boardPaths.flatMap((boardPath) => [
     element: (
       <ProtectedRoute
         roles={getRolesForReadBoard(boardPath)}
-        message={'게시판 접근 권한이 없습니다.'}
+        message={'게시판 접근 권한이 없어요'}
       >
         {boardPath === 'notice' ? <NoticeListPage /> : <PostListPage />}
       </ProtectedRoute>
@@ -133,7 +133,7 @@ const boardRoutes = boardPaths.flatMap((boardPath) => [
     element: (
       <ProtectedRoute
         roles={getRolesForReadBoard(boardPath)}
-        message={'게시판 접근 권한이 없습니다.'}
+        message={'게시판 접근 권한이 없어요'}
       >
         <NoticeListPage />
       </ProtectedRoute>
@@ -147,7 +147,7 @@ const boardRoutes = boardPaths.flatMap((boardPath) => [
     element: (
       <ProtectedRoute
         roles={getRolesForReadBoard(boardPath)}
-        message={'게시글 접근 권한이 없습니다.'}
+        message={'게시글 접근 권한이 없어요'}
       >
         <PostPage />
       </ProtectedRoute>
@@ -161,7 +161,7 @@ const boardRoutes = boardPaths.flatMap((boardPath) => [
     element: (
       <ProtectedRoute
         roles={getRolesForWriteBoard(boardPath)}
-        message={'게시글 작성 권한이 없습니다.'}
+        message={'게시글 작성 권한이 없어요'}
       >
         <WritePostPage />
       </ProtectedRoute>
@@ -175,7 +175,7 @@ const boardRoutes = boardPaths.flatMap((boardPath) => [
     element: (
       <ProtectedRoute
         roles={getRolesForWriteBoard(boardPath)}
-        message={'게시글 편집 권한이 없습니다.'}
+        message={'게시글 편집 권한이 없어요'}
       >
         <EditPostPage />
       </ProtectedRoute>
@@ -189,7 +189,7 @@ const boardRoutes = boardPaths.flatMap((boardPath) => [
     element: (
       <ProtectedRoute
         roles={getRolesForReadBoard(boardPath)}
-        message={'게시판 접근 권한이 없습니다.'}
+        message={'게시판 접근 권한이 없어요'}
       >
         <SearchPage />
       </ProtectedRoute>
@@ -230,7 +230,7 @@ export const routeList = [
         element: (
           <ProtectedRoute
             roles={[ROLE.user, ROLE.admin]}
-            message={'시험후기 게시판 접근 권한이 없습니다.'}
+            message={'시험후기 게시판 접근 권한이 없어요'}
           >
             <ExamReviewListPage />
           </ProtectedRoute>
@@ -241,7 +241,7 @@ export const routeList = [
         element: (
           <ProtectedRoute
             roles={[ROLE.user, ROLE.admin]}
-            message={'시험후기 게시판 접근 권한이 없습니다.'}
+            message={'시험후기 게시판 접근 권한이 없어요'}
           >
             <NoticeListPage />
           </ProtectedRoute>
@@ -255,7 +255,7 @@ export const routeList = [
         element: (
           <ProtectedRoute
             roles={[ROLE.user, ROLE.admin]}
-            message={'시험후기 게시판 접근 권한이 없습니다.'}
+            message={'시험후기 게시판 접근 권한이 없어요'}
           >
             <ExamReviewListPage />
           </ProtectedRoute>
@@ -267,7 +267,7 @@ export const routeList = [
         element: (
           <ProtectedRoute
             roles={[ROLE.user, ROLE.admin]}
-            message={'시험후기 접근 권한이 없습니다.'}
+            message={'시험후기 접근 권한이 없어요'}
           >
             <ExamReviewPage />
           </ProtectedRoute>
@@ -281,7 +281,7 @@ export const routeList = [
         element: (
           <ProtectedRoute
             roles={[ROLE.user, ROLE.admin]}
-            message={'공지글 접근 권한이 없습니다.'}
+            message={'공지글 접근 권한이 없어요'}
           >
             <PostPage />
           </ProtectedRoute>
@@ -295,7 +295,7 @@ export const routeList = [
         element: (
           <ProtectedRoute
             roles={[ROLE.admin]}
-            message={'공지글 수정 권한이 없습니다.'}
+            message={'공지글 수정 권한이 없어요'}
           >
             <EditPostPage />
           </ProtectedRoute>
@@ -309,7 +309,7 @@ export const routeList = [
         element: (
           <ProtectedRoute
             roles={[ROLE.user, ROLE.admin]}
-            message={'시험후기 수정 권한이 없습니다.'}
+            message={'시험후기 수정 권한이 없어요'}
           >
             <EditExamReviewPage />
           </ProtectedRoute>
@@ -324,7 +324,7 @@ export const routeList = [
           <CheckExamPeriodRoute>
             <ProtectedRoute
               roles={[ROLE.user, ROLE.admin]}
-              message={'시험후기 작성 권한이 없습니다.'}
+              message={'시험후기 작성 권한이 없어요'}
             >
               <WriteExamReviewPage />
             </ProtectedRoute>
@@ -482,7 +482,7 @@ export const routeList = [
         element: (
           <ProtectedRoute
             roles={[ROLE.preUser, ROLE.admin]}
-            message='이미 인증을 완료했거나 인증 대상이 아닙니다'
+            message='이미 인증을 완료했거나 인증 대상이 아니에요'
           >
             <SnoroseVerifyPage />
           </ProtectedRoute>


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1032

- [Notion](https://www.notion.so/snorose/1ea7ef0aa3bf811faa26e9012ad4c4dd?source=copy_link)

## 🎯 변경 사항

- ProtectedRoute에서 렌더링 이전에 권한을 확인하기 위해 useEffect을 제거했습니다.
- `open`, `navigate`는 사이드 이펙트이기 때문에 useEffect 내부에서 처리하기 위해 모달 노출 로직은 따로 컴포넌트로 분리했습니다.

## 📸 스크린샷 (선택 사항)

| Before | After |
| :----: | :---: |
| <img width="600" alt="image" src="https://github.com/user-attachments/assets/50252f94-797d-45e8-8b0c-25a3fad5b874" /> | <img width="600" alt="image" src="https://github.com/user-attachments/assets/7f297c14-084a-4914-9be0-7944c5e74ccc" /> |

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
