### PR TITLE
[SNO-267] #1342 본인 게시글 댓글 알림 ON/OFF 시 빈 토스트 메시지 출력 오류 해결

### DIFF
--- a/src/page/board/PostPage/PostPage.jsx
+++ b/src/page/board/PostPage/PostPage.jsx
@@ -229,11 +229,12 @@ function MetaContainer({
           : '댓글 알림이 해제되었습니다.',
       });
     } catch (error) {
-      if (error instanceof AppError) {
-        toast.error(error.message);
-      } else {
-        toast.error('잠시 후 다시 시도해주세요.');
-      }
+      const errorMessage =
+        error instanceof AppError
+          ? error.message
+          : '잠시 후 다시 시도해주세요.';
+
+      toast({ message: errorMessage, variant: 'error' });
     }
   };
 


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1342

## 🎯 변경 사항

- 주요 변경점을 설명해주세요.
1. 토스트 호출 인자 수정 : `toast(message)` -> `toast({message: "..."})` 형태로 수정하여 ToastContext 규격 준수
2. 에러 처리 로직 개선 : `toast.error()` 호출 대신 `toast({message: errorMessage, variant: 'error'})`를 사용하여 에러 발생 시 출력되도록 수정