### PR TITLE
#1185 [SNO-201] 알림 설정 쿼리가 갱신되지 않는 문제 해결

### DIFF
--- a/src/feature/alert/hook/notification.js
+++ b/src/feature/alert/hook/notification.js
@@ -167,7 +167,6 @@ export function useUpdateNotificationSetting() {
     onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: QUERY_KEY.notificationSettings,
-        refetchType: 'inactive',
       });
     },
   });


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1185

- [Figma]()
- [Notion]()

## 🎯 변경 사항

### 현상
알림 설정을 변경한 뒤 설정 페이지를 다시 열면, UI가 최신 상태가 아니라 이전 상태를 그대로 보여주는 문제가 있었습니다.
한 번 더 페이지를 나갔다 들어와야만 최신 상태가 반영되었습니다.

### 원인
- mutation의 onSettled에서 `refetchType: 'inactive'`를 사용해, 알림 설정 변경 직후 쿼리가 갱신되지 않았습니다.
- 또한 쿼리 데이터를 리듀서 초기값으로만 사용하고 있기 때문에, refetch가 일어나더라도 리듀서 상태가 갱신되지 않아 UI는 이전 상태를 계속 바라보게 되었습니다.

### 해결
`refetchType` 옵션을 제거해 기본값(`'active'`)으로 동작하도록 수정했습니다. 이제 알림 설정 변경 후 쿼리가 즉시 refetch되어, UI와 캐시가 일관된 최신 상태를 보여주게 됩니다.

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
