### PR TITLE
[SNO-297] #1448 글 상세보기 숫자 정렬 적용

### DIFF
--- a/src/page/board/PostPage/PostPage.module.css
+++ b/src/page/board/PostPage/PostPage.module.css
@@ -94,20 +94,18 @@
   }
 }
 
+.contentText ol,
+.contentText ul {
+  padding-left: 2.4rem;
+  margin: 1.2rem 0;
+}
+
 .contentText ol {
   list-style-type: decimal;
-  padding-left: 24px;
-  margin: 12px 0;
 }
 
 .contentText ul {
   list-style-type: disc;
-  padding-left: 24px;
-  margin: 12px 0;
-}
-
-.contentText li {
-  margin: 4px 0;
 }
 
 /* action */


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1448 

- [Notion](https://www.notion.so/snorose/3177ef0aa3bf80079143e66ad2e8e77e?v=1b37ef0aa3bf802db8b3000c1b0b2579&source=copy_link)

## 🎯 변경 사항
- 게시글 상세보기 페이지에서 숫자 정렬을 확인할 수 있도록 PostPage.module.css에 ol, ul, li와 관련된 css 추가

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
| 
<img width="340" height="358" alt="image" src="https://github.com/user-attachments/assets/b9fc5264-dc86-44b3-bbc4-7f219625f21a" />
 | 
<img width="2880" height="1519" alt="image" src="https://github.com/user-attachments/assets/9b18725f-4fdd-4004-a7d2-60b550f863ad" />
 |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
- css 디자인이 괜찮은지, 그리고 잘 적용되는지 확인해주세요
- reset.css에서 ol, ul과 관련된 css를 none으로 정의하고 있기 때문에 게시글 본문 영역인  PostPage module.css에 다시 한번 정의하여 css가 보일 수 있게 했습니다. 