### PR TITLE
[SNO-283] #1402 boardName에 따라 렌더링 페이지를 결정하는 중간 레이어(PageSelector) 추가

### DIFF
--- a/src/new-router.js
+++ b/src/new-router.js
@@ -1,9 +1,11 @@
 import { attendanceLoader } from '@/shared/loader';
-import { NavbarLayout } from '@/shared/ui';
-// import WriteLayoutSelector from '@/shared/ui/WriteLayoutSelector';
-// import PostListLayoutSelector from '@/shared/ui/PostListLayoutSelector';
-// import PostLayoutSelector from '@/shared/ui/PostLayoutSelector';
-// import EditLayoutSelector from '@/shared/ui/EditLayoutSelector';
+import {
+  NavbarLayout,
+  PostListPageSelector,
+  PostPageSelector,
+  WritePageSelector,
+  EditPageSelector,
+} from '@/shared/ui';
 import { BOARD_SECTION } from '@/shared/constant';
 
 import App from '@/App';
@@ -122,7 +124,7 @@ export const routeList = [
           </BoardValidator>
         ),
         children: [
-          // { index: true, element: <PostListLayoutSelector /> },
+          { index: true, element: <PostListPageSelector /> },
           {
             path: `search`,
             element: <SearchPage />,
@@ -137,10 +139,7 @@ export const routeList = [
                 element: <BoardGuard isAdminOnly />,
                 children: [
                   { path: `write`, element: <WritePostPage isNotice /> },
-                  {
-                    path: `:postId/edit`,
-                    element: <EditPostPage isNotice />,
-                  } /* 공지글 수정 페이지 오류나고 있음 */,
+                  { path: `:postId/edit`, element: <EditPostPage isNotice /> },
                 ],
               },
             ],
@@ -148,14 +147,14 @@ export const routeList = [
           },
           {
             path: `post/:postId`,
-            // element: <PostLayoutSelector />,
+            element: <PostPageSelector />,
             handle: { feature: BOARD_SECTION.DETAIL },
           },
           {
             element: <BoardGuard action={'write'} />,
             children: [
-              // { path: `write`, element: <WriteLayoutSelector /> },
-              // { path: `post/:postId/edit`, element: <EditLayoutSelector /> },
+              { path: `write`, element: <WritePageSelector /> },
+              { path: `post/:postId/edit`, element: <EditPageSelector /> },
             ],
             handle: { feature: BOARD_SECTION.EDITOR },
           },

--- a/src/shared/ui/EditPageSelector.tsx
+++ b/src/shared/ui/EditPageSelector.tsx
@@ -1,0 +1,21 @@
+import { useParams } from 'react-router-dom';
+
+import { EditExamReviewPage } from '@/page/exam';
+import { EditEventPage } from '@/page/event';
+import { EditPostPage } from '@/page/board';
+
+export default function EditPageSelector() {
+  const { boardName } = useParams();
+
+  switch (boardName) {
+    case 'exam-review': {
+      return <EditExamReviewPage />;
+    }
+    case 'event': {
+      return <EditEventPage />;
+    }
+    default: {
+      return <EditPostPage />;
+    }
+  }
+}

--- a/src/shared/ui/PostListPageSelector.tsx
+++ b/src/shared/ui/PostListPageSelector.tsx
@@ -1,0 +1,27 @@
+import { useParams } from 'react-router-dom';
+
+import NavbarLayout from '@/shared/ui/NavbarLayout';
+
+import { ExamReviewListPage } from '@/page/exam';
+import { EventListPage } from '@/page/event';
+import { PostListPage } from '@/page/board';
+
+export default function PostListPageSelector() {
+  const { boardName } = useParams();
+
+  switch (boardName) {
+    case 'exam-review': {
+      return (
+        <NavbarLayout>
+          <ExamReviewListPage />
+        </NavbarLayout>
+      );
+    }
+    case 'event': {
+      return <EventListPage />;
+    }
+    default: {
+      return <PostListPage />;
+    }
+  }
+}

--- a/src/shared/ui/PostPageSelector.tsx
+++ b/src/shared/ui/PostPageSelector.tsx
@@ -1,0 +1,21 @@
+import { useParams } from 'react-router-dom';
+
+import { ExamReviewPage } from '@/page/exam';
+import { EventPage } from '@/page/event';
+import { PostPage } from '@/page/board';
+
+export default function PostPageSelector() {
+  const { boardName } = useParams();
+
+  switch (boardName) {
+    case 'exam-review': {
+      return <ExamReviewPage />;
+    }
+    case 'event': {
+      return <EventPage />;
+    }
+    default: {
+      return <PostPage />;
+    }
+  }
+}

--- a/src/shared/ui/WritePageSelector.tsx
+++ b/src/shared/ui/WritePageSelector.tsx
@@ -1,0 +1,27 @@
+import { useParams } from 'react-router-dom';
+
+import { WriteExamReviewPage } from '@/page/exam';
+import { WriteEventPage } from '@/page/event';
+import { WritePostPage } from '@/page/board';
+
+import { CheckExamPeriodRoute } from '@/feature/exam/lib';
+
+export default function WritePageSelector() {
+  const { boardName } = useParams();
+
+  switch (boardName) {
+    case 'exam-review': {
+      return (
+        <CheckExamPeriodRoute>
+          <WriteExamReviewPage />
+        </CheckExamPeriodRoute>
+      );
+    }
+    case 'event': {
+      return <WriteEventPage />;
+    }
+    default: {
+      return <WritePostPage />;
+    }
+  }
+}

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,1 +1,5 @@
 export { default as NavbarLayout } from './NavbarLayout';
+export { default as PostListPageSelector } from './PostListPageSelector';
+export { default as PostPageSelector } from './PostPageSelector';
+export { default as WritePageSelector } from './WritePageSelector';
+export { default as EditPageSelector } from './EditPageSelector';


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1402

## 🎯 변경 사항

- 시험후기, 이벤트는 기존 포스트 페이지 컴포넌트를 따르지 않고 별도의 페이지 컴포넌트를 갖습니다.
- `boardName`에 따라 적절한 페이지 컴포넌트를 렌더링할 수 있도록 중간 레이어(PageSelector)를 추가했습니다.

### PostListPageSelector
`exam-review`: ExamReviewListPage (depth 1까지 하단 메뉴가 보여야 하기 때문에 NavbarLayout 적용)
`event`: EventListPage
그 외: PostListPage

### PostPageSelector
`exam-review`: ExamReviewPage
`event`: EventPage
그 외: PostPage

### WritePageSelector
`exam-review`: WriteExamReviewPage (시험후기 작성 기간을 제한을 위해 CheckExamPeriodRoute 적용)
`event`: WriteEventPage
그 외: WritePostPage

### EditPageSelector
`exam-review`: EditExamReviewPage
`event`: EditEventPage
그 외: EditPostPage


## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
