### PR TITLE
#1144 [SNO-182] 단일 버튼 모달인 NoticeModal 컴포넌트 추가 및 인증 페이지에 적용

### DIFF
--- a/src/ProtectedRoute.jsx
+++ b/src/ProtectedRoute.jsx
@@ -1,8 +1,12 @@
 import { Navigate, useNavigate } from 'react-router-dom';
 
 import { useAuth } from '@/shared/hook';
-import { USER_STATUS, CONFIRM_MODAL_TEXT } from '@/shared/constant';
-import { ConfirmModal } from '@/shared/component';
+import {
+  USER_STATUS,
+  CONFIRM_MODAL_TEXT,
+  NOTICE_MODAL_TEXT,
+} from '@/shared/constant';
+import { ConfirmModal, NoticeModal } from '@/shared/component';
 
 // 토큰이 유효한지 확인하는 로직 필요
 export default function ProtectedRoute({ roles, message, children }) {
@@ -20,6 +24,16 @@ export default function ProtectedRoute({ roles, message, children }) {
   }
 
   if (roles && !roles.includes(userInfo?.userRoleId)) {
+    // "이미 인증을 완료했거나 인증 대상이 아니에요" 메시지인 경우 단일 버튼 모달 사용
+    if (message === '이미 인증을 완료했거나 인증 대상이 아니에요') {
+      return (
+        <NoticeModal
+          modalText={NOTICE_MODAL_TEXT.ALREADY_VERIFIED}
+          onConfirm={() => navigate('/', { replace: true })}
+        />
+      );
+    }
+
     const modalText = {
       ...CONFIRM_MODAL_TEXT.ACCESS_DENIED,
       title: message,
@@ -28,7 +42,7 @@ export default function ProtectedRoute({ roles, message, children }) {
     return (
       <ConfirmModal
         modalText={modalText}
-        onConfirm={() => navigate('/verify', { replace: true })}
+        onConfirm={() => navigate('/', { replace: true })}
         onCancel={() => navigate(-1)}
       />
     );

--- a/src/ProtectedRoute.jsx
+++ b/src/ProtectedRoute.jsx
@@ -42,7 +42,7 @@ export default function ProtectedRoute({ roles, message, children }) {
     return (
       <ConfirmModal
         modalText={modalText}
-        onConfirm={() => navigate('/', { replace: true })}
+        onConfirm={() => navigate('/verify', { replace: true })}
         onCancel={() => navigate(-1)}
       />
     );

--- a/src/shared/component/Modal/NoticeModal/NoticeModal.jsx
+++ b/src/shared/component/Modal/NoticeModal/NoticeModal.jsx
@@ -1,0 +1,31 @@
+import { useContext } from 'react';
+import styles from './NoticeModal.module.css';
+
+import { DimModalLayout } from '@/shared/component';
+import { ModalContext } from '@/shared/context/ModalContext';
+
+export default function NoticeModal({ modalText, onConfirm }) {
+  const { modal, setModal } = useContext(ModalContext);
+
+  const handleConfirm = () => {
+    onConfirm?.() || setModal({ id: null, type: null });
+  };
+
+  return (
+    <DimModalLayout isOpen={modal?.id}>
+      <div className={styles.container}>
+        <div className={styles.content}>
+          {modalText.title && (
+            <h3 className={styles.title}>{modalText.title}</h3>
+          )}
+          {modalText.description && (
+            <p className={styles.description}>{modalText.description}</p>
+          )}
+        </div>
+        <button className={styles.confirmButton} onClick={handleConfirm}>
+          {modalText.confirmText}
+        </button>
+      </div>
+    </DimModalLayout>
+  );
+}

--- a/src/shared/component/Modal/NoticeModal/NoticeModal.module.css
+++ b/src/shared/component/Modal/NoticeModal/NoticeModal.module.css
@@ -1,0 +1,41 @@
+.container {
+  background-color: white;
+  border-radius: 1rem;
+  overflow: hidden;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  padding: 2.3rem 4rem;
+  text-align: center;
+}
+
+.title {
+  color: var(--black);
+  font: var(--text-headline-1-med);
+  word-break: keep-all;
+}
+
+.description {
+  color: var(--grey-4);
+  font: var(--text-headline-2-reg);
+  word-break: keep-all;
+}
+
+.confirmButton {
+  width: 100%;
+  padding: 1.3rem 5.7rem;
+  color: var(--blue-3);
+  font: var(--text-headline-2-med);
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  border-top: solid 0.1rem var(--blue-0);
+  border-bottom-left-radius: 1rem;
+  border-bottom-right-radius: 1rem;
+}
+
+.confirmButton:hover {
+  background-color: var(--blue-0);
+}

--- a/src/shared/component/index.js
+++ b/src/shared/component/index.js
@@ -32,6 +32,7 @@ export { default as FetchLoadingOverlay } from './loading/FetchLoadingOverlay/Fe
 // modal
 export { default as DimModalLayout } from './Modal/DimModalLayout/DimModalLayout';
 export { default as ConfirmModal } from './Modal/ConfirmModal/ConfirmModal';
+export { default as NoticeModal } from './Modal/NoticeModal/NoticeModal';
 export { default as MoreOptionModal } from './Modal/MoreOptionModal/MoreOptionModal';
 export { default as OptionModal } from './Modal/OptionModal/OptionModal';
 

--- a/src/shared/constant/modalText.js
+++ b/src/shared/constant/modalText.js
@@ -195,6 +195,15 @@ const CONFIRM_MODAL = {
   },
 };
 
+// =================== Notice Modal ===================
+const NOTICE_MODAL = {
+  ALREADY_VERIFIED: {
+    title: '인증이 필요하지 않아요',
+    description: '이미 인증을 완료했거나 인증 대상이 아니에요.',
+    confirmText: '홈으로 이동',
+  },
+};
+
 // =================== Option Modal ===================
 // 게시글 신고 모달
 const REPORT_POST_TYPE_LIST = [
@@ -418,6 +427,8 @@ export const MORE_OPTION_MODAL_TEXT = {
 };
 
 export const CONFIRM_MODAL_TEXT = CONFIRM_MODAL;
+
+export const NOTICE_MODAL_TEXT = NOTICE_MODAL;
 
 export const OPTION_MODAL_TEXT = {
   REPORT_POST_TYPE_LIST,


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1144

- [Figma](https://www.figma.com/design/00Ywy8VC5KoHOSu01uC9sZ/-%EC%8A%A4%EB%85%B8%EB%A1%9C%EC%A6%88--%EC%9C%A0%EC%A0%80%EC%9B%B9-%EB%94%94%EC%9E%90%EC%9D%B8?node-id=5604-11619&m=dev)


## 🎯 변경 사항

- 단일 버튼 모달인 `NoticeModal` 컴포넌트를 추가하고 인증 페이지에 적용  
  - 기존 모달에서 `예` 버튼 클릭 시 `verify` 페이지로 무한 루프에 빠지는 문제가 있어, 버튼이 동작하지 않는 것처럼 보이는 이슈가 있었습니다.


## 📸 스크린샷 (선택 사항)


| Before | After |
| :----: | :---: |
| <img width="250"  alt="image" src="https://github.com/user-attachments/assets/60c5a918-aa5c-46c5-b49c-d6d5c805b47b" /> |  <img width="250"  alt="image" src="https://github.com/user-attachments/assets/041044a4-f407-4ba7-9088-e922b88426fe" /> |


## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
