### PR TITLE
#1176 [SNO-200] 알림함 및 안 읽은 알림 개수 실시간 동기화

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,16 +1,14 @@
 import { useEffect } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 
 import { useFeatureIsOn } from '@growthbook/growthbook-react';
 
-import { Navbar, Sidebar } from '@/shared/component';
 import { findRouteByPath } from '@/shared/lib';
+import { Navbar, Sidebar } from '@/shared/component';
+import { QUERY_KEY } from '@/shared/constant';
 
 import { PushNotificationManager } from '@/feature/alert/lib';
-
-import { routeList } from '@/router.js';
-
-import styles from './App.module.css';
 
 import {
   MAINTENANCE_START,
@@ -18,7 +16,12 @@ import {
 } from '@/feature/maintenance/hook/useMaintenance';
 import { MaintenancePage } from './page/maintenance';
 
+import { routeList } from '@/router.js';
+
+import styles from './App.module.css';
+
 function App() {
+  const queryClient = useQueryClient();
   const isEnabled = useFeatureIsOn('push-notification');
   const { pathname } = useLocation();
   const currentRoute = findRouteByPath(pathname, routeList);
@@ -28,9 +31,17 @@ function App() {
   useEffect(() => {
     if (!isEnabled) return;
 
-    PushNotificationManager.registerServiceWorker().catch((error) =>
-      console.error(error)
-    );
+    const listen = () => {
+      console.log('listen');
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY.notifications() });
+      queryClient.invalidateQueries({
+        queryKey: QUERY_KEY.unreadNotificationCount,
+      });
+    };
+
+    PushNotificationManager.registerServiceWorker()
+      .then(() => PushNotificationManager.onForegroundMessage(listen))
+      .catch((error) => console.error(error));
   }, [isEnabled]);
 
   // 서버 점검 페이지 처리

--- a/src/apis/alert.js
+++ b/src/apis/alert.js
@@ -1,6 +1,6 @@
 import { authAxios } from '@/axios';
 
-export const getUnreadAlertCount = async () => {
+export const fetchUnreadAlertCount = async () => {
   const response = await authAxios.get('/v1/alerts/unread/count');
   const data = response?.data ?? {};
 

--- a/src/feature/alert/lib/PushNotification.js
+++ b/src/feature/alert/lib/PushNotification.js
@@ -1,4 +1,4 @@
-import { getToken, isSupported } from 'firebase/messaging';
+import { getToken, isSupported, onMessage } from 'firebase/messaging';
 import { messaging } from './firebase-config';
 
 import { sendFCMToken } from '@/apis';
@@ -112,5 +112,11 @@ export class PushNotificationManager {
   static #setCachedToken(token) {
     const key = process.env.REACT_APP_FCM_TOKEN_KEY;
     localStorage.setItem(key, token);
+  }
+
+  static onForegroundMessage(callback) {
+    onMessage(messaging, (payload) => {
+      callback();
+    });
   }
 }

--- a/src/shared/component/layout/Navbar/Navbar.jsx
+++ b/src/shared/component/layout/Navbar/Navbar.jsx
@@ -1,16 +1,16 @@
 import { Link, useLocation } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 
+import { fetchUnreadAlertCount } from '@/apis/alert';
+
+import { useAuth } from '@/shared/hook';
 import { Icon } from '@/shared/component';
-import { NAVBAR_MENUS } from '@/shared/constant';
+import { NAVBAR_MENUS, QUERY_KEY } from '@/shared/constant';
 
 import styles from './Navbar.module.css';
-import { useEffect, useState } from 'react';
-import { getUnreadAlertCount } from '@/apis/alert';
-import { useAuth } from '@/shared/hook';
 
 export default function Navbar() {
   const { pathname } = useLocation();
-  const [unreadAlertCount, setUnreadAlertCount] = useState(0);
   const { status } = useAuth();
 
   const isActive = ({ id, to }) =>
@@ -18,31 +18,17 @@ export default function Navbar() {
     (id === 'home' && pathname === '/') ||
     (id === 'test' && pathname.startsWith('/board/exam-review/search'));
 
-  // 폴링 로직
-  useEffect(() => {
-    if (status !== 'authenticated') return; // 로그인이 안 되어 있으면 API를 호출하지 않음
+  const { data: unreadAlertCount = 0 } = useQuery({
+    queryKey: QUERY_KEY.unreadNotificationCount,
 
-    let alive = true; // 비동기 작업이 끝났을 때 컴포넌트가 이미 언마운트 상태인지 체크하기 위한 취소 플래그
+    queryFn: fetchUnreadAlertCount,
 
-    async function loadUnread() {
-      try {
-        const count = await getUnreadAlertCount();
-        if (alive) setUnreadAlertCount(count);
-      } catch (e) {
-        console.error('알림 개수 불러오기 실패:', e);
-        if (alive) setUnreadAlertCount(0);
-      }
-    }
+    staleTime: 5 * 60 * 1000,
 
-    loadUnread(); // 마운트 직후 1회 즉시 호출해서 첫 렌더에서 값이 비어 있지 않도록 함
-    const interval = setInterval(loadUnread, 30000); // 30초마다 loadUnread를 호출하는 폴링 타이머
+    gcTime: 30 * 60 * 1000,
 
-    // 언마운트 시 clean-up
-    return () => {
-      alive = false;
-      clearInterval(interval); // 폴링 중단 -> 타이머 누수 방지
-    };
-  }, [status]);
+    enabled: status === 'authenticated',
+  });
 
   return (
     <nav className={styles.nav}>

--- a/src/shared/constant/reactQuery.js
+++ b/src/shared/constant/reactQuery.js
@@ -20,6 +20,7 @@ export const QUERY_KEY = Object.freeze({
   best3: 'best3',
   notifications: (category) =>
     category ? ['notifications', { category }] : ['notifications'],
+  unreadNotificationCount: ['unreadNotificationCount'],
   notificationSettings: ['notificationSettings'],
 });
 


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1176

- [Notion](https://www.notion.so/snorose/26d7ef0aa3bf802aab6ce6c491a9fbfe?source=copy_link)

## 🎯 변경 사항

- 안 읽은 알림 개수 조회를 react query로 캐싱
- PushNotification 클래스에 onForegroundMessage 콜백 등록 함수 생성
- App.jsx에서 `onForegroundMessage`를 호출하여 알림 관련 캐시 데이터 무효화 로직 등록
  - 무효화 대상은 알림함 및 안 읽은 알림 개수

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
- FCM 토큰이 있어야 제대로 된 테스트가 가능합니다. 모바일에서 테스트해주세요.
- 불가피하게 PC로 테스트 해야하는 경우 임의로 가드를 꺼주시기 바랍니다.