### PR TITLE
#1174 [SNO-199] 로고 단일 파일로 교체 및 관련 페이지 수정

### DIFF
--- a/src/assets/images/blackCloudLogo.svg
+++ b/src/assets/images/blackCloudLogo.svg
@@ -1,0 +1,9 @@
+<svg width="28" height="18" viewBox="0 0 28 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M19.4033 0.40625C24.1511 0.406502 28 4.22072 28 8.92578C28 13.6309 24.1511 17.4451 19.4033 17.4453C17.356 17.4453 15.4765 16.7348 14 15.5508C12.5235 16.7348 10.644 17.4453 8.59668 17.4453C3.84883 17.4451 0 13.6309 0 8.92578C2.96442e-05 4.22068 3.84885 0.406424 8.59668 0.40625C10.6438 0.40625 12.5236 1.116 14 2.2998C15.4764 1.11604 17.3563 0.40625 19.4033 0.40625Z" fill="url(#paint0_radial_5608_23501)"/>
+<defs>
+<radialGradient id="paint0_radial_5608_23501" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(19 9.40625) rotate(90) scale(14 23.0057)">
+<stop stop-color="#898989"/>
+<stop offset="1" stop-color="#232323"/>
+</radialGradient>
+</defs>
+</svg>

--- a/src/assets/images/cloudLogo.svg
+++ b/src/assets/images/cloudLogo.svg
@@ -1,0 +1,9 @@
+<svg width="23" height="15" viewBox="0 0 23 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M11.7549 13.4983C10.6142 14.3251 9.21467 14.812 7.70225 14.812C3.86533 14.812 0.754883 11.678 0.754883 7.81201C0.754883 3.94602 3.86533 0.812012 7.70225 0.812012C9.21467 0.812012 10.6142 1.29895 11.7549 2.12572C12.8955 1.29895 14.2951 0.812012 15.8075 0.812012C19.6444 0.812012 22.7549 3.94602 22.7549 7.81201C22.7549 11.678 19.6444 14.812 15.8075 14.812C14.2951 14.812 12.8955 14.3251 11.7549 13.4983Z" fill="url(#paint0_radial_4855_9917)"/>
+<defs>
+<radialGradient id="paint0_radial_4855_9917" cx="0" cy="0" r="1" gradientTransform="matrix(-1.06662 16.7224 -26.278 -3.78817 17.8797 9.05516)" gradientUnits="userSpaceOnUse">
+<stop offset="0.29142" stop-color="#C5D2FF"/>
+<stop offset="1" stop-color="#82B5FF"/>
+</radialGradient>
+</defs>
+</svg>

