### PR TITLE
[SNO-334] #1494 띄어쓰기 있는 파일도 업로드 가능하게 수정

### DIFF
--- a/src/feature/attachment/lib/attachment.js
+++ b/src/feature/attachment/lib/attachment.js
@@ -121,7 +121,7 @@ export const checkIfVideo = (newAtts) => {
 };
 export const filterUnusableCharNamedAtts = (atts) => {
   // 허용 문자 regex
-  const allowedChars = /^[\p{L}\p{N} ~!@$^&()\-_=\\[\]{};`',.]+$/u;
+  const allowedChars = /^[\p{L}\p{N} ~!@$^&()\-_=\[\]{};`',.]+$/u;
 
   return atts.filter((att) => allowedChars.test(att.name));
 };


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1494

## 🎯 변경 사항

**lib/attachment.js 수정**
- filterUnusableCharNamedAtts 함수의 허용 특수문자 regex인 allowedSpecialChars에 space를 추가했습니다
- 이제 파일 이름에 띄어쓰기가 있어도 허용될 것입니다.

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
- 기존 되던 파일 이름들이 여전히 잘 되는지
- 띄어쓰기가 포함된 파일 이름들이 허용되는지
    - 이미지 되는지 확인
    - 영상 되는지 확인
