### PR TITLE
#1103 [SNO-136] 공감 줄바꿈으로 인한 gap 조정

### DIFF
--- a/src/page/board/PostPage/PostPage.jsx
+++ b/src/page/board/PostPage/PostPage.jsx
@@ -228,7 +228,7 @@ export default function PostPage() {
           className={styles.contentText}
           dangerouslySetInnerHTML={convertHyperlink(data.content)}
         ></p>
-        <div className={styles.post_bottom}>
+        <div className={styles.postBottom}>
           <div
             className={styles.count}
             style={{

--- a/src/page/board/PostPage/PostPage.module.css
+++ b/src/page/board/PostPage/PostPage.module.css
@@ -67,11 +67,11 @@
   padding-left: 0.2rem;
 }
 
-.post_bottom {
+.postBottom {
   display: flex;
   justify-content: space-between;
-  gap: 2.5rem;
-  padding: 0.9rem 0 0 0;
+  gap: 1.6rem;
+  padding: 0.9rem 0 0;
   border-top: 0.05rem solid rgba(var(--grey-3-1-rgb), 0.7);
 }
 


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1103

- [Figma](https://www.figma.com/design/00Ywy8VC5KoHOSu01uC9sZ/%EC%9C%A0%EC%A0%80%EC%9B%B9-%EB%94%94%EC%9E%90%EC%9D%B8---1%EC%B0%A8-%EA%B0%9C%EB%B0%9C?node-id=5332-14791&m=dev)

## 🎯 변경 사항

아이콘 변경 전에 iPhone 12 Pro에서는 좋아요 수가 1,000개 이상일 때 줄바꿈 이슈가 있었습니다. [Notion 참고](https://www.notion.so/snorose/1000-2337ef0aa3bf8018a7cce3ab3e411dce?source=copy_link)
아이콘 변경 후에 해당 디바이스에서 나타나는 이슈는 해결되었지만, SE 버전에서는 여전히 줄바꿈이 발생하고 있습니다. 
Figma 기준으로는 공감 수가 3자리일 때 gap이 `2.5rem`으로 설정되어 있어 gap 크기를 줄였습니다. (hover 효과도 있어 해당 gap 유지가 필요해 보입니당)
크게 눈에 띄는 이슈는 아니지만, 이슈라이징 된 김에 수정해두었어요 :)

## 📸 스크린샷 (선택 사항)

| Before | After |
| :----: | :---: |
|  <img width="281" height="500" alt="image" src="https://github.com/user-attachments/assets/79d305e6-ab34-4693-bcdb-81cfb4d02821" />| <img width="281" height="500" alt="image" src="https://github.com/user-attachments/assets/7de6030b-77dd-4f5c-9c42-bd4dd94c0bf3" />  |


## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
