### PR TITLE
#1096 [SNO-145] 베숙트 워딩 변경

### DIFF
--- a/src/feature/home/component/HomeBesookt/HomeBesooktErrorFallback.jsx
+++ b/src/feature/home/component/HomeBesookt/HomeBesooktErrorFallback.jsx
@@ -1,5 +1,7 @@
 import { ServerErrorFallback } from '@/shared/component';
 
+import { ACCESS_MESSAGES } from '@/feature/home/constant';
+
 import styles from './HomeBesooktErrorFallback.module.css';
 
 export default function HomeBesooktErrorFallback({
@@ -9,11 +11,11 @@ export default function HomeBesooktErrorFallback({
   const { status } = error;
 
   if (status === 401) {
-    return <Fallback text={'로그인 후 이용해 주세요'} />;
+    return <Fallback text={ACCESS_MESSAGES.NEED_LOGIN} />;
   }
 
   if (status === 403) {
-    return <Fallback text={'등업 완료 후 이용 가능해요'} />;
+    return <Fallback text={ACCESS_MESSAGES.NEED_UPGRADE} />;
   }
 
   return <ServerErrorFallback reset={resetErrorBoundary} />;

--- a/src/feature/home/component/HomeBoardCard/HomeBoardCard.jsx
+++ b/src/feature/home/component/HomeBoardCard/HomeBoardCard.jsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 
 import { useAuth } from '@/shared/hook';
 import { USER_STATUS } from '@/shared/constant';
+import { ACCESS_MESSAGES } from '@/feature/home/constant';
 
 import lockImage from '@/assets/images/lock.svg';
 
@@ -31,7 +32,7 @@ export default function HomeBoardCard({
           </>
         )}
         {status !== USER_STATUS.isLogin && (
-          <p className={style.notLogin}>{`로그인 후 이용해 주세요`}</p>
+          <p className={style.notLogin}>{ACCESS_MESSAGES.NEED_LOGIN}</p>
         )}
       </div>
     </Link>

--- a/src/feature/home/constant/home.js
+++ b/src/feature/home/constant/home.js
@@ -1,0 +1,4 @@
+export const ACCESS_MESSAGES = Object.freeze({
+  NEED_LOGIN: '로그인 후 이용해 주세요',
+  NEED_UPGRADE: '등업 완료 후 이용 가능해요',
+});

--- a/src/feature/home/constant/index.js
+++ b/src/feature/home/constant/index.js
@@ -1,1 +1,2 @@
 export * from './about.js';
+export * from './home.js';


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1096

- [Figma](https://www.figma.com/design/00Ywy8VC5KoHOSu01uC9sZ/%EC%9C%A0%EC%A0%80%EC%9B%B9-%EB%94%94%EC%9E%90%EC%9D%B8---1%EC%B0%A8-%EA%B0%9C%EB%B0%9C?node-id=4279-18969&m=dev)


## 🎯 변경 사항
- 문구 변경 
  - `로그인 후 이용 가능합니다` >> `로그인 후 이용해 주세요` (베숙트 - 미로그인)
  - `등업 완료 후 이용 가능합니다` >> `등업 완료 후 이용 가능해요`(베숙트 - 준회원 로그인)
- 문구 상수화 작업
  - 커뮤니티 영역은 이미 '-해 주세요' 형태의 문구로 변경되어 있었지만, 
베숙트 영역에는 '-합니다' 형태로 작성되어 있어 문구 스타일을 통일하기 위해 상수로 분리하였습니다.

## 📸 스크린샷 (선택 사항)


| Before | After (미로그인, 준회원 로그인 상태) |
| :----: | :---: |
|<img width="200" alt="image" src="https://github.com/user-attachments/assets/6905b644-5bf6-4fb0-95c2-3fc64fae506c" />| <img width="200" alt="image" src="https://github.com/user-attachments/assets/0942527d-6657-40b6-b516-32e091833a1b" /> <img width="200" alt="image" src="https://github.com/user-attachments/assets/94521478-b411-4b9e-a3db-9570c2c8f894" />|


## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
