### PR TITLE
#1278 [SNO-230] 이미지 정책을 10장에서 5장으로 축소

### DIFF
--- a/src/shared/constant/attachment.js
+++ b/src/shared/constant/attachment.js
@@ -1,7 +1,7 @@
 //이미지*영상 개수 및 용량 제한 정책
 export const ATTACHMENT_SIZE_LIMIT = Object.freeze({
   imageFileSize: 5 * 1024 * 1024, //MB
-  imageQuantity: 10,
+  imageQuantity: 5,
   videoFileSize: 50 * 1024 * 1024,
   videoQuantity: 1,
 });

--- a/src/shared/constant/toast.js
+++ b/src/shared/constant/toast.js
@@ -57,7 +57,7 @@ const TOAST = Object.freeze({
   },
   ATTACHMENT: {
     imageFileSizeError: '파일 크기는 최대 5MB까지 업로드할 수 있어요.',
-    imageQuantityError: '이미지는 최대 10개까지 첨부 가능해요.',
+    imageQuantityError: '이미지는 최대 5개까지 첨부 가능해요.',
     videoFileSizeError: '파일 크기는 최대 50MB까지 업로드할 수 있어요.',
     videoQuantityError: '영상은 최대 1개까지 첨부 가능해요.',
   },


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1278 

- [Notion](https://www.notion.so/snorose/2a27ef0aa3bf80f589e1c553c32b622f?source=copy_link)

## 🎯 변경 사항

이미지 정책을 수정했습니다. 
이미지 개수 제한을 10개에서 5개로 축소했습니다.
