### PR TITLE
#1178 [SNO-206] 알림 모두읽기 시 미확인 알림 개수가 실시간으로 동기화 되지 않는 이슈 해결

### DIFF
--- a/src/feature/alert/hook/notification.js
+++ b/src/feature/alert/hook/notification.js
@@ -64,6 +64,11 @@ export function useReadNotifications() {
     if (context?.previousData) {
       invalidateAll(context.queryKeys);
     }
+
+    queryClient.invalidateQueries({
+      queryKey: QUERY_KEY.unreadNotificationCount,
+      refetchType: 'inactive',
+    });
   };
 
   const markNotificationAsRead = useMutation({
@@ -105,6 +110,10 @@ export function useReadNotifications() {
       );
       const ids = notifications.map((notification) => notification.id);
       readNotifications(ids);
+    },
+
+    onSuccess: () => {
+      queryClient.setQueryData(QUERY_KEY.unreadNotificationCount, 0);
     },
 
     onMutate: async (category) => {


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1178

- [Notion](https://www.notion.so/snorose/26d7ef0aa3bf805abbc0fb45d0651328?source=copy_link)

## 🎯 변경 사항

- 알림 모두읽기 시 클라이언트 단에서 미확인 알림 개수를 0으로 바꾸고, 클라이언트 값을 서버 데이터에 맞춰 동기화 하기 위해 `queryClient.invalidateQueries`를 추가했습니다.
- `queryClient.invalidateQueries`를 onSettled에서 호출했음에도 백엔드에서 최신 데이터가 아닌 이전 데이터를 내려주어서 refetchType: 'inactive'으로 지정했습니다.

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
