### PR TITLE
#1140 [SNO-177] 시험후기 작성 페이지 내 CloseAppBar보다 라벨이 상단에 올라오는 이슈 해결

### DIFF
--- a/src/shared/component/layout/BackAppBar/BackAppBar.module.css
+++ b/src/shared/component/layout/BackAppBar/BackAppBar.module.css
@@ -8,6 +8,7 @@
   background-color: var(--white);
   position: fixed;
   top: 0;
+  z-index: var(--z-index-appbar);
 }
 
 .hasGap {

--- a/src/shared/component/layout/CloseAppBar/CloseAppBar.module.css
+++ b/src/shared/component/layout/CloseAppBar/CloseAppBar.module.css
@@ -9,6 +9,7 @@
   font: var(--text-headline-1-bold);
   position: fixed;
   top: 0;
+  z-index: var(--z-index-appbar);
 }
 
 .close {


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1140


## 🎯 변경 사항

- 시험후기 작성 페이지 내 CloseAppBar보다 라벨이 상단에 올라오는 이슈 해결
  - `AppBar`에는 `z-index`가 설정되어 있었지만, `CloseAppBar`와 `BackAppBar`에는 없어 동일하게 추가했습니다.
  
## 📸 스크린샷 (선택 사항)

| Before | After |
| :----: | :---: |
| <img width="250" alt="image" src="https://github.com/user-attachments/assets/2b3555db-6b09-4b48-afd5-2d14d1aeddcb" /> | <img width="250" alt="image" src="https://github.com/user-attachments/assets/fab5ef4d-a437-43b4-907f-785d4d183844" />|


## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
