### PR TITLE
#1118 [SNO-156] 댓글 등록 및 삭제 시 화면 깜빡거리는 이슈 해결

### DIFF
--- a/src/feature/comment/hook/useComment.jsx
+++ b/src/feature/comment/hook/useComment.jsx
@@ -52,6 +52,20 @@ export default function useComment() {
     }));
   };
 
+  const updateUserPoints = (pointDifference) => {
+    queryClient.setQueryData([QUERY_KEY.userInfo], (prev) => ({
+      ...prev,
+      points: prev.points + pointDifference,
+    }));
+  };
+
+  const invalidateUserInfo = () => {
+    queryClient.invalidateQueries({
+      queryKey: [QUERY_KEY.userInfo],
+      refetchType: 'inactive',
+    });
+  };
+
   const onError = ({ response }) => {
     toast(response.data.message);
   };
@@ -68,13 +82,8 @@ export default function useComment() {
     onSuccess: (newComment) => {
       const { parentId, pointDifference } = newComment;
 
-      // 포인트 갱신
-      queryClient.setQueryData([QUERY_KEY.userInfo], (prev) => ({
-        ...prev,
-        points: prev.points + pointDifference,
-      }));
+      updateUserPoints(pointDifference);
 
-      // 댓글 목록 갱신
       queryClient.setQueryData([QUERY_KEY.comments, postId], (prev) => {
         const flattenComments = flatPaginationCache(prev);
 
@@ -97,10 +106,7 @@ export default function useComment() {
         ? toast(TOAST.COMMENT.createNoPoints)
         : toast(TOAST.COMMENT.create);
 
-      queryClient.invalidateQueries({
-        queryKey: [QUERY_KEY.userInfo],
-        refetchType: 'inactive',
-      });
+      invalidateUserInfo();
     },
     onError,
     onSettled,
@@ -114,13 +120,8 @@ export default function useComment() {
     onSuccess: (deletedComment) => {
       const { id, pointDifference } = deletedComment;
 
-      // 포인트 갱신
-      queryClient.setQueryData([QUERY_KEY.userInfo], (prev) => ({
-        ...prev,
-        points: prev.points + pointDifference,
-      }));
+      updateUserPoints(pointDifference);
 
-      // 댓글 목록에 삭제 반영
       updateCommentCache((comment) =>
         deleteIfTargetComment({
           comment,
@@ -134,10 +135,7 @@ export default function useComment() {
         ? toast(TOAST.COMMENT.deleteNoPoints)
         : toast(TOAST.COMMENT.delete);
 
-      queryClient.invalidateQueries({
-        queryKey: [QUERY_KEY.userInfo],
-        refetchType: 'inactive',
-      });
+      invalidateUserInfo();
     },
     onError,
     onSettled,

--- a/src/feature/comment/hook/useComment.jsx
+++ b/src/feature/comment/hook/useComment.jsx
@@ -96,6 +96,11 @@ export default function useComment() {
       !pointDifference
         ? toast(TOAST.COMMENT.createNoPoints)
         : toast(TOAST.COMMENT.create);
+
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEY.userInfo],
+        refetchType: 'inactive',
+      });
     },
     onError,
     onSettled,
@@ -128,6 +133,11 @@ export default function useComment() {
       currentBoard.id === 23 || currentBoard.id === 32
         ? toast(TOAST.COMMENT.deleteNoPoints)
         : toast(TOAST.COMMENT.delete);
+
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEY.userInfo],
+        refetchType: 'inactive',
+      });
     },
     onError,
     onSettled,

--- a/src/feature/comment/hook/useComment.jsx
+++ b/src/feature/comment/hook/useComment.jsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router-dom';
 import { useQueryClient, useMutation } from '@tanstack/react-query';
-import { useLocation } from 'react-router-dom';
 
 import {
   deleteComment as remove,


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1118

## 🎯 변경 사항

- 댓글 등록 및 삭제 시 화면이 하얗게 깜빡이는 이슈가 있어 해결 했습니다. (수정은 정상)

## 📸 스크린샷 (선택 사항)


- Before

https://github.com/user-attachments/assets/f797004d-91c5-459a-8004-f9670c68d3b8

- After
 
https://github.com/user-attachments/assets/a5cac144-a2b9-4e99-808f-f1430cf7d8a6




## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)

- QA할 때, 포인트가 실시간으로 업데이트 되는지 함께 확인해 주시면 좋을 것 같아요 :)

- 이슈 원인
 `invalidUserInfoQuery()` 호출로 `userInfo` 쿼리가 전역 무효화되어 리패치가 발생했고, 이 과정에서 화면이 일시적으로 로딩(Suspense) 상태로 전환되며 하얀 화면(깜빡임)이 노출되었습니다.

- 해결 방법
  - `invalidUserInfoQuery()` 제거(전역 리페치 중단).
  - `onSuccess`에서 부분 캐시 갱신만 수행:
    - `setQueryData([comments, postId], …)`로 댓글 목록 갱신
    - `setQueryData([post, postId], …)`로 `commentCount` 증감 처리
