### PR TITLE
[SNO-266] #1437 시험후기 페이지 내 툴팁 구현

### DIFF
--- a/src/feature/board/component/PostBar/PostBar.jsx
+++ b/src/feature/board/component/PostBar/PostBar.jsx
@@ -27,12 +27,15 @@ export default function PostBar({ data, hasComment = true, hasLike = true }) {
             <p>{DateTime.formatAdaptive(data.createdAt)}</p>
             {data.isEdited && <p className={styles.edited}>&nbsp;(수정됨)</p>}
             {data.isConfirmed && (
-              <Icon
-                className={styles.checkCircleIcon}
-                id='check-circle'
-                width={12}
-                height={12}
-              />
+              <div className={styles.checkCircleWrapper}>
+                <Icon
+                  className={styles.checkCircleIcon}
+                  id='check-circle'
+                  width={12}
+                  height={12}
+                />
+                <span className={styles.tooltip}>리자 인증 완료</span>
+              </div>
             )}
             {data.boardName && <Chip type={'board'} label={data.boardName} />}
             {data.progressType && (

--- a/src/feature/board/component/PostBar/PostBar.module.css
+++ b/src/feature/board/component/PostBar/PostBar.module.css
@@ -49,8 +49,58 @@
   padding: 0 0.3rem;
 }
 
-.checkCircleIcon {
+.checkCircleWrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   margin-left: 0.4rem;
+  width: 1.2rem;
+  height: 1.2rem;
+  border-radius: 50%;
+  flex-shrink: 0;
+  cursor: default;
+}
+
+.checkCircleWrapper:hover {
+  background-color: var(--grey-3);
+}
+
+.checkCircleIcon {
+  flex-shrink: 0;
+}
+
+.tooltip {
+  position: absolute;
+  bottom: calc(100% + 0.6rem);
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: var(--grey-4);
+  color: #fff;
+  font: var(--text-body-2-reg);
+  font-size: 1.1rem;
+  white-space: nowrap;
+  padding: 0.5rem 0.7rem 0.3rem;
+  border-radius: 0.5rem;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  width: 0.8rem;
+  height: 0.8rem;
+  background-color: var(--grey-4);
+  transform: translateX(-50%) rotate(45deg);
+  margin-top: -0.4rem;
+  border-bottom-right-radius: 0.2rem;
+}
+
+.checkCircleWrapper:hover .tooltip {
+  opacity: 1;
 }
 
 .postBarCenter {


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1437

- [Figma](https://www.figma.com/design/00Ywy8VC5KoHOSu01uC9sZ/-%EC%8A%A4%EB%85%B8%EB%A1%9C%EC%A6%88--%EC%9C%A0%EC%A0%80%EC%9B%B9-%EB%94%94%EC%9E%90%EC%9D%B8?node-id=4279-16001&m=dev)
- [제언](https://www.notion.so/snorose/28a7ef0aa3bf8024a9abea62955edc70?source=copy_link)

## 🎯 변경 사항

- 시험후기 페이지 내 툴팁 구현

## 📸 스크린샷 (선택 사항)


| Before | After |
| :----: | :---: |
| hover 효과 없음  | <img width="576" height="135" alt="image" src="https://github.com/user-attachments/assets/7ff5c24f-03d0-416d-a10b-b5e658ef0d97" />  |


## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
flex를 사용해도 세로축 가운데 정렬이 되지 않아, padding-top에 0.2rem을 추가하였습니다.
<img width="576" height="191" alt="image" src="https://github.com/user-attachments/assets/cd1316f2-fbee-4af2-a900-01cc858ac511" />
