### PR TITLE
#1088 [SNO-140] 홈 화면 하단 계좌번호 선택시 복붙 기능

### DIFF
--- a/src/shared/component/layout/Footer/Footer.jsx
+++ b/src/shared/component/layout/Footer/Footer.jsx
@@ -1,20 +1,23 @@
 import { Link } from 'react-router-dom';
 
 import { Icon } from '@/shared/component';
+import { useToast } from '@/shared/hook';
+import { TOAST } from '@/shared/constant';
 
 import style from './Footer.module.css';
 
 export default function Footer() {
+  const { toast } = useToast();
   const textToCopy = '카카오뱅크 3333-31-8162062';
 
   const handleCopy = () => {
     navigator.clipboard
       .writeText(textToCopy)
       .then(() => {
-        alert('복사 완료:)');
+        toast(TOAST.COPY_AND_PASTE.SUCCESS);
       })
       .catch((error) => {
-        alert('복사 실패ㅜ.ㅜ');
+        toast(TOAST.COPY_AND_PASTE.FAIL);
       });
   };
 

--- a/src/shared/component/layout/Footer/Footer.jsx
+++ b/src/shared/component/layout/Footer/Footer.jsx
@@ -5,6 +5,19 @@ import { Icon } from '@/shared/component';
 import style from './Footer.module.css';
 
 export default function Footer() {
+  const textToCopy = '카카오뱅크 3333-31-8162062';
+
+  const handleCopy = () => {
+    navigator.clipboard
+      .writeText(textToCopy)
+      .then(() => {
+        alert('복사 완료:)');
+      })
+      .catch((error) => {
+        alert('복사 실패ㅜ.ㅜ');
+      });
+  };
+
   return (
     <footer className={style.footer}>
       <Icon id='logo' width={118} height={21} />
@@ -15,8 +28,11 @@ export default function Footer() {
           <a href='mailto:snorose1906@gmail.com'>snorose1906@gmail.com</a>
         </p>
         <p>
-          <span className={style.bold}>숙명여대 후원하기</span> 카카오뱅크
-          3333-31-8162062 (예금주: 김*지)
+          <span className={style.bold}>숙명여대 후원하기</span>{' '}
+          <span onClick={handleCopy} className={style.accountNumber}>
+            {textToCopy}
+          </span>{' '}
+          (예금주: 김*지)
         </p>
       </div>
 

--- a/src/shared/component/layout/Footer/Footer.module.css
+++ b/src/shared/component/layout/Footer/Footer.module.css
@@ -24,6 +24,10 @@
   font: var(--text-body-2-med);
 }
 
+.accountNumber {
+  cursor: pointer;
+}
+
 .menu {
   display: flex;
   justify-content: center;

--- a/src/shared/constant/toast.js
+++ b/src/shared/constant/toast.js
@@ -39,6 +39,10 @@ const TOAST = Object.freeze({
     SERVER: '서버 에러, 잠시 후 다시 시도해주세요',
     NETWORK: '네트워크 에러, 잠시 후 다시 시도해주세요',
   },
+  COPY_AND_PASTE: {
+    SUCCESS: '복사되었어요.',
+    FAIL: '⚠️ 복사에 실패했어요.',
+  },
 });
 
 export { TOAST };


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1088 


## 🎯 변경 사항

홈 화면 Footer에 있는 후원 계좌를 클릭하면 계좌번호가 자동으로 복사되는 기능을 구현했습니다.
스노로즈에는 우클릭 기능이 제한되어 있어, 후원 계좌번호를 간편하게 복사할 수 있도록 클릭 시 자동 복사 기능을 추가하게 되었습니다.

## 📸 스크린샷 (선택 사항)

| 복사 성공 | 복사 실패 |
| :----: | :---: |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/9feefcc7-72b0-45c8-844e-204acb195484" /> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/3aacab23-c2da-4fec-9cc2-1c943f53c17c" />|


## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
- 실패 케이스 UI 확인 방법 
  ```
  // 콘솔에 붙여넣어 실행 후, 후원 계좌 클릭
  navigator.clipboard.writeText = () => Promise.reject(new Error('강제 실패'));
  ```

- 성공 메시지와 실패 메시지 구분을 위해 이모지를 넣었어요.
  스노로즈는 성공과 실패의 UI가 동일해 토스트 메시지만으로는 직관적인 전달이 어려운 부분이 있어요.
  아래에 Toss 사례를 함께 첨부했는데, 추후 이런 부분에 대해서도 함께 고민해보면 좋을 것 같아요 :)
  <img width="500" height="759" alt="image" src="https://github.com/user-attachments/assets/4a3f24a5-5e66-4db9-b870-884c5615727c" />
