### PR TITLE
#1240 [SNO-179] 공지창과 검색창 컴포넌트 padding, 폰트사이즈, 아이콘 크기를 동일한 값으로 수정

### DIFF
--- a/src/feature/search/component/Search/Search.module.css
+++ b/src/feature/search/component/Search/Search.module.css
@@ -1,6 +1,6 @@
 .container {
   width: 100%;
-  padding: 1.2rem 1.2rem;
+  padding: 1.2rem 1.5rem;
   display: flex;
   align-items: center;
   gap: 0.7rem;

--- a/src/feature/search/component/Search/Search.module.css
+++ b/src/feature/search/component/Search/Search.module.css
@@ -13,11 +13,11 @@
   outline: none;
   border: none;
   background-color: transparent;
-  font: var(--text-body-2-reg);
+  font: var(--text-body-1-reg);
   color: var(--black);
 }
 
 .search::placeholder {
-  font: var(--text-body-2-reg);
+  font: var(--text-body-1-reg);
   color: var(--grey-3-1);
 }

--- a/src/page/alert/AlertPage/AlertPage.module.css
+++ b/src/page/alert/AlertPage/AlertPage.module.css
@@ -16,17 +16,15 @@
 }
 
 .notificationBar {
-  width: 100%;
-
   display: flex;
   align-items: center;
   gap: 1rem;
-  padding: 0.9rem 1.5rem;
   border-radius: 0.5rem;
+  background-color: var(--pink-1);
+  padding: 1.2rem 1.5rem;
 
   font: var(--text-body-1-reg);
   color: var(--pink-3);
-  background-color: var(--pink-1);
 }
 
 .categoryTabs {

--- a/src/page/board/PostListPage/PostListPage.jsx
+++ b/src/page/board/PostListPage/PostListPage.jsx
@@ -53,7 +53,9 @@ export default function PostListPage() {
           to={`/board/${currentBoardTextId}/notice`}
         >
           <Icon id='notice-bell' width={13} height={16} />
-          <p>[필독]&nbsp;&nbsp;{noticeLineData?.title}</p>
+          <p className={styles.notificationBarText}>
+            [필독]&nbsp;&nbsp;{noticeLineData?.title}
+          </p>
         </Link>
       )}
       <PostListSuspense saveScrollPosition={saveScrollPosition} />

--- a/src/page/board/PostListPage/PostListPage.module.css
+++ b/src/page/board/PostListPage/PostListPage.module.css
@@ -5,22 +5,24 @@
 }
 
 .notificationBar {
-  height: 4rem;
-
-  padding: 0 1.5rem;
-  margin: 1rem var(--default-margin);
-
   display: flex;
   align-items: center;
   gap: 1rem;
-
+  margin: 1rem var(--default-margin);
   border-radius: 0.5rem;
   background-color: var(--pink-1);
+  padding: 1.2rem 1.5rem;
 
   font: var(--text-body-1-reg);
   color: var(--pink-3);
 
   cursor: pointer;
+}
+
+.notificationBarText {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .writeButton {

--- a/src/page/exam/ExamReviewListPage/ExamReviewListPage.jsx
+++ b/src/page/exam/ExamReviewListPage/ExamReviewListPage.jsx
@@ -32,7 +32,7 @@ export default function ExamReviewListPage() {
       </AppBar>
 
       <Link className={styles.notificationBar} to={`/board/exam-review/notice`}>
-        <Icon id='notice-bell' width={11} height={13} />
+        <Icon id='notice-bell' width={13} height={16} />
         <p>[필독]&nbsp;&nbsp;{noticeLineData?.title}</p>
       </Link>
 

--- a/src/page/exam/ExamReviewListPage/ExamReviewListPage.module.css
+++ b/src/page/exam/ExamReviewListPage/ExamReviewListPage.module.css
@@ -5,17 +5,13 @@
 }
 
 .notificationBar {
-  height: 4rem;
-
-  padding: 0 1.5rem;
-  margin: 1rem var(--default-margin);
-
   display: flex;
   align-items: center;
   gap: 1rem;
-
+  margin: 1rem var(--default-margin);
   border-radius: 0.5rem;
   background-color: var(--pink-1);
+  padding: 1.2rem 1.5rem;
 
   font: var(--text-body-1-reg);
   color: var(--pink-3);


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1240

- [Figma](https://www.figma.com/design/00Ywy8VC5KoHOSu01uC9sZ/-%EC%8A%A4%EB%85%B8%EB%A1%9C%EC%A6%88--%EC%9C%A0%EC%A0%80%EC%9B%B9-%EB%94%94%EC%9E%90%EC%9D%B8?node-id=4279-13125&m=dev)


## 🎯 변경 사항

- 공지 컴포넌트
  - 상하 padding 값을 적용하고, 줄바꿈 시 글자가 넘어가면 '...'으로 표시되도록 CSS 속성 추가
  - 알림 페이지 내 bell 아이콘 크기와 동일하게 수정
- 검색창 컴포넌트
  - 공지 컴포넌트와 폰트 사이즈 동일하게 수정 
  - 공지 컴포넌트와 좌우 padding 값 동일하게 수정

-> 공지와 검색창 컴포넌트의 `폰트 사이즈`, `padding`을 통일하고,
페이지별로 `아이콘 크기`가 다르던 공지 컴포넌트를 일관되게 수정했습니다. (기준: 알림 페이지)

## 📸 스크린샷 (선택 사항)


| Before | After |
| :----: | :---: |
|<img width="250" alt="image" src="https://github.com/user-attachments/assets/9358f554-a4b4-446e-ae03-15d218d1abcf" />  |<img width="250" alt="image" src="https://github.com/user-attachments/assets/1be6227b-8693-463a-958d-a3c7a2b1c9cc" />  |




## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
