### PR TITLE
[SNO-326] #1457 validate 리팩토링 

### DIFF
--- a/src/feature/account/component/signUpStep/AccountInfoStep/AccountInfoStep.jsx
+++ b/src/feature/account/component/signUpStep/AccountInfoStep/AccountInfoStep.jsx
@@ -13,17 +13,13 @@ import {
   validateSookmyungEmail,
   validateId,
   validatePassword,
+  validateCheckedPassword,
 } from '@/feature/account/lib';
 
 import styles from './AccountInfoStep.module.css';
 
 export default function AccountInfoStep({ formData, setFormData, setStage }) {
   const { toast } = useToast();
-
-  const validateCheckedPassword = () => {
-    if (formData.checkedPassword === '') return 'default';
-    return formData.password === formData.checkedPassword ? 'valid' : 'error';
-  };
 
   const inputList = [
     {
@@ -88,7 +84,7 @@ export default function AccountInfoStep({ formData, setFormData, setStage }) {
       label: '비밀번호 확인',
       id: 'checkedPassword',
       placeholder: '비밀번호를 다시 입력해 주세요',
-      value: formData.checkedPassword,
+      value: [formData.checkedPassword, formData.password],
       onChange: (next) =>
         setFormData((prev) => ({
           ...prev,

--- a/src/feature/account/component/signUpStep/AccountInfoStep/AccountInfoStep.jsx
+++ b/src/feature/account/component/signUpStep/AccountInfoStep/AccountInfoStep.jsx
@@ -84,13 +84,14 @@ export default function AccountInfoStep({ formData, setFormData, setStage }) {
       label: '비밀번호 확인',
       id: 'checkedPassword',
       placeholder: '비밀번호를 다시 입력해 주세요',
-      value: [formData.checkedPassword, formData.password],
+      value: formData.checkedPassword,
       onChange: (next) =>
         setFormData((prev) => ({
           ...prev,
           checkedPassword: next,
         })),
-      validate: validateCheckedPassword,
+      validate: (checkedPassword) =>
+        validateCheckedPassword(formData.password, checkedPassword),
       message: '비밀번호가 일치하지 않아요',
     },
   ];

--- a/src/feature/account/lib/inputCheck.ts
+++ b/src/feature/account/lib/inputCheck.ts
@@ -1,6 +1,8 @@
 import { isNumber } from '@/shared/lib';
 
-export function validateUserName(value = '') {
+type ValidationResult = 'default' | 'valid' | 'error';
+
+export function validateUserName(value: string = ''): ValidationResult {
   const format = /^[A-Za-z가-힣ㄱ-ㅎ]+$/;
 
   if (value.length === 0) {
@@ -14,7 +16,7 @@ export function validateUserName(value = '') {
   return 'error';
 }
 
-export function validateSookmyungEmail(value = '') {
+export function validateSookmyungEmail(value: string = ''): ValidationResult {
   const domain = value.split('@')[1];
 
   if (value.length === 0) {
@@ -28,7 +30,7 @@ export function validateSookmyungEmail(value = '') {
   return 'error';
 }
 
-export function validateId(value = '') {
+export function validateId(value: string): ValidationResult {
   const pathname = window.location.pathname.split('/')[1];
 
   const format = /^[A-Za-z0-9]+$/;
@@ -50,7 +52,7 @@ export function validateId(value = '') {
   return 'error';
 }
 
-export function validatePassword(value = '') {
+export function validatePassword(value: string = ''): ValidationResult {
   const format = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#%^&*])[A-Za-z\d!@#%^&*]+$/;
 
   if (value.length === 0) {
@@ -64,7 +66,7 @@ export function validatePassword(value = '') {
   return 'error';
 }
 
-export function validateNickname(value = '') {
+export function validateNickname(value: string = ''): ValidationResult {
   const format = /^[A-Za-z가-힣ㄱ-ㅎ0-9]+$/;
 
   if (value.length === 0) {
@@ -78,7 +80,7 @@ export function validateNickname(value = '') {
   return 'error';
 }
 
-export function validateStudentNumber(value = '') {
+export function validateStudentNumber(value: string = ''): ValidationResult {
   if (value.length === 0) {
     return 'default';
   }
@@ -90,7 +92,7 @@ export function validateStudentNumber(value = '') {
   return 'error';
 }
 
-export function validateBirthday(value) {
+export function validateBirthday(value: string = ''): ValidationResult {
   const format = /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/;
 
   if (value.length === 0) {
@@ -119,7 +121,7 @@ export function validateBirthday(value) {
   return 'valid';
 }
 
-export function validateEmail(value) {
+export function validateEmail(value: string = ''): ValidationResult {
   const format = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
 
   if (value.length === 0) {

--- a/src/feature/account/lib/inputCheck.ts
+++ b/src/feature/account/lib/inputCheck.ts
@@ -2,7 +2,7 @@ import { isNumber } from '@/shared/lib';
 
 type ValidationResult = 'default' | 'valid' | 'error';
 
-export function validateUserName(value: string = ''): ValidationResult {
+export function validateUserName(value: string): ValidationResult {
   const format = /^[A-Za-z가-힣ㄱ-ㅎ]+$/;
 
   if (value.length === 0) {
@@ -16,7 +16,7 @@ export function validateUserName(value: string = ''): ValidationResult {
   return 'error';
 }
 
-export function validateSookmyungEmail(value: string = ''): ValidationResult {
+export function validateSookmyungEmail(value: string): ValidationResult {
   const domain = value.split('@')[1];
 
   if (value.length === 0) {
@@ -52,7 +52,7 @@ export function validateId(value: string): ValidationResult {
   return 'error';
 }
 
-export function validatePassword(value: string = ''): ValidationResult {
+export function validatePassword(value: string): ValidationResult {
   const format = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#%^&*])[A-Za-z\d!@#%^&*]+$/;
 
   if (value.length === 0) {
@@ -66,7 +66,13 @@ export function validatePassword(value: string = ''): ValidationResult {
   return 'error';
 }
 
-export function validateNickname(value: string = ''): ValidationResult {
+export function validateCheckedPassword(inputs: string[]): ValidationResult {
+  const [checkedPassword, password] = inputs;
+  if (checkedPassword === '') return 'default';
+  return password === checkedPassword ? 'valid' : 'error';
+}
+
+export function validateNickname(value: string): ValidationResult {
   const format = /^[A-Za-z가-힣ㄱ-ㅎ0-9]+$/;
 
   if (value.length === 0) {
@@ -80,7 +86,7 @@ export function validateNickname(value: string = ''): ValidationResult {
   return 'error';
 }
 
-export function validateStudentNumber(value: string = ''): ValidationResult {
+export function validateStudentNumber(value: string): ValidationResult {
   if (value.length === 0) {
     return 'default';
   }
@@ -92,7 +98,7 @@ export function validateStudentNumber(value: string = ''): ValidationResult {
   return 'error';
 }
 
-export function validateBirthday(value: string = ''): ValidationResult {
+export function validateBirthday(value: string): ValidationResult {
   const format = /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/;
 
   if (value.length === 0) {
@@ -121,7 +127,7 @@ export function validateBirthday(value: string = ''): ValidationResult {
   return 'valid';
 }
 
-export function validateEmail(value: string = ''): ValidationResult {
+export function validateEmail(value: string): ValidationResult {
   const format = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
 
   if (value.length === 0) {

--- a/src/feature/account/lib/inputCheck.ts
+++ b/src/feature/account/lib/inputCheck.ts
@@ -66,8 +66,10 @@ export function validatePassword(value: string): ValidationResult {
   return 'error';
 }
 
-export function validateCheckedPassword(inputs: string[]): ValidationResult {
-  const [checkedPassword, password] = inputs;
+export function validateCheckedPassword(
+  password: string,
+  checkedPassword: string
+): ValidationResult {
   if (checkedPassword === '') return 'default';
   return password === checkedPassword ? 'valid' : 'error';
 }

--- a/src/shared/lib/validate.js
+++ b/src/shared/lib/validate.js
@@ -1,3 +1,0 @@
-export const isNumber = (value) => {
-  return /^\d+$/.test(value);
-};

--- a/src/shared/lib/validate.ts
+++ b/src/shared/lib/validate.ts
@@ -1,0 +1,3 @@
+export const isNumber = (value: string) => {
+  return /^\d+$/.test(value);
+};


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1457

## 🎯 변경 사항

- validate관련 코드를 TS로 리팩토링 했습니다.
- 리팩토링해야하는 총 파일들은 다음과 같습니다
[validate 관련 코드 정리한 Notion 링크](https://www.notion.so/snorose/validate-2ff7ef0aa3bf804baf70c41bcc0b9d23?source=copy_link)
- 그 중 AccountInfoStep.jsx의 validateCheckedPassword, inputCheck.js, validate.js를 리팩토링 했습니다.    
    
**validate.ts**
- 간단하게 파라미터 타입 추가했습니다.
- 리턴값은 TS가 추론 가능하니 굳이 명시하지 않았습니다.
    
**inputCheck.ts**
- <ins>ValidationResult alias</ins>: 모든 함수들이 'default', 'valid', 'error' 중 하나의 스트링을 반환하고 있어서 반환값 타입 alias를 생성했습니다.
- 각 함수의 파라미터 타입과 리턴 타입을 명시했습니다.

**AccountInfoStep.jsx**
- 안의 validateCheckedPassword가 inputCheck.ts의 함수들과 동일하게 ValidateResult alias 반환 타입을 가져서 ('default' | 'valid' | 'error' 중 하나 반환) 해당 함수를 inputCheck.ts로 옯겼습니다.
- 위의 변화에 맞춰 inputList의 checkedPassword쪽의 validate 함수를 수정했습니다. 

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
- 적절히 ts로 마이그레이션 했는지 확인해주세요.
- AccountInfoStep.jsx의 validateCheckedPassword 위치를 바꾼 것이 타당한지 확인해주세요.
- 회원가입을 해서 전과 동일하게 잘 작동하는지 확인해주세요.