### PR TITLE
[SNO-270] #1376 toNotificationItem의 date 포맷 유틸 교체

### DIFF
--- a/src/feature/alert/mapper/notification.js
+++ b/src/feature/alert/mapper/notification.js
@@ -1,3 +1,5 @@
+import { DateTime } from '@/shared/lib';
+
 export function toNotificationItem({
   id,
   title,
@@ -12,29 +14,8 @@ export function toNotificationItem({
     title,
     content: body,
     isRead,
-    createdAt: formatToKST_MMDD_HHMM(createdAt),
+    createdAt: DateTime.format(createdAt, 'MD_HM'),
     url,
     category: filter,
   };
-}
-
-function formatToKST_MMDD_HHMM(iso) {
-  const d = new Date(iso);
-  if (isNaN(d.getTime())) return '';
-
-  const parts = new Intl.DateTimeFormat('ko-KR', {
-    timeZone: 'Asia/Seoul',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  })
-    .formatToParts(d)
-    .reduce((acc, p) => {
-      acc[p.type] = p.value;
-      return acc;
-    }, {});
-
-  return `${parts.month}.${parts.day} ${parts.hour}:${parts.minute}`;
 }


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1376 

## 🎯 변경 사항

- toNotificationItem.jsx의 `formatToKST_MMDD_HHMM` 삭제
- createAt 포맷을 `formatToKST_MMDD_HHMM`에서 DateTime.format(createdAt, 'MD_HM')으로 교체

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
