### PR TITLE
[SNO-291] #1424 게시글 상세에서 발생하는 useBoard 훅 오류 수정

### DIFF
--- a/src/feature/board/component/PostModalRenderer/PostModalRenderer.jsx
+++ b/src/feature/board/component/PostModalRenderer/PostModalRenderer.jsx
@@ -1,5 +1,8 @@
+import { useLocation } from 'react-router-dom';
+
 import { useBoard } from '@/shared/hook';
 import { MoreOptionModal, ConfirmModal, OptionModal } from '@/shared/component';
+import { getBoard } from '@/shared/lib';
 import {
   MORE_OPTION_MODAL_TEXT,
   CONFIRM_MODAL_TEXT,
@@ -7,6 +10,102 @@ import {
 } from '@/shared/constant';
 
 export default function PostModalRenderer({
+  modal,
+  handleEdit,
+  handleReport,
+  handleDelete,
+  handleShare,
+}) {
+  const { pathname } = useLocation();
+  const currentBoard = getBoard(pathname.split('/')[2]);
+
+  return (
+    <>
+      {(() => {
+        switch (modal.id) {
+          // 게시글 더보기 모달 (게시글 신고, 이용자 신고, 공유하기)
+          case 'post-more-options':
+            return (
+              <MoreOptionModal
+                title='게시글'
+                optionList={MORE_OPTION_MODAL_TEXT.POST_MORE_OPTION_LIST}
+                functions={[null, null, handleShare]}
+              />
+            );
+          // 내 게시글 더보기 모달 (수정, 삭제, 공유하기)
+          case 'my-post-more-options':
+            return (
+              <MoreOptionModal
+                title='내 게시글'
+                optionList={MORE_OPTION_MODAL_TEXT.MY_POST_MORE_OPTION_LIST}
+                functions={[handleEdit, null, handleShare]}
+              />
+            );
+          // 이벤트 게시글 더보기 모달 (공유하기)
+          case 'event-post-more-option':
+            return (
+              <MoreOptionModal
+                title='이벤트'
+                optionList={MORE_OPTION_MODAL_TEXT.EVENT_MORE_OPTION_LIST}
+                functions={[handleShare]}
+              />
+            );
+          // 게시글 신고하기 옵션 리스트 모달
+          case 'report-post-types':
+            return (
+              <OptionModal
+                title='게시글 신고'
+                optionList={OPTION_MODAL_TEXT.REPORT_POST_TYPE_LIST}
+              />
+            );
+          // 유저 신고하기 옵션 리스트 모달
+          case 'report-user-types':
+            return (
+              <OptionModal
+                title='이용자 신고'
+                optionList={OPTION_MODAL_TEXT.REPORT_USER_TYPE_LIST}
+              />
+            );
+          // 게시글 신고 최종 확인 모달
+          case 'confirm-post-report':
+            return (
+              <ConfirmModal
+                modalText={CONFIRM_MODAL_TEXT.REPORT_POST}
+                onConfirm={handleReport}
+              />
+            );
+          // 유저 신고 최종 확인 모달
+          case 'confirm-user-report':
+            return (
+              <ConfirmModal
+                modalText={CONFIRM_MODAL_TEXT.REPORT_USER}
+                onConfirm={handleReport}
+              />
+            );
+          // 게시글 삭제 최종 확인 모달
+          case 'confirm-post-delete':
+            return (
+              <ConfirmModal
+                modalText={
+                  [21, 22].includes(Number(currentBoard.id))
+                    ? CONFIRM_MODAL_TEXT.DELETE_POST
+                    : CONFIRM_MODAL_TEXT.DELETE_POST_WITHOUT_POINT_DEDUCTION
+                }
+                onConfirm={handleDelete}
+              />
+            );
+          default:
+            return null;
+        }
+      })()}
+    </>
+  );
+}
+
+/**
+ * TODO(other): 동적 라우트에서 사용할 수 있기 때문에 route.migration.js를 사용할 때 함께 교체
+ */
+export function NewPostModalRenderer({
   modal,
   handleEdit,
   handleReport,

--- a/src/feature/board/component/index.js
+++ b/src/feature/board/component/index.js
@@ -11,3 +11,5 @@ export { default as PostListErrorFallback } from './PostList/PostListErrorFallba
 export { default as PostListSuspense } from './PostList/PostListSuspense';
 
 export { default as PostModalRenderer } from './PostModalRenderer/PostModalRenderer';
+
+export * from './PostModalRenderer/PostModalRenderer';

--- a/src/page/board/PostPage/PostPage.jsx
+++ b/src/page/board/PostPage/PostPage.jsx
@@ -27,7 +27,10 @@ import {
 } from '@/shared/component';
 import { LIKE_TYPE, QUERY_KEY, ROLE } from '@/shared/constant';
 
-import { FullScreenAttachment } from '@/feature/board/component';
+import {
+  FullScreenAttachment,
+  NewPostModalRenderer,
+} from '@/feature/board/component';
 import { useDeletePostHandler } from '@/feature/board/hook/useDeletePostHandler';
 import { PostModalRenderer } from '@/feature/board/component';
 
@@ -324,7 +327,7 @@ export function NewPostPage() {
         commentCount={data.commentCount}
       />
 
-      <PostModalRenderer
+      <NewPostModalRenderer
         modal={modal}
         handleEdit={handleEdit}
         handleReport={handleReport}


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1424

## 🎯 변경 사항

### useBoard 훅 오류 수정
- 원인: route.migration.js 적용 전이라 동적 라우트의 path param을 통한 `boardKey` 조회가 불가능한 상태입니다.
- 문제: PostModalRenderer에서 useBoard를 호출하면서 `boardKey`를 찾지 못해 런타임 오류가 발생했습니다.
- 해결: 마이그레이션 전까지 useBoard를 사용하는 로직은 NewPostModalRenderer로 분리하고, 기존 PostModalRenderer는 이전 방식을 유지하도록 수정하여 참조 오류를 해결했습니다.

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
