### PR TITLE
#1243 [FIX] PostBar 텍스트에 링크 있을 때 overflow되지 않도록 글자 단위 줄바꿈 처리

### DIFF
--- a/src/feature/board/component/PostBar/PostBar.module.css
+++ b/src/feature/board/component/PostBar/PostBar.module.css
@@ -59,9 +59,12 @@
   font: var(--text-body-1-med);
   display: -webkit-box;
   -webkit-line-clamp: 1;
+  line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
+  word-break: break-all;
+  overflow-wrap: break-word;
 }
 
 .text {
@@ -69,9 +72,12 @@
   color: var(--grey-4);
   display: -webkit-box;
   -webkit-line-clamp: 3;
+  line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
+  word-break: break-all;
+  overflow-wrap: break-word;
 }
 
 .thumbnail {


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1243 

<img width="864" height="382" alt="스크린샷 2025-10-08 오후 5 36 11" src="https://github.com/user-attachments/assets/d6b9f100-7c7e-406f-bd27-9f8231a4ad17" />

## 🎯 변경 사항
- 오류: PostBar에서 텍스트가 card를 넘어가는 케이스 발견
- 원인: 링크가 있는 케이스에서, 줄바꿈이 제대로 되지 않아 텍스트가 card가 넘어가는 현상 발생
- 해결: PostBar의 텍스틀를 `글자` 단위로 줄바꿈이 되도록 수정해 링크의 overflow 방지

## 📸 스크린샷 
| Before | After |
| :----: | :---: |
| <img width="600" alt="Image" src="https://github.com/user-attachments/assets/9c522ef3-9f78-4874-b334-b708e13def96" /> | <img width="600" alt="image" src="https://github.com/user-attachments/assets/8f9e0538-2ab9-45d0-845b-9b670d0a5d49" /> |

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요?
- 요 pr은 dev 머지 후, cherry-pick으로 main에도 바로 머지 pr 올리도록 하겠습니다.
