### PR TITLE
[SNO-307] 알림 컨테이너가 콘텐츠 길이에 맞춰 늘어나도록 설정

### DIFF
--- a/src/page/alert/AlertPage/AlertPage.module.css
+++ b/src/page/alert/AlertPage/AlertPage.module.css
@@ -1,5 +1,5 @@
 .container {
-  height: 100%;
+  min-height: 100%;
   padding: 7rem 0 9rem 0;
 
   display: flex;


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1468 
- [Notion](https://www.notion.so/snorose/31c7ef0aa3bf8011a8e1c5c8483b7e8b?source=copy_link)

## 🎯 변경 사항
- 문제 상황
알림 내용 일부가 하단 네비게이션 바에 의해 보이지 않았습니다.

- 문제 원인
`height: 100%`로 설정한 경우, 알림 리스트 내 출력되는 알림이 많아지게 되면 알림 리스트가 `.container`를 뚫고 overflow하게 됩니다.
결과적으로 overflow된 리스트들이 하단 패딩 영역을 덮어버려서 하단 padding 값이 적용되지 않은 것처럼 보이게 됩니다.

- 해결 방법
알림 컨테이너가 내부 리스트 길이에 맞춰 늘어나도록 `min-height: 100%`로 설정했습니다.

## 📸 스크린샷 (선택 사항)

| Before | After |
| :----: | :---: |
| <img width="743" height="1625" alt="스크린샷 2026-03-09 오후 2 50 20" src="https://github.com/user-attachments/assets/2233687f-7fc4-414e-807c-ee9bcc0df235" /> | <img width="744" height="1623" alt="스크린샷 2026-03-09 오후 2 39 53" src="https://github.com/user-attachments/assets/7ccbbbac-98aa-4542-9827-d643f55c89d9" /> |

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
1. test4 계정 로그인
2. 알림 페이지로 이동
3. 알림 뱃지에 나와있는 확인하지 않은 알림 개수와 확인하지 않아 활성화되어 있는 알림 컴포넌트 개수가 일치하는지 확인