### PR TITLE
#1283 [SNO-233] 스크롤 복원 안 되는 이슈 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,11 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 
 import { useFeatureIsOn } from '@growthbook/growthbook-react';
 
 import { findRouteByPath } from '@/shared/lib';
+import { useScrollRestoration } from '@/shared/hook';
 import { Navbar, Sidebar } from '@/shared/component';
 import { QUERY_KEY } from '@/shared/constant';
 
@@ -21,6 +22,7 @@ import { routeList } from '@/router.js';
 import styles from './App.module.css';
 
 function App() {
+  const appRef = useRef();
   const queryClient = useQueryClient();
   const isEnabled = useFeatureIsOn('push-notification');
   const { pathname } = useLocation();
@@ -43,6 +45,8 @@ function App() {
       .catch((error) => console.error(error));
   }, [isEnabled]);
 
+  useScrollRestoration(appRef);
+
   // 서버 점검 페이지 처리
   const now = new Date();
   const isMaintenance = now >= MAINTENANCE_START && now <= MAINTENANCE_END;
@@ -51,7 +55,7 @@ function App() {
   }
 
   return (
-    <div className={styles.app}>
+    <div className={styles.app} ref={appRef}>
       <Outlet />
       {!hideNav && <Navbar />}
       <Sidebar />

--- a/src/feature/board/component/PostList/PostList.jsx
+++ b/src/feature/board/component/PostList/PostList.jsx
@@ -16,7 +16,7 @@ import { PostBar } from '@/feature/board/component';
 
 import styles from './PostList.module.css';
 
-export default function PostList({ saveScrollPosition }) {
+export default function PostList() {
   const { pathname } = useLocation();
   const currentBoardTextId = pathname.split('/')[2];
   const currentBoard = getBoard(currentBoardTextId);
@@ -46,7 +46,6 @@ export default function PostList({ saveScrollPosition }) {
                 : `/board/${currentBoardTextId}/post/${post.postId}`
             }
             ref={index === postList.length - 1 ? ref : undefined}
-            onClick={() => saveScrollPosition()}
           >
             <PostBar data={{ ...post, timeAgo: timeAgo(post.date) }} />
           </Link>

--- a/src/feature/board/component/PostList/PostListSuspense.jsx
+++ b/src/feature/board/component/PostList/PostListSuspense.jsx
@@ -6,7 +6,7 @@ import { FetchLoading } from '@/shared/component';
 
 import { PostList, PostListErrorFallback } from '@/feature/board/component';
 
-export default function PostListSuspense({ saveScrollPosition }) {
+export default function PostListSuspense() {
   return (
     <QueryErrorResetBoundary>
       {({ reset }) => (
@@ -17,7 +17,7 @@ export default function PostListSuspense({ saveScrollPosition }) {
           <Suspense
             fallback={<FetchLoading>게시글 불러오는 중...</FetchLoading>}
           >
-            <PostList saveScrollPosition={saveScrollPosition} />
+            <PostList />
           </Suspense>
         </ErrorBoundary>
       )}

--- a/src/feature/my/component/MyPostList/MyPostList.jsx
+++ b/src/feature/my/component/MyPostList/MyPostList.jsx
@@ -24,7 +24,6 @@ export default function MyPostList({
   queryFn,
   hasLike = true,
   errorMessage,
-  saveScrollPosition,
 }) {
   const { data, ref, isFetching } = useSuspensePagination({
     queryKey: [queryKey],
@@ -79,7 +78,6 @@ export default function MyPostList({
           ref={index === list.length - 1 ? ref : undefined}
           key={post.postId}
           to={makePath({ boardId: post.boardId, postId: post.postId })}
-          onClick={saveScrollPosition}
         >
           <PostBar data={post} hasLike={hasLike} />
         </Link>

--- a/src/feature/search/component/SearchExamReviewList/SearchExamReviewList.jsx
+++ b/src/feature/search/component/SearchExamReviewList/SearchExamReviewList.jsx
@@ -11,7 +11,7 @@ import { PostBar } from '@/feature/board/component';
 
 import styles from './SearchExamReviewList.module.css';
 
-export default function SearchExamReviewList({ saveScrollPosition }) {
+export default function SearchExamReviewList() {
   const [searchParams] = useSearchParams();
   const params = Object.fromEntries(searchParams.entries());
   const paramsLength = Object.keys(params).length;
@@ -40,7 +40,6 @@ export default function SearchExamReviewList({ saveScrollPosition }) {
             ref={index === examList.length - 1 ? ref : undefined}
             key={post.postId}
             to={`/board/exam-review/post/${post.postId}`}
-            onClick={saveScrollPosition}
           >
             <PostBar data={post} hasLike={false} />
           </Link>

--- a/src/feature/search/component/SearchExamReviewList/SearchExamReviewListSuspense.jsx
+++ b/src/feature/search/component/SearchExamReviewList/SearchExamReviewListSuspense.jsx
@@ -10,7 +10,7 @@ import {
   SearchExamReviewListErrorFallback,
 } from '@/feature/search/component';
 
-export default function SearchExamReviewListSuspense({ saveScrollPosition }) {
+export default function SearchExamReviewListSuspense() {
   const [searchParams] = useSearchParams();
   const params = Object.fromEntries(searchParams.entries());
 
@@ -23,7 +23,7 @@ export default function SearchExamReviewListSuspense({ saveScrollPosition }) {
           resetKeys={[params]}
         >
           <Suspense fallback={<FetchLoading>검색 중</FetchLoading>}>
-            <SearchExamReviewList saveScrollPosition={saveScrollPosition} />
+            <SearchExamReviewList />
           </Suspense>
         </ErrorBoundary>
       )}

--- a/src/feature/search/component/SearchResultList/SearchResultList.jsx
+++ b/src/feature/search/component/SearchResultList/SearchResultList.jsx
@@ -13,7 +13,7 @@ import { useSearch } from '@/feature/search/hook';
 
 import styles from './SearchResultList.module.css';
 
-export default function SearchResultList({ saveScrollPosition }) {
+export default function SearchResultList() {
   const { pathname } = useLocation();
   const boardId = BOARDS.find(({ path }) => pathname.includes(path)).id;
 
@@ -31,7 +31,6 @@ export default function SearchResultList({ saveScrollPosition }) {
             ref={index === postList.length - 1 ? ref : undefined}
             key={post.postId}
             to={`/board/${getBoardTitleToTextId(post.boardName)}/post/${post.postId}`}
-            onClick={saveScrollPosition}
           >
             <PostBar data={post} />
           </Link>

--- a/src/feature/search/component/SearchResultList/SearchResultListSuspense.jsx
+++ b/src/feature/search/component/SearchResultList/SearchResultListSuspense.jsx
@@ -10,7 +10,7 @@ import {
   SearchResultListErrorFallback,
 } from '@/feature/search/component';
 
-export default function SearchResultListSuspense({ saveScrollPosition }) {
+export default function SearchResultListSuspense() {
   const [searchParams] = useSearchParams();
   const params = Object.fromEntries(searchParams.entries());
 
@@ -23,7 +23,7 @@ export default function SearchResultListSuspense({ saveScrollPosition }) {
           resetKeys={[params]}
         >
           <Suspense fallback={<FetchLoading>검색 중</FetchLoading>}>
-            <SearchResultList saveScrollPosition={saveScrollPosition} />
+            <SearchResultList />
           </Suspense>
         </ErrorBoundary>
       )}

--- a/src/page/board/NoticeListPage/NoticeListPage.jsx
+++ b/src/page/board/NoticeListPage/NoticeListPage.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 
-import { useAuth, useScrollRestoration } from '@/shared/hook';
+import { useAuth } from '@/shared/hook';
 import { BackAppBar, FetchLoading, WriteButton } from '@/shared/component';
 import { getBoard } from '@/shared/lib';
 import { QUERY_KEY, STALE_TIME, ROLE } from '@/shared/constant';
@@ -26,8 +26,6 @@ export default function NoticeListPage() {
     staleTime: STALE_TIME.noticeList,
     enabled: !!currentBoard?.id,
   });
-
-  const { scrollRef, saveScrollPosition } = useScrollRestoration();
 
   // 데이터 화면 표시
   useEffect(() => {
@@ -57,7 +55,7 @@ export default function NoticeListPage() {
   }
 
   return (
-    <div className={styles.container} ref={scrollRef}>
+    <div className={styles.container}>
       <BackAppBar
         title={
           currentBoardTextId === 'notice'
@@ -74,7 +72,6 @@ export default function NoticeListPage() {
               key={post.postId}
               data={post}
               onClick={() => {
-                saveScrollPosition();
                 if (currentBoardTextId === 'exam-review') {
                   navigate(`/board/exam-review-notice/post/${post.postId}`);
                 } else {

--- a/src/page/board/PostListPage/PostListPage.jsx
+++ b/src/page/board/PostListPage/PostListPage.jsx
@@ -5,7 +5,7 @@ import { getNoticeLine } from '@/apis';
 
 import { BackAppBar, Icon, WriteButton } from '@/shared/component';
 import { OFFICIAL_BOARD, QUERY_KEY, ROLE } from '@/shared/constant';
-import { useAuth, useScrollRestoration } from '@/shared/hook';
+import { useAuth } from '@/shared/hook';
 import { getBoard } from '@/shared/lib';
 
 import { PostListSuspense } from '@/feature/board/component';
@@ -17,7 +17,7 @@ export default function PostListPage() {
   const { userInfo } = useAuth();
   const currentBoardTextId = pathname.split('/')[2];
   const currentBoard = getBoard(currentBoardTextId);
-  const { scrollRef, saveScrollPosition } = useScrollRestoration();
+
   const isBesookt = currentBoardTextId === 'besookt' ? true : false;
   const isFirstSnow = currentBoardTextId === 'first-snow' ? true : false;
   const isPreUser = userInfo?.userRoleId === ROLE.preUser;
@@ -37,11 +37,12 @@ export default function PostListPage() {
   const { data: noticeLineData } = useQuery({
     queryKey: [QUERY_KEY.noticeLine, currentBoard.id],
     queryFn: () => getNoticeLine(currentBoard?.id),
-    staleTime: 1000 * 60 * 5,
+    staleTime: 0,
+    // staleTime: 1000 * 60 * 5,
   });
 
   return (
-    <section className={styles.container} ref={scrollRef}>
+    <section className={styles.container}>
       <BackAppBar
         title={currentBoard.title}
         hasMenu
@@ -58,7 +59,7 @@ export default function PostListPage() {
           </p>
         </Link>
       )}
-      <PostListSuspense saveScrollPosition={saveScrollPosition} />
+      <PostListSuspense />
       {showWriteButton && (
         <WriteButton
           to={`/board/${currentBoardTextId}/post-write`}

--- a/src/page/exam/ExamReviewListPage/ExamReviewListPage.jsx
+++ b/src/page/exam/ExamReviewListPage/ExamReviewListPage.jsx
@@ -3,7 +3,6 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getNoticeLine } from '@/apis';
 
-import { useScrollRestoration } from '@/shared/hook';
 import { AppBar, Icon, MenuIcon, WriteButton } from '@/shared/component';
 import { QUERY_KEY, STALE_TIME } from '@/shared/constant';
 
@@ -23,10 +22,8 @@ export default function ExamReviewListPage() {
     staleTime: STALE_TIME.noticeLine,
   });
 
-  const { scrollRef, saveScrollPosition } = useScrollRestoration();
-
   return (
-    <section className={styles.container} ref={scrollRef}>
+    <section className={styles.container}>
       <AppBar title='시험후기'>
         <MenuIcon />
       </AppBar>
@@ -46,7 +43,7 @@ export default function ExamReviewListPage() {
           placeholder='시험 종류'
         />
       </FilterList>
-      <SearchExamReviewListSuspense saveScrollPosition={saveScrollPosition} />
+      <SearchExamReviewListSuspense />
 
       <WriteButton to='/board/exam-review-write' />
     </section>

--- a/src/page/search/SearchPage/SearchPage.jsx
+++ b/src/page/search/SearchPage/SearchPage.jsx
@@ -1,6 +1,5 @@
 import { useSearchParams, useLocation } from 'react-router-dom';
 
-import { useScrollRestoration } from '@/shared/hook';
 import { BackAppBar } from '@/shared/component';
 
 import { Search, SearchResultListSuspense } from '@/feature/search/component';
@@ -16,17 +15,13 @@ export default function SearchPage() {
   const { pathname } = useLocation();
   const current = pathname.split('/')[2];
 
-  const { scrollRef, saveScrollPosition } = useScrollRestoration();
-
   return (
-    <div className={styles.container} ref={scrollRef}>
+    <div className={styles.container}>
       <BackAppBar hasSearchInput={true}>
         <Search placeholder={PLACEHOLDER[current]} />
       </BackAppBar>
 
-      {paramsLength > 0 && (
-        <SearchResultListSuspense saveScrollPosition={saveScrollPosition} />
-      )}
+      {paramsLength > 0 && <SearchResultListSuspense />}
     </div>
   );
 }

--- a/src/page/search/SearchPage/SearchPage.module.css
+++ b/src/page/search/SearchPage/SearchPage.module.css
@@ -3,8 +3,6 @@
 
   padding-top: calc(var(--default-appbar-height) + 0.4rem);
   padding-bottom: 8rem;
-
-  overflow-y: auto;
 }
 
 .to {

--- a/src/page/user/ActivityPage/ActivityPage.jsx
+++ b/src/page/user/ActivityPage/ActivityPage.jsx
@@ -3,7 +3,6 @@ import { useLocation } from 'react-router-dom';
 import { ErrorBoundary } from 'react-error-boundary';
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
 
-import { useScrollRestoration } from '@/shared/hook';
 import { BackAppBar, FetchLoading } from '@/shared/component';
 
 import { MyPostList, MyPostListErrorFallback } from '@/feature/my/component';
@@ -13,14 +12,13 @@ import styles from './ActivityPage.module.css';
 
 export default function ActivityPage() {
   const { pathname } = useLocation();
-  const { scrollRef, saveScrollPosition } = useScrollRestoration();
 
   const { title, queryKey, queryFn, hasLike, errorMessage } = ACTIVITIES.find(
     ({ path }) => path === pathname
   );
 
   return (
-    <section className={styles.container} ref={scrollRef}>
+    <section className={styles.container}>
       <BackAppBar />
 
       <div className={styles.contentWrapper}>
@@ -40,7 +38,6 @@ export default function ActivityPage() {
                   queryFn={queryFn}
                   hasLike={hasLike}
                   errorMessage={errorMessage}
-                  saveScrollPosition={saveScrollPosition}
                 />
               </Suspense>
             </ErrorBoundary>

--- a/src/page/user/ActivityPage/ActivityPage.module.css
+++ b/src/page/user/ActivityPage/ActivityPage.module.css
@@ -4,7 +4,6 @@
 
   display: flex;
   flex-direction: column;
-  overflow-y: auto;
 }
 
 .contentWrapper {

--- a/src/shared/component/List/List.module.css
+++ b/src/shared/component/List/List.module.css
@@ -4,5 +4,4 @@
   flex-direction: column;
   align-items: center;
   gap: 0.8rem;
-  overflow-y: auto;
 }


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1283

## 🎯 변경 사항

- 해당 버그는 스크롤 컨테이너가 리스트에서 div.app으로 바뀐 것이 원인이었습니다. 따라서 스크롤 컨테이너 ref를 각 페이지의 리스트가 아닌 div.app으로 설정했습니다.
- 기존엔 스크롤 복구가 필요한 페이지 마다 훅을 사용했지만, 이제는 전역으로 관리할 수 있도록 `useScrollRestoration` 훅을 변경했습니다.
- div.app을 스크롤 컨테이너로 두기 위해 스크롤 복원 기능이 필요한 페이지의 `overflow-y: auto`를 삭제했습니다.

### useScrollRestoration
  - 스크롤 위치는 세션 스토리지가 아닌 useRef를 사용해서 Map 형태로 관리합니다.
  - map에 사용할 키로는 `useLocation`에서 제공해주는 key를 사용했습니다. (history entry를 식별하는 key)
  - 해당 key는 history entry를 식별하는 용도이기 때문에 같은 URL이더라도 새로운 진입이라면 서로 다른 key를 가지게 됩니다.
  - 반면, 뒤로가기 하는 경우 새로운 진입이 아닌 이전 엔트리로 돌아가는 것이기 때문에 key가 달라지지 않습니다.
  - 이 특성 때문에 상세 > 리스트로 뒤로가기 하는 경우에만 스크롤 위치를 복구하게 됩니다.

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
