### PR TITLE
#1170 [SNO-195] fullScreenAttachment 위치 변경

### DIFF
--- a/src/page/board/PostPage/PostPage.jsx
+++ b/src/page/board/PostPage/PostPage.jsx
@@ -114,7 +114,15 @@ export default function PostPage() {
 
   return (
     <div className={styles.container}>
-      {clickedImageIndex == 0 && <BackAppBar backgroundColor={'#eaf5fd'} />}
+      {clickedImageIndex === 0 ? (
+        <BackAppBar backgroundColor={'#eaf5fd'} />
+      ) : (
+        <FullScreenAttachment
+          attachmentUrls={data.attachments}
+          clickedImageIndex={clickedImageIndex}
+          setClickedImageIndex={setClickedImageIndex}
+        />
+      )}
 
       <div className={styles.content}>
         <div className={styles.contentTop}>
@@ -236,13 +244,6 @@ export default function PostPage() {
         handleReport={handleReport}
         handleDelete={handleDelete}
       />
-      {clickedImageIndex !== 0 && (
-        <FullScreenAttachment
-          attachmentUrls={data.attachments}
-          clickedImageIndex={clickedImageIndex}
-          setClickedImageIndex={setClickedImageIndex}
-        />
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1170

## 🎯 변경 사항

- FullScreenAttachment가 원하는 위치에 있지 않고 밑으로 밀려나는 버그가 생겼습니다.

## 📸 스크린샷 (선택 사항)

<img width="1127" height="729" alt="image" src="https://github.com/user-attachments/assets/98a7e750-09e9-43fd-a8a7-2f0b409be80e" />
이랬었는데
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/66ffb4e3-f60f-47e0-a843-cf169758a561" />
이렇게 수정했습니다

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
FullScreenAttachment가 기대하는 위치에 있는지 확인해주시면 감사하겠습니다.
