### PR TITLE
#1080 [SNO-134] 시험후기 게시판 z-index 수정

### DIFF
--- a/src/feature/home/component/PopUp/PopUp.module.css
+++ b/src/feature/home/component/PopUp/PopUp.module.css
@@ -9,7 +9,7 @@
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 2;
+  z-index: 500;
 }
 
 .popUp {

--- a/src/shared/component/layout/AppBar/AppBar.module.css
+++ b/src/shared/component/layout/AppBar/AppBar.module.css
@@ -8,7 +8,7 @@
   background-color: var(--white);
   position: fixed;
   top: 0;
-  z-index: 1;
+  z-index: 300;
 }
 
 .title {

--- a/src/shared/component/layout/Sidebar/Sidebar.module.css
+++ b/src/shared/component/layout/Sidebar/Sidebar.module.css
@@ -6,7 +6,7 @@
   top: 0;
   left: 50%;
   transform: translateX(-50%);
-  z-index: 1;
+  z-index: 400;
   background: rgba(228, 228, 228, 0.6);
   backdrop-filter: blur(1rem);
   /* Note: backdrop-filter has minimal browser support */

--- a/src/shared/component/modal/Modal.module.css
+++ b/src/shared/component/modal/Modal.module.css
@@ -5,7 +5,7 @@
   position: fixed;
   top: 0;
   left: 50%;
-  z-index: 1;
+  z-index: 200;
   width: 100vw;
   max-width: var(--default-width);
   height: 100vh;


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1080

## 🎯 변경 사항

- 상단 앱바보다 높게 표시되던 필터, 모달창을 수정했습니다.
<img width="616" height="159" alt="image" src="https://github.com/user-attachments/assets/2e69fc35-bb52-4310-86f2-7fd9a56ef64c" />


## 📸 스크린샷 (선택 사항)

| Before | After |
| :----: | :---: |
| <img width="200"  alt="image" src="https://github.com/user-attachments/assets/6fb5c64a-48bc-419a-aad4-32ac6725dd93" /> | <img width="200" alt="image" src="https://github.com/user-attachments/assets/6022c0b8-f2d0-44fa-a0dc-a243d2b38fc0" /> <img width="200" alt="image" src="https://github.com/user-attachments/assets/c2c0f63d-eba9-4c56-8de6-a1ae28623b94" /> |


## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
- 담당페이지가 아닌 부분을 수정했어서, 혹시 `z-index` 관련해서 놓친 부분이 있다면 알려주세요 :)

- [기존 이슈 공유]
홈화면이 아닌 페이지 (ex. 게시판, 시험후기)에서 사이드바를 열었다가 홈화면으로 이동할 경우, 
팝업창과 사이드바가 겹쳐보이는 이슈가 있어요~ 
팝업창을 닫으면 사이드바가 바로 사라지기는 하지만, 해당 이슈는 이번 PR이 아닌 새로운 액션 아이템으로서 작업이 필요해 보여요 :)

<img width="200" alt="image" src="https://github.com/user-attachments/assets/39922404-d17b-4960-8748-dc1642accad5" />