--- a/src/feature/board/component/PostBar/PostBar.jsx
+++ b/src/feature/board/component/PostBar/PostBar.jsx
@@ -17,7 +17,7 @@ export default function PostBar({ data, hasComment = true, hasLike = true }) {
       <div className={styles.thumbnailContainer}>
         <div>
           <div className={styles.postBarTop}>
-            <img src={cloudLogo} alt='로고' />
+            <img className={styles.cloudLogoIcon} src={cloudLogo} alt='로고' />
             <p className={styles.author}>{data.userDisplay}</p>
             {showBadge && (
               <Badge userRoleId={data.userRoleId} className={styles.badge} />

--- a/src/feature/board/component/PostBar/PostBar.jsx
+++ b/src/feature/board/component/PostBar/PostBar.jsx
@@ -2,6 +2,8 @@ import { Badge, Icon } from '@/shared/component';
 import { ROLE } from '@/shared/constant';
 import { postBarDateFormat } from '@/shared/lib';
 
+import cloudLogo from '@/assets/images/cloudLogo.svg';
+
 import styles from './PostBar.module.css';
 
 export default function PostBar({ data, hasComment = true, hasLike = true }) {
@@ -14,9 +16,9 @@ export default function PostBar({ data, hasComment = true, hasLike = true }) {
     <div className={styles.post}>
       <div className={styles.thumbnailContainer}>
         <div>
-          <div className={styles.post_top}>
-            <Icon id='cloud' width={23} height={14} />
-            <p className={styles.name}>{data.userDisplay}</p>
+          <div className={styles.postBarTop}>
+            <img src={cloudLogo} alt='로고' />
+            <p className={styles.author}>{data.userDisplay}</p>
             {showBadge && (
               <Badge userRoleId={data.userRoleId} className={styles.badge} />
             )}
@@ -31,9 +33,9 @@ export default function PostBar({ data, hasComment = true, hasLike = true }) {
                 height={12}
               />
             )}
-            <div className={styles.boardChip}>{data.boardName}</div>
+            <div className={styles.boardName}>{data.boardName}</div>
           </div>
-          <div className={styles.post_center}>
+          <div className={styles.postBarCenter}>
             <p className={styles.title}>{data.title}</p>
             <p className={styles.text}>{data.questionDetail ?? data.content}</p>
           </div>
@@ -47,7 +49,7 @@ export default function PostBar({ data, hasComment = true, hasLike = true }) {
         )}
       </div>
 
-      <div className={styles.post_bottom}>
+      <div className={styles.postBarBottom}>
         <div className={styles.iconListContainer}>
           {data.likeCount > 0 && (
             <div className={styles.iconContainer}>

--- a/src/feature/board/component/PostBar/PostBar.module.css
+++ b/src/feature/board/component/PostBar/PostBar.module.css
@@ -21,6 +21,11 @@
   white-space: nowrap;
 }
 
+.cloudLogoIcon {
+  width: 2.2rem;
+  height: 1.4rem;
+}
+
 .author {
   white-space: nowrap;
   overflow: hidden;

--- a/src/feature/board/component/PostBar/PostBar.module.css
+++ b/src/feature/board/component/PostBar/PostBar.module.css
@@ -12,7 +12,7 @@
   justify-content: space-between;
 }
 
-.post_top {
+.postBarTop {
   padding-bottom: 1rem;
   display: flex;
   align-items: center;
@@ -21,7 +21,7 @@
   white-space: nowrap;
 }
 
-.name {
+.author {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -44,7 +44,7 @@
   margin-left: 0.4rem;
 }
 
-.post_center {
+.postBarCenter {
   display: flex;
   flex-direction: column;
   row-gap: 0.6rem;
@@ -75,7 +75,7 @@
   border-radius: 0.5rem;
 }
 
-.post_bottom {
+.postBarBottom {
   display: flex;
   align-items: center;
   justify-content: flex-end;
@@ -87,7 +87,7 @@
   }
 }
 
-.boardChip {
+.boardName {
   padding: 0.1rem 0.4rem;
   display: flex;
   justify-content: center;

--- a/src/feature/comment/component/Comment/Comment.jsx
+++ b/src/feature/comment/component/Comment/Comment.jsx
@@ -18,6 +18,8 @@ import {
 import { useCommentContext } from '@/feature/comment/context';
 import { useLike } from '@/feature/like/hook';
 
+import cloudLogo from '@/assets/images/cloudLogo.svg';
+
 import styles from './Comment.module.css';
 
 const Comment = forwardRef((props, ref) => {
@@ -114,7 +116,7 @@ const Comment = forwardRef((props, ref) => {
         <div className={styles.commentTop}>
           <div className={styles.commentTopLeft}>
             <div className={styles.cloud}>
-              <Icon id='cloud' width={22} height={14} />
+              <img src={cloudLogo} alt='로고' />
             </div>
             <p className={`${isWriterWithdrawn && styles.isWriterWithdrawn}`}>
               {isWriterWithdrawn ? '(알 수 없음)' : userDisplay}

--- a/src/feature/comment/component/Comment/Comment.jsx
+++ b/src/feature/comment/component/Comment/Comment.jsx
@@ -116,7 +116,11 @@ const Comment = forwardRef((props, ref) => {
         <div className={styles.commentTop}>
           <div className={styles.commentTopLeft}>
             <div className={styles.cloud}>
-              <img src={cloudLogo} alt='로고' />
+              <img
+                className={styles.cloudLogoIcon}
+                src={cloudLogo}
+                alt='로고'
+              />
             </div>
             <p className={`${isWriterWithdrawn && styles.isWriterWithdrawn}`}>
               {isWriterWithdrawn ? '(알 수 없음)' : userDisplay}

--- a/src/feature/comment/component/Comment/Comment.module.css
+++ b/src/feature/comment/component/Comment/Comment.module.css
@@ -38,6 +38,11 @@
   align-items: center;
 }
 
+.cloudLogoIcon {
+  width: 2.2rem;
+  height: 1.4rem;
+}
+
 .isWriterWithdrawn {
   color: var(--grey-3-1);
 }

--- a/src/feature/comment/component/CommentInput/CommentInput.jsx
+++ b/src/feature/comment/component/CommentInput/CommentInput.jsx
@@ -84,11 +84,11 @@ const CommentInput = () => {
       className={styles.container}
       onClick={(event) => event.stopPropagation()}
     >
-      <div className={styles.input_bar}>
-        <img src={cloudLogo} alt='로고' />
+      <div className={styles.inputBar}>
+        <img className={styles.cloudLogoIcon} src={cloudLogo} alt='로고' />
         <TextareaAutosize
           ref={inputRef}
-          className={styles.input_zone}
+          className={styles.inputZone}
           placeholder='댓글을 입력하세요'
           value={content}
           onKeyDown={handleKeyPress}

--- a/src/feature/comment/component/CommentInput/CommentInput.jsx
+++ b/src/feature/comment/component/CommentInput/CommentInput.jsx
@@ -6,6 +6,8 @@ import { useToast } from '@/shared/hook';
 import { useCommentContext } from '@/feature/comment/context';
 import { useComment } from '@/feature/comment/hook';
 
+import cloudLogo from '@/assets/images/cloudLogo.svg';
+
 import styles from './CommentInput.module.css';
 
 const CommentInput = () => {
@@ -83,7 +85,7 @@ const CommentInput = () => {
       onClick={(event) => event.stopPropagation()}
     >
       <div className={styles.input_bar}>
-        <Icon id='cloud' width={22} height={14} />
+        <img src={cloudLogo} alt='로고' />
         <TextareaAutosize
           ref={inputRef}
           className={styles.input_zone}

--- a/src/feature/comment/component/CommentInput/CommentInput.module.css
+++ b/src/feature/comment/component/CommentInput/CommentInput.module.css
@@ -15,7 +15,7 @@
   bottom: 0;
 }
 
-.input_bar {
+.inputBar {
   background-color: var(--grey-1-1);
   width: 100%;
   min-height: 4rem;
@@ -26,7 +26,12 @@
   border-radius: 0.5rem;
 }
 
-.input_zone {
+.cloudLogoIcon {
+  width: 2.2rem;
+  height: 1.4rem;
+}
+
+.inputZone {
   width: 100%;
   min-height: 2rem;
   outline: none;
@@ -36,14 +41,8 @@
   resize: none;
 }
 
-.input_zone::placeholder {
+.inputZone::placeholder {
   color: var(--grey-3-1);
-}
-
-.profile_icon {
-  display: flex;
-  width: 2rem;
-  height: 2rem;
 }
 
 .enter {

--- a/src/feature/comment/component/NestedComment/NestedComment.jsx
+++ b/src/feature/comment/component/NestedComment/NestedComment.jsx
@@ -6,6 +6,8 @@ import { LIKE_TYPE, ROLE, SHOW_BADGE_PATH } from '@/shared/constant';
 import { useCommentContext } from '@/feature/comment/context';
 import { useLike } from '@/feature/like/hook';
 
+import cloudLogo from '@/assets/images/cloudLogo.svg';
+
 import styles from '@/feature/comment/component/Comment/Comment.module.css';
 import { useRef } from 'react';
 
@@ -55,7 +57,7 @@ export default function NestedComment({
             {isFirst && <Icon id='nested-arrow' width={15} height={15} />}
           </div>
           <div className={styles.cloud}>
-            <Icon id='cloud' width={22} heigth={14} />
+            <img src={cloudLogo} alt='로고' />
           </div>
           <p className={`${isWriterWithdrawn && styles.isWriterWithdrawn}`}>
             {isWriterWithdrawn ? '(알 수 없음)' : userDisplay}

--- a/src/feature/comment/component/NestedComment/NestedComment.jsx
+++ b/src/feature/comment/component/NestedComment/NestedComment.jsx
@@ -57,7 +57,7 @@ export default function NestedComment({
             {isFirst && <Icon id='nested-arrow' width={15} height={15} />}
           </div>
           <div className={styles.cloud}>
-            <img src={cloudLogo} alt='로고' />
+            <img className={styles.cloudLogoIcon} src={cloudLogo} alt='로고' />
           </div>
           <p className={`${isWriterWithdrawn && styles.isWriterWithdrawn}`}>
             {isWriterWithdrawn ? '(알 수 없음)' : userDisplay}

--- a/src/feature/home/component/AccordionListItem/AccordionListItem.jsx
+++ b/src/feature/home/component/AccordionListItem/AccordionListItem.jsx
@@ -1,20 +1,18 @@
 import { Badge, Icon } from '@/shared/component';
 import styles from './AccordionListItem.module.css';
 
+import cloudLogo from '@/assets/images/cloudLogo.svg';
+import blackCloud from '@/assets/images/blackCloudLogo.svg';
+
 export default function AccordionListItem({ list, listName }) {
   return (
     <ul className={styles.list}>
       {list.map((content) => (
         <li key={content.name} className={styles.item}>
           {content.name === '블랙리스트' ? (
-            <Icon
-              className={styles.icon}
-              id='black-cloud'
-              width={28}
-              height={17}
-            />
+            <img className={styles.icon} src={blackCloud} alt='블랙 클라우드' />
           ) : (
-            <Icon className={styles.icon} id='cloud' width={28} height={17} />
+            <img className={styles.icon} src={cloudLogo} alt='로고' />
           )}
           <div className={styles.itemContainer}>
             <span className={styles.name}>

--- a/src/feature/home/component/AccordionListItem/AccordionListItem.jsx
+++ b/src/feature/home/component/AccordionListItem/AccordionListItem.jsx
@@ -2,7 +2,7 @@ import { Badge, Icon } from '@/shared/component';
 import styles from './AccordionListItem.module.css';
 
 import cloudLogo from '@/assets/images/cloudLogo.svg';
-import blackCloud from '@/assets/images/blackCloudLogo.svg';
+import blackCloudLogo from '@/assets/images/blackCloudLogo.svg';
 
 export default function AccordionListItem({ list, listName }) {
   return (
@@ -10,7 +10,7 @@ export default function AccordionListItem({ list, listName }) {
       {list.map((content) => (
         <li key={content.name} className={styles.item}>
           {content.name === '블랙리스트' ? (
-            <img className={styles.icon} src={blackCloud} alt='블랙 클라우드' />
+            <img className={styles.icon} src={blackCloudLogo} alt='블랙로고' />
           ) : (
             <img className={styles.icon} src={cloudLogo} alt='로고' />
           )}

--- a/src/feature/home/component/AccordionListItem/AccordionListItem.module.css
+++ b/src/feature/home/component/AccordionListItem/AccordionListItem.module.css
@@ -12,7 +12,8 @@
 
 .icon {
   margin-top: 0.2rem;
-  flex-shrink: 0;
+  width: 2.8rem;
+  height: 1.7rem;
 }
 
 .itemContainer {

--- a/src/page/board/BoardCategoryPage/BoardCategoryPage.jsx
+++ b/src/page/board/BoardCategoryPage/BoardCategoryPage.jsx
@@ -1,10 +1,12 @@
 import { useNavigate } from 'react-router-dom';
 
-import { Header, Icon } from '@/shared/component';
+import { Header } from '@/shared/component';
 import { BOARD_MENUS } from '@/shared/constant';
 
 import { BoardBar } from '@/feature/board/component';
 import { Search } from '@/feature/search/component';
+
+import cloudLogo from '@/assets/images/cloudLogo.svg';
 
 import styles from './BoardCategoryPage.module.css';
 
@@ -49,7 +51,7 @@ export default function BoardCategoryPage() {
         </div>
       </div>
       <div className={styles.moreBoardBox}>
-        <Icon className={styles.iconLogo} id='cloud' width={31} height={19} />
+        <img className={styles.iconLogo} src={cloudLogo} alt='로고' />
         <p>스노로즈에서 더 다양한 게시판을 준비하고 있어요</p>
       </div>
     </div>

--- a/src/page/board/BoardCategoryPage/BoardCategoryPage.jsx
+++ b/src/page/board/BoardCategoryPage/BoardCategoryPage.jsx
@@ -51,7 +51,7 @@ export default function BoardCategoryPage() {
         </div>
       </div>
       <div className={styles.moreBoardBox}>
-        <img className={styles.iconLogo} src={cloudLogo} alt='로고' />
+        <img className={styles.cloudLogoIcon} src={cloudLogo} alt='로고' />
         <p>스노로즈에서 더 다양한 게시판을 준비하고 있어요</p>
       </div>
     </div>

--- a/src/page/board/BoardCategoryPage/BoardCategoryPage.module.css
+++ b/src/page/board/BoardCategoryPage/BoardCategoryPage.module.css
@@ -79,6 +79,8 @@
   font: var(--text-body-2-reg);
 }
 
-.iconLogo {
+.cloudLogoIcon {
   margin-bottom: 1rem;
+  width: 3.1rem;
+  height: 1.9rem;
 }

--- a/src/page/board/EditPostPage/EditPostPage.jsx
+++ b/src/page/board/EditPostPage/EditPostPage.jsx
@@ -29,6 +29,8 @@ import { ModalContext } from '@/shared/context/ModalContext';
 
 import { getPostContent, patchPost } from '@/apis';
 
+import cloudLogo from '@/assets/images/cloudLogo.svg';
+
 import styles from './EditPostPage.module.css';
 
 export default function EditPostPage() {
@@ -204,7 +206,7 @@ export default function EditPostPage() {
               <div className={styles.profileBoxLeft}>
                 {userInfo?.userRoleId !== ROLE.admin &&
                 userInfo?.userRoleId !== ROLE.official ? (
-                  <Icon id='cloud' width={25} height={16} />
+                  <img className={styles.logoIcon} src={cloudLogo} alt='로고' />
                 ) : (
                   <Badge
                     userRoleId={userInfo?.userRoleId}

--- a/src/page/board/EditPostPage/EditPostPage.module.css
+++ b/src/page/board/EditPostPage/EditPostPage.module.css
@@ -48,6 +48,11 @@
   gap: 0.7rem;
 }
 
+.logoIcon {
+  width: 2.5rem;
+  height: 1.6rem;
+}
+
 .badge {
   width: 2.4rem;
   height: 2.4rem;

--- a/src/page/board/PostPage/PostPage.jsx
+++ b/src/page/board/PostPage/PostPage.jsx
@@ -27,6 +27,8 @@ import { useLike } from '@/feature/like/hook';
 import { useScrap } from '@/feature/scrap/hook';
 import { useCommentContext } from '@/feature/comment/context';
 
+import cloudLogo from '@/assets/images/cloudLogo.svg';
+
 import styles from './PostPage.module.css';
 import 'swiper/css';
 import 'swiper/css/free-mode';
@@ -127,7 +129,7 @@ export default function PostPage() {
       <div className={styles.content}>
         <div className={styles.contentTop}>
           <div className={styles.contentTopLeft}>
-            <Icon id='cloud' width={25} height={16} />
+            <img className={styles.logoIcon} src={cloudLogo} alt='로고' />
             <p>{data.userDisplay || 'Unknown'}</p>
             {showBadge && (
               <Badge userRoleId={data.userRoleId} className={styles.badge} />

--- a/src/page/board/PostPage/PostPage.module.css
+++ b/src/page/board/PostPage/PostPage.module.css
@@ -29,6 +29,11 @@
   gap: 0.7rem;
 }
 
+.logoIcon {
+  width: 2.5rem;
+  height: 1.6rem;
+}
+
 .badge {
   width: 1.8rem;
   height: 1.8rem;

--- a/src/page/board/WritePostPage/WritePostPage.jsx
+++ b/src/page/board/WritePostPage/WritePostPage.jsx
@@ -28,6 +28,8 @@ import { ModalContext } from '@/shared/context/ModalContext';
 import { createThumbnail, postPost } from '@/apis';
 import { AttachmentBar } from '@/feature/board/component';
 
+import cloudLogo from '@/assets/images/cloudLogo.svg';
+
 import styles from './WritePostPage.module.css';
 
 export default function WritePostPage() {
@@ -252,7 +254,7 @@ export default function WritePostPage() {
               <div className={styles.profileBoxLeft}>
                 {userInfo?.userRoleId !== ROLE.admin &&
                 userInfo?.userRoleId !== ROLE.official ? (
-                  <Icon id='cloud' width={25} height={16} />
+                  <img className={styles.logoIcon} src={cloudLogo} alt='로고' />
                 ) : (
                   <Badge
                     userRoleId={userInfo?.userRoleId}

--- a/src/page/board/WritePostPage/WritePostPage.module.css
+++ b/src/page/board/WritePostPage/WritePostPage.module.css
@@ -57,6 +57,11 @@
   gap: 0.7rem;
 }
 
+.logoIcon {
+  width: 2.5rem;
+  height: 1.6rem;
+}
+
 .badge {
   width: 2.4rem;
   height: 2.4rem;

--- a/src/page/exam/ExamReviewPage/ExamReviewPage.jsx
+++ b/src/page/exam/ExamReviewPage/ExamReviewPage.jsx
@@ -29,12 +29,14 @@ import {
   FLEX_ALIGN,
 } from '@/feature/exam/constant';
 import { useScrap } from '@/feature/scrap/hook';
+import { useReportHandler } from '@/feature/report/hook/useReport';
+import { useDeleteExamReviewHandler } from '@/feature/exam/hook/useDeleteExamReviewHandler';
 
 import styles from './ExamReviewPage.module.css';
 import { ModalContext } from '@/shared/context/ModalContext';
-import { useReportHandler } from '@/feature/report/hook/useReport';
-import { useDeleteExamReviewHandler } from '@/feature/exam/hook/useDeleteExamReviewHandler';
 import { useModalReset } from '@/shared/hook/useBlocker';
+
+import cloudLogo from '@/assets/images/cloudLogo.svg';
 
 const COURSE_TYPE = convertToObject(LECTURE_TYPES);
 const SEMESTER = convertToObject(SEMESTERS);
@@ -118,24 +120,12 @@ export default function ExamReviewPage() {
         <BackAppBar backgroundColor={'#eaf5fd'} />
         <div className={styles.displayBox}>
           <div className={styles.displayBoxLeft}>
-            <Icon
-              className={styles.cloudIcon}
-              id='cloud'
-              width={25}
-              height={16}
-            />
+            <img src={cloudLogo} alt='로고' />
             <span>{userDisplay}</span>
             <span className={styles.dot}></span>
             <span>{dateFormat(createdAt)}</span>
             {isEdited && <span>&nbsp;(수정됨)</span>}
-            {isConfirmed && (
-              <Icon
-                className={styles.checkCircleIcon}
-                id='check-circle'
-                width={15}
-                height={15}
-              />
-            )}
+            {isConfirmed && <Icon id='check-circle' width={15} height={15} />}
           </div>
           <Icon
             className={styles.more}

--- a/src/page/exam/ExamReviewPage/ExamReviewPage.jsx
+++ b/src/page/exam/ExamReviewPage/ExamReviewPage.jsx
@@ -120,7 +120,7 @@ export default function ExamReviewPage() {
         <BackAppBar backgroundColor={'#eaf5fd'} />
         <div className={styles.displayBox}>
           <div className={styles.displayBoxLeft}>
-            <img src={cloudLogo} alt='로고' />
+            <img className={styles.cloudLogoIcon} src={cloudLogo} alt='로고' />
             <span>{userDisplay}</span>
             <span className={styles.dot}></span>
             <span>{dateFormat(createdAt)}</span>

--- a/src/page/exam/ExamReviewPage/ExamReviewPage.module.css
+++ b/src/page/exam/ExamReviewPage/ExamReviewPage.module.css
@@ -23,20 +23,12 @@
 .displayBoxLeft {
   display: flex;
   align-items: center;
-}
-
-.cloudIcon {
-  margin-right: 0.7rem;
-}
-
-.checkCircleIcon {
-  margin-left: 0.4rem;
+  gap: 0.6rem;
 }
 
 .dot {
   width: 0.3rem;
   height: 0.3rem;
-  margin: 0 0.8rem;
   background: var(--grey-3-1);
   border-radius: 100%;
 }

--- a/src/page/exam/ExamReviewPage/ExamReviewPage.module.css
+++ b/src/page/exam/ExamReviewPage/ExamReviewPage.module.css
@@ -26,6 +26,11 @@
   gap: 0.6rem;
 }
 
+.cloudLogoIcon {
+  width: 2.5rem;
+  height: 1.6rem;
+}
+
 .dot {
   width: 0.3rem;
   height: 0.3rem;

--- a/src/shared/component/PullToRefresh/PullToRefresh.jsx
+++ b/src/shared/component/PullToRefresh/PullToRefresh.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
-import { Icon } from '@/shared/component';
+import cloudLogo from '@/assets/images/cloudLogo.svg';
 
 import styles from './PullToRefresh.module.css';
 
@@ -95,7 +95,7 @@ export default function PullToRefresh({ children, onRefresh }) {
       {refreshing ? (
         <div className={styles.refreshBox}>
           <div className={styles.refreshIcon}>
-            <Icon id='cloud' width={34} height={21} />
+            <img src={cloudLogo} alt='로고' />
           </div>
         </div>
       ) : (

--- a/src/shared/component/PullToRefresh/PullToRefresh.module.css
+++ b/src/shared/component/PullToRefresh/PullToRefresh.module.css
@@ -11,6 +11,8 @@
 
 .refreshIcon {
   animation: rotateAndPause 1s linear infinite;
+  width: 3.4rem;
+  height: 2.1rem;
 }
 
 .ptrTouchZone {

--- a/src/shared/component/loading/FetchLoading/FetchLoading.jsx
+++ b/src/shared/component/loading/FetchLoading/FetchLoading.jsx
@@ -1,4 +1,4 @@
-import { Icon } from '@/shared/component';
+import cloudLogo from '@/assets/images/cloudLogo.svg';
 
 import styles from './FetchLoading.module.css';
 
@@ -11,7 +11,7 @@ export default function FetchLoading({
     <div className={`${styles.loading} ${className}`}>
       <div className={styles.centerBox}>
         <div className={animation ? styles.icon : styles.iconStatic}>
-          <Icon id='cloud' width={25} height={16} />
+          <img src={cloudLogo} alt='로고' />
         </div>
         <p>{children}</p>
       </div>

--- a/src/shared/component/loading/FetchLoading/FetchLoading.module.css
+++ b/src/shared/component/loading/FetchLoading/FetchLoading.module.css
@@ -16,6 +16,8 @@
 
 .icon {
   animation: rotateAndPause 1s linear infinite;
+  width: 2.5rem;
+  height: 1.6rem;
 }
 
 .iconStatic {


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1174

## 🎯 변경 사항

- 로고를 단일 파일로 교체하고 관련 페이지를 수정했습니다.
아이폰 iOS 26 버전에서 네이버, 사파리, 크롬 등 일부 브라우저에서 로고가 표시되지 않는 문제가 있었는데, 아이콘 내 그라데이션 처리로 인해 발생한 이슈로 보입니다. 이를 해결하기 위해 단일 파일 로고로 교체하는 작업을 진행했습니다.

## 📸 스크린샷 (선택 사항)


| Before | After |
| :----: | :---: |
| <img width="200"  alt="IMG_4248" src="https://github.com/user-attachments/assets/a9424f8d-60fc-4d37-8228-19baf3a4a3e2" /><img width="200"  alt="IMG_4247" src="https://github.com/user-attachments/assets/2b57e9c8-b30f-46d7-b467-be22c12fc6d7" /> | <img width="200"  alt="IMG_4245" src="https://github.com/user-attachments/assets/1ab23d66-a985-4b40-a22f-30fc55eeb81a" /><img width="200"  alt="IMG_4246" src="https://github.com/user-attachments/assets/9a37d3c2-82a9-4983-99f7-a9bb4f003e9f" /> |

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
- 기존에도 PC에서 이슈는 없었던터라, 모바일 환경 네이버, 사파리, 크롬 등 브라우저에서 확인해 주시면 좋을 것 같아요 :)
- `dev` 브랜치에서 베숙트에 있는 공지사항 글만 영역을 벗어나네요... 원인 파악이 필요해 보입니다. (`main` 브랜치는 정상)
  <img width="594" height="497" alt="image" src="https://github.com/user-attachments/assets/a99ce565-3913-40d5-9deb-bdf6f4dcaace" />
