### PR TITLE
#1038 [SNO-112] 출석 상태에 따라 버튼 메시지 분기 (제언)

### DIFF
--- a/src/apis/attendance.js
+++ b/src/apis/attendance.js
@@ -1,0 +1,30 @@
+import { authAxios } from '@/axios';
+
+export const isAttendanceCheckedToday = async () => {
+  const response = await authAxios.get('/v1/points/attendance/today');
+  return response?.data.result.isAttendedToday;
+};
+
+export const updatePoint = async ({
+  userId,
+  category,
+  source,
+  sourceId,
+  difference,
+}) => {
+  const response = await authAxios.post('/v1/points', {
+    userId,
+    category,
+    source,
+    ...(sourceId && { sourceId }),
+    ...(difference && { difference }),
+  });
+  return response;
+};
+
+export const getMonthlyAttendanceHistory = async ({ year, month }) => {
+  const response = await authAxios.get('/v1/points/attendance', {
+    params: { year, month },
+  });
+  return response?.data.result;
+};

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -1,4 +1,5 @@
 export * from './account';
+export * from './attendance';
 export * from './banner';
 export * from './comment';
 export * from './examReview';

--- a/src/apis/point.js
+++ b/src/apis/point.js
@@ -1,32 +1,8 @@
 import { authAxios } from '@/axios';
 
-export const updatePoint = async ({
-  userId,
-  category,
-  source,
-  sourceId,
-  difference,
-}) => {
-  const response = await authAxios.post('/v1/points', {
-    userId,
-    category,
-    source,
-    ...(sourceId && { sourceId }),
-    ...(difference && { difference }),
-  });
-  return response;
-};
-
 export const getPointLogs = async (params) => {
   const response = await authAxios.get('/v1/points/log', {
     params,
-  });
-  return response?.data.result;
-};
-
-export const getMonthlyAttendanceHistory = async ({ year, month }) => {
-  const response = await authAxios.get('/v1/points/attendance', {
-    params: { year, month },
   });
   return response?.data.result;
 };

--- a/src/page/home/AttendancePage/AttendancePage.jsx
+++ b/src/page/home/AttendancePage/AttendancePage.jsx
@@ -100,7 +100,7 @@ function AttendanceButton({ setLoading }) {
 
   if (isAttendance) {
     return (
-      <button className={styles.attendanceButton}>
+      <button className={styles.attendanceButton} disabled>
         오늘 출석을 완료했어요
       </button>
     );

--- a/src/page/home/AttendancePage/AttendancePage.module.css
+++ b/src/page/home/AttendancePage/AttendancePage.module.css
@@ -30,15 +30,21 @@
   font-size: 1.4rem;
   text-align: center;
   color: var(--blue-4);
-}
 
-.attendanceButton:active {
-  filter: brightness(0.9);
+  &:active {
+    filter: brightness(0.9);
+  }
 }
 
 .attendanceButton:disabled {
+  color: var(--grey-4);
+  background: var(--grey-3);
+
   cursor: not-allowed;
-  filter: brightness(0.5);
+
+  &:active {
+    filter: none;
+  }
 }
 
 /* bottom */

--- a/src/router.js
+++ b/src/router.js
@@ -1,3 +1,6 @@
+import { attendanceLoader } from '@/shared/loader';
+import { ROLE } from '@/shared/constant';
+
 import App from '@/App';
 import {
   LoginPage,
@@ -46,8 +49,6 @@ import {
 import ProtectedRoute from '@/ProtectedRoute';
 import { MaintenancePage } from '@/page/maintenance';
 // import { AlertPage } from '@/pages/AlertPage';
-
-import { ROLE } from '@/shared/constant';
 
 import { CheckExamPeriodRoute } from '@/feature/exam/lib';
 
@@ -337,6 +338,7 @@ export const routeList = [
       {
         path: '/attendance',
         element: <AttendancePage />,
+        loader: attendanceLoader,
         meta: {
           hideNav: true,
         },
@@ -476,7 +478,6 @@ export const routeList = [
           hideNav: true,
         },
       },
-
       {
         path: '/verify',
         element: (

--- a/src/shared/component/loading/FetchLoadingOverlay/FetchLoadingOverlay.module.css
+++ b/src/shared/component/loading/FetchLoadingOverlay/FetchLoadingOverlay.module.css
@@ -1,13 +1,18 @@
 .loading {
-  max-width: var(--default-width);
-  width: 100%;
-  height: 100%;
   position: fixed;
   top: 0;
   left: 50%;
   transform: translateX(-50%);
-  background-color: rgba(var(--black-rgb), 0.4);
   z-index: 1;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  max-width: var(--default-width);
+  width: 100%;
+  height: 100%;
+
+  background-color: rgba(var(--black-rgb), 0.4);
 }
 
 .loading .text {

--- a/src/shared/loader/attendance.js
+++ b/src/shared/loader/attendance.js
@@ -1,0 +1,8 @@
+import { json } from 'react-router-dom';
+
+import { isAttendanceCheckedToday } from '@/apis';
+
+export const attendanceLoader = async () => {
+  const attendance = await isAttendanceCheckedToday();
+  return json({ attendance });
+};

--- a/src/shared/loader/index.js
+++ b/src/shared/loader/index.js
@@ -1,0 +1,1 @@
+export * from './attendance';


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1038

- [Notion-제언](https://www.notion.so/snorose/1ea7ef0aa3bf8150b075dfcb045d1592?source=copy_link)

## 🎯 변경 사항

- `router.js`의 출석체크 페이지에서 loader를 추가해서 출석체크 페이지 접근 전 오늘의 출석 여부 데이터를 fetch합니다.
  ```js
  // router.js
  ...

  {
    path: '/attendance',
    element: <AttendancePage />,
    loader: attendanceLoader,
    meta: {
      hideNav: true,
    },
  },

  ...
  ```

  ```js
  // attendance loader
  export const attendanceLoader = async () => {
    const attendance = await isAttendanceCheckedToday();
    return json({ attendance });
  };
  ```
- AttendanceButton에서 useLoaderData로 출석 여부 데이터를 가져와 `isAttendance` state를 초기화 합니다.
  ```jsx
  const { attendance } = useLoaderData();
  const [isAttendance, setIsAttendance] = useState(attendance);
  ```
- 출석체크 성공 시 `isAttendance`을 `true`로 업데이트 합니다.

## 📸 스크린샷 (선택 사항)
<!--
| Before | After |
| :----: | :---: |
|        |       |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
