### PR TITLE
#1258 [SNO-209] 시험후기 작성 시 필수 값 입력하지 않고 제출 가능한 버그 수정

### DIFF
--- a/src/page/exam/WriteExamReviewPage/WriteExamReviewPage.jsx
+++ b/src/page/exam/WriteExamReviewPage/WriteExamReviewPage.jsx
@@ -98,10 +98,10 @@ export default function WriteExamReviewPage() {
   const pass =
     lectureName.trim() &&
     professor.trim() &&
-    lectureType &&
-    examType &&
-    lectureYear &&
-    semester &&
+    Object.keys(lectureType).length > 0 &&
+    Object.keys(examType).length > 0 &&
+    Object.keys(lectureYear).length > 0 &&
+    Object.keys(semester).length > 0 &&
     classNumber &&
     questionDetail.trim() &&
     file;
@@ -338,7 +338,9 @@ export default function WriteExamReviewPage() {
           }}
         />
       )}
+
       {loading && <FetchLoadingOverlay />}
+
       {/* 페이지 이탈 방지 모달 */}
       {modal.id === 'exit-page' && (
         <ConfirmModal

--- a/src/style/variable.css
+++ b/src/style/variable.css
@@ -71,7 +71,6 @@
   --text-body-2-reg: 400 1.3rem/1.4 'Spoqa Han Sans Neo';
 
   /* z-index */
-  --z-index-fetch-loading: 100;
   --z-index-pull-to-refresh: 100;
   --z-index-mypage-background: 100;
   --z-index-profile-image: 200;
@@ -82,5 +81,6 @@
   --z-index-modal: 600;
   --z-index-sidebar: 700;
   --z-index-popup: 800;
+  --z-index-fetch-loading: 900;
   --z-index-toast: 1000;
 }


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1258

## 🎯 변경 사항

- WriteExamReviewPage에서 제출 가능 여부를 판단하는 로직에서 강의종류, 시험종류, 수강연도, 수강학기 state에 Object.keys()를 사용하여 빈 객체인지 확인하도록 로직 수정했습니다.
- 시험후기 제출 시 FetchLoadingOverlay가 BackAppBar 밑으로 내려가는 문제가 있어 variable.css의 `--z-index-fetch-loading`을 100 -> 900으로 수정했습니다. 

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
- 원래 빈 토스트가 뜨는 문제가 있다고 제보받았는데, 현재 해당 오류는 재현이 불가능하고 400 오류가 발생합니다.
