### PR TITLE
#1251 [SNO-221] 일부 iOS에서 알림 토글이 활성화되지 않는 문제

### DIFF
--- a/src/feature/alert/lib/PushNotification.js
+++ b/src/feature/alert/lib/PushNotification.js
@@ -5,7 +5,7 @@ import { sendFCMToken } from '@/apis';
 
 import { AppError } from '@/shared/lib';
 
-import { isIPhone } from '@/feature/alert/lib';
+import { isIOSPWA } from '@/feature/alert/lib';
 import { ERROR_CODE, ERROR_MESSAGE } from '@/feature/alert/constant';
 
 export class PushNotificationManager {
@@ -49,7 +49,7 @@ export class PushNotificationManager {
 
     if (current === 'granted') return;
     if (current === 'denied') {
-      const message = isIPhone()
+      const message = isIOSPWA()
         ? ERROR_MESSAGE.PERMISSION_DENIED_IOS
         : ERROR_MESSAGE.PERMISSION_DENIED_ANDROID;
 

--- a/src/feature/alert/lib/environment.js
+++ b/src/feature/alert/lib/environment.js
@@ -1,3 +1,5 @@
+const MAX_SMARTPHONE_WIDTH = 600;
+
 export function isWebPushSupported() {
   return (
     'Notification' in window &&
@@ -6,20 +8,14 @@ export function isWebPushSupported() {
   );
 }
 
-export function isAndroidPhone() {
-  const isSmartPhone = navigator.userAgentData?.mobile;
+function isSmallTouchDevice() {
+  const isTouch =
+    ('maxTouchPoints' in navigator && navigator.maxTouchPoints > 0) ||
+    'ontouchstart' in window;
 
-  if (isSmartPhone !== undefined) {
-    return isSmartPhone;
-  }
+  if (!isTouch) return false;
 
-  // userAgentData을 지원하지 않는 경우의 fallback
-  const ua = navigator.userAgent || '';
-  return /Android/i.test(ua) && /Mobile/i.test(ua);
-}
-
-export function isIPhone() {
-  return navigator.platform === 'iPhone';
+  return window.innerWidth <= MAX_SMARTPHONE_WIDTH;
 }
 
 export function isIOSPWA() {
@@ -31,11 +27,11 @@ export function isIOSPWA() {
 export function canUseAlertSetting() {
   if (!isWebPushSupported()) return false;
 
-  if (isAndroidPhone()) return true;
+  if (isIOSPWA()) {
+    return isSmallTouchDevice();
+  }
 
-  if (isIPhone() && isIOSPWA()) return true;
-
-  return false;
+  return isSmallTouchDevice();
 }
 
 /**
@@ -48,8 +44,7 @@ export function getDeviceType() {
   const ua = navigator.userAgent || '';
   const platform = navigator.platform || '';
 
-  if (isIPhone()) return 'MOBILE';
-  if (isAndroidPhone()) return 'MOBILE';
+  if (isSmallTouchDevice()) return 'MOBILE';
 
   if (platform === 'iPad') return 'TABLET';
   if (platform === 'MacIntel' && navigator.maxTouchPoints > 1) return 'TABLET';

--- a/src/page/alert/AlertSettingPage/AlertSettingPage.jsx
+++ b/src/page/alert/AlertSettingPage/AlertSettingPage.jsx
@@ -19,10 +19,6 @@ import {
   PushNotificationManager,
   getDeviceType,
   canUseAlertSetting,
-  isWebPushSupported,
-  isAndroidPhone,
-  isIPhone,
-  isIOSPWA,
 } from '@/feature/alert/lib';
 import {
   useUpdateNotificationSetting,
@@ -130,34 +126,9 @@ function NotificationSettings() {
     userAgent: navigator.userAgent,
   });
 
-  const supported = isWebPushSupported();
-  const android = isAndroidPhone();
-  const ios = isIPhone();
-  const iosPWA = isIOSPWA();
-
   return (
     <>
       <div className={style.alert}>
-        <div>supported: {supported ? 'true' : 'false'}</div>
-        <div>android: {android ? 'true' : 'false'}</div>
-        <div>ios: {ios ? 'true' : 'false'}</div>
-        <div>iosPWA: {iosPWA ? 'true' : 'false'}</div>
-
-        <hr />
-
-        <div>
-          Notification in window: {'Notification' in window ? 'true' : 'false'}
-        </div>
-        <div>
-          serviceWorker in navigator:{' '}
-          {'serviceWorker' in window ? 'true' : 'false'}
-        </div>
-        <div>
-          PushManager in window: {'PushManager' in window ? 'true' : 'false'}
-        </div>
-        <div>navigator.standalone: {navigator.standalone}</div>
-        <div>navigator.platform: {navigator.platform}</div>
-        <div>userAgent: {navigator.userAgent}</div>
         <SettingItem
           title='알림 받기'
           content={content.alert}


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1251

## 🎯 변경 사항

- 일부 iOS의 UA에서 아이폰임에도 iPhone이 아닌 Macintosh로 인식되는 문제로 인해 발생하는 버그였습니다.
- 따라서 스마트폰 판별을 UA에 의지하지 않고 디바이스 너비로 판별하도록 수정했습니다.


## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
