### PR TITLE
#1125 [SNO-168] 알림 읽기 API 연결

### DIFF
--- a/src/apis/alert.js
+++ b/src/apis/alert.js
@@ -17,7 +17,18 @@ export async function fetchNotificationList(category) {
     params: { filter: category },
   });
 
-  return response.data;
+  return response.data.result;
+}
+
+export async function readNotifications(alertIds) {
+  const params = new URLSearchParams();
+  alertIds.forEach((id) => params.append('alertIds', String(id)));
+
+  const response = await authAxios.patch('/v1/alerts/is-read', null, {
+    params,
+  });
+
+  return response.data.result;
 }
 
 export async function fetchNotificationSettings() {

--- a/src/feature/alert/component/NotificationItem/NotificationItem.jsx
+++ b/src/feature/alert/component/NotificationItem/NotificationItem.jsx
@@ -7,9 +7,13 @@ export default function NotificationItem({
   createdAt,
   isRead = false,
   url,
+  onClick,
 }) {
   return (
-    <div className={`${style.container} ${isRead ? style.read : style.unread}`}>
+    <div
+      className={`${style.container} ${isRead ? style.read : style.unread}`}
+      onClick={onClick}
+    >
       <div className={style.top}>
         <div>
           <div className={style.title}>{title}</div>

--- a/src/feature/alert/hook/notification.js
+++ b/src/feature/alert/hook/notification.js
@@ -7,22 +7,130 @@ import {
 import {
   fetchNotificationList,
   fetchNotificationSettings,
+  readNotifications,
   updateNotificationSettings,
 } from '@/apis';
 
 import { MUTATION_KEY, QUERY_KEY } from '@/shared/constant';
 
 import { toNotificationItem } from '@/feature/alert/mapper';
+import { calculateNextNotificationSettings } from '@/feature/alert/lib';
+import { CATEGORY } from '@/feature/alert/constant';
 
 export function useNotification(category) {
   return useSuspenseQuery({
     queryKey: QUERY_KEY.notifications(category),
+
     queryFn: () =>
       fetchNotificationList(category === 'ALL' ? undefined : category),
-    select: ({ result }) => result.map(toNotificationItem),
+
+    select: (data) => data.map(toNotificationItem),
+
     staleTime: 5 * 60 * 1000,
+
     gcTime: 30 * 60 * 1000,
   });
+}
+
+export function useReadNotifications() {
+  const queryClient = useQueryClient();
+
+  const cancelAll = (queryKeys) =>
+    Promise.all(
+      queryKeys.map((qk) =>
+        queryClient.cancelQueries({ queryKey: qk, exact: true })
+      )
+    );
+
+  const backupAll = (queryKeys) =>
+    queryKeys.map((qk) => [qk, queryClient.getQueryData(qk)]);
+
+  const restoreAll = (entries) =>
+    entries.forEach(([qk, prev]) => queryClient.setQueryData(qk, prev));
+
+  const invalidateAll = (queryKeys) =>
+    Promise.all(
+      queryKeys.map((qk) =>
+        queryClient.invalidateQueries({ queryKey: qk, exact: true })
+      )
+    );
+
+  const onError = (error, variables, context) => {
+    if (context?.previousEntries) restoreAll(context.previousEntries);
+  };
+
+  const onSettled = async (data, error, variables, context) => {
+    if (context?.previousData) {
+      invalidateAll(context.queryKeys);
+    }
+  };
+
+  const markNotificationAsRead = useMutation({
+    mutationKey: MUTATION_KEY.readNotifications,
+
+    mutationFn: (notification) => readNotifications([notification.id]),
+
+    onMutate: async (notification) => {
+      const queryKeys = [
+        QUERY_KEY.notifications('ALL'),
+        QUERY_KEY.notifications(notification.category),
+      ];
+
+      await cancelAll(queryKeys);
+
+      const previousEntries = backupAll(queryKeys);
+
+      const optimisticOne = (id) => (old) =>
+        old?.map((n) => (n.id === id ? { ...n, isRead: true } : n));
+
+      queryKeys.forEach((qk) =>
+        queryClient.setQueryData(qk, optimisticOne(notification.id))
+      );
+
+      return { previousEntries, queryKeys };
+    },
+
+    onError,
+
+    onSettled,
+  });
+
+  const markAllNotificationsAsRead = useMutation({
+    mutationKey: MUTATION_KEY.readAllNotifications,
+
+    mutationFn: (category) => {
+      const notifications = queryClient.getQueryData(
+        QUERY_KEY.notifications(category)
+      );
+      const ids = notifications.map((notification) => notification.id);
+      readNotifications(ids);
+    },
+
+    onMutate: async (category) => {
+      const queryKeys =
+        category === 'ALL'
+          ? Object.keys(CATEGORY).map(QUERY_KEY.notifications)
+          : ['ALL', category].map(QUERY_KEY.notifications);
+
+      await cancelAll(queryKeys);
+
+      const previousEntries = backupAll(queryKeys);
+
+      const optimisticAll = (old) => old?.map((n) => ({ ...n, isRead: true }));
+
+      queryKeys.forEach((queryKey) =>
+        queryClient.setQueryData(queryKey, optimisticAll)
+      );
+
+      return { previousEntries, queryKeys };
+    },
+
+    onError,
+
+    onSettled,
+  });
+
+  return { markNotificationAsRead, markAllNotificationsAsRead };
 }
 
 export function useNotificationSettings() {

--- a/src/feature/alert/lib/index.js
+++ b/src/feature/alert/lib/index.js
@@ -1,3 +1,4 @@
 export * from './environment';
-export * from './PushNotification';
 export * from './firebase-config';
+export * from './notification';
+export * from './PushNotification';

--- a/src/feature/alert/lib/notification.js
+++ b/src/feature/alert/lib/notification.js
@@ -1,0 +1,35 @@
+// 알림 수신 설정 다음 상태값 계산
+export function calculateNextNotificationSettings({ current, type }) {
+  switch (type.toUpperCase()) {
+    case 'REQUIRED': {
+      const next = !current.required;
+
+      return {
+        required: next,
+        marketing: next ? current.marketing : false,
+        attendance: next ? current.attendance : false,
+      };
+    }
+
+    case 'MARKETING': {
+      if (!current.required) return current;
+
+      return {
+        ...current,
+        marketing: !current.marketing,
+      };
+    }
+
+    case 'ATTENDANCE': {
+      if (!current.required) return current;
+
+      return {
+        ...current,
+        attendance: !current.attendance,
+      };
+    }
+
+    default:
+      return current;
+  }
+}

--- a/src/feature/alert/mapper/notification.js
+++ b/src/feature/alert/mapper/notification.js
@@ -1,5 +1,3 @@
-import { CATEGORY } from '@/feature/alert/constant';
-
 export function toNotificationItem({
   id,
   title,
@@ -16,7 +14,7 @@ export function toNotificationItem({
     isRead,
     createdAt: formatToKST_MMDD_HHMM(createdAt),
     url,
-    category: CATEGORY[filter],
+    category: filter,
   };
 }
 

--- a/src/shared/constant/reactQuery.js
+++ b/src/shared/constant/reactQuery.js
@@ -18,7 +18,8 @@ export const QUERY_KEY = Object.freeze({
   myScrapedPosts: 'myScrapedPosts',
   myScrapedExamReviews: 'myScrapedExamReviews',
   best3: 'best3',
-  notifications: (category) => ['notifications', { category }],
+  notifications: (category) =>
+    category ? ['notifications', { category }] : ['notifications'],
   notificationSettings: ['notificationSettings'],
 });
 
@@ -39,6 +40,8 @@ export const MUTATION_KEY = Object.freeze({
   unscrap: 'unscrap',
   updateUserInfo: 'updateUserInfo',
   updatePassword: 'updatePassword',
+  readNotifications: ['readNotifications', 'single'],
+  readAllNotifications: ['readNotifications', 'all'],
   updateNotificationSettings: ['updateNotificationSettings'],
 });
 


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1125

- [Notion](https://www.notion.so/snorose/1e77ef0aa3bf80168d4cd9913161e9e6?v=78a0cf7cdf4940fd98e9b53219663fe6&source=copy_link)

## 🎯 변경 사항

- 알림 읽기 API 레이어 추가 (src/apis/alert.js)
- NotificationItem 컴포넌트에 `onClick` prop 추가
- 개별 알림 읽기와 전체 알림 읽기를 관리하는 useReadNotifications 훅 추가
- src/feature/alert/mapper/notification.js에서 category map 데이터 변경
- calculateNextNotificationSettings을 hook에서 lib로 분리
- 알림 리스트가 isFetching 상태이거나 알림 리스트 개수가 0개 이거나 모든 알림이 읽음 상태일 경우 "모두읽기" 버튼 비활성화

## 📸 스크린샷 (선택 사항)

<img width="557" height="200" alt="image" src="https://github.com/user-attachments/assets/9bc1c395-9f73-4fa8-abde-47dd26550000" />

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
- [ ] 개별 읽기, 모두 읽기가 정상적으로 처리되는가
- [ ] url이 있는 경우 알림 클릭 시 해당 경로로 페이지가 이동되는가
- [ ] 누락된 엣지 케이스 혹은 에러 핸들링이 있는가