### PR TITLE
#1314 [SNO-247] postBar 잘려서 보이는 오류로 인한 padding-bottom 값 추가

### DIFF
--- a/src/feature/search/component/SearchExamReviewList/SearchExamReviewList.jsx
+++ b/src/feature/search/component/SearchExamReviewList/SearchExamReviewList.jsx
@@ -33,7 +33,7 @@ export default function SearchExamReviewList() {
     <PullToRefresh
       onRefresh={() => refetch().then(() => console.log('Refreshed!'))}
     >
-      <List>
+      <List className={styles.examReviewList}>
         {examList.map((post, index) => (
           <Link
             className={styles.to}

--- a/src/feature/search/component/SearchExamReviewList/SearchExamReviewList.module.css
+++ b/src/feature/search/component/SearchExamReviewList/SearchExamReviewList.module.css
@@ -1,3 +1,7 @@
 .to {
   width: 100%;
 }
+
+.examReviewList {
+  padding-bottom: 10rem;
+}

--- a/src/shared/component/List/List.module.css
+++ b/src/shared/component/List/List.module.css
@@ -4,5 +4,5 @@
   flex-direction: column;
   align-items: center;
   gap: 0.8rem;
-  padding-bottom: 10rem;
+  padding-bottom: 2rem;
 }


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1314

[DIscord 제보](https://discord.com/channels/1218891487312351283/1442373910392864811)

## 🎯 변경 사항

- postBar가 다 보이도록 padding-bottom 값을 추가했습니다.

## 📸 스크린샷 (선택 사항)

- 하단 nav바✅ :  SearchExamReviewList 내 padding-bottom 10rem 추가
    | Before | After |
    | :----: | :---: |
    | ![잘린 이미지](https://github.com/user-attachments/assets/51d7d601-e091-4a39-936e-854ba2121a60) | ![수정 후](https://github.com/user-attachments/assets/b5986b9d-5fad-42ea-8a84-e97d0929908d) |

- 하단 nav바❌ : list 내 padding bottom 2rem 추가
  | Before | After |
    | :----: | :---: |
    | ![잘린 이미지](https://github.com/user-attachments/assets/9b4d55b7-d994-42d6-a28d-00f8081ce5f3)| ![수정 후](https://github.com/user-attachments/assets/00f866fb-a37a-4903-82be-373f4514b5a8) |

