### PR TITLE
[SNO-352] #1515 디자인 QA 내 정보, 알림 부분 수정 반영

### DIFF
--- a/src/page/alert/AlertPage/AlertPage.jsx
+++ b/src/page/alert/AlertPage/AlertPage.jsx
@@ -151,7 +151,7 @@ function NotificationList({ category }) {
           src={noAlertIllustration}
           alt='새로운 알림이 없어요'
         />
-        <div>새로운 알림이 없어요</div>
+        <div className={style.noAlertText}>새로운 알림이 없어요</div>
       </div>
     );
   }

--- a/src/page/alert/AlertPage/AlertPage.module.css
+++ b/src/page/alert/AlertPage/AlertPage.module.css
@@ -86,9 +86,11 @@
 
   box-sizing: border-box;
 
-  & div {
-    font: var(--text-headline-2-reg);
-  }
+}
+
+.noAlertText {
+  font: var(--text-headline-2-reg);
+  color: var(--grey-4);
 }
 
 .noAlertIllustration {

--- a/src/page/alert/MarketingTermsPage/MarketingTermsPage.jsx
+++ b/src/page/alert/MarketingTermsPage/MarketingTermsPage.jsx
@@ -7,7 +7,7 @@ import styles from './MarketingTermsPage.module.css';
 export default function MarketingTermsPage() {
   return (
     <div className={styles.contianer}>
-      <BackAppBar notFixed />
+      <BackAppBar />
 
       <div className={styles.title}>마케팅 정보 수신 동의 약관</div>
 

--- a/src/page/alert/MarketingTermsPage/MarketingTermsPage.jsx
+++ b/src/page/alert/MarketingTermsPage/MarketingTermsPage.jsx
@@ -6,7 +6,7 @@ import styles from './MarketingTermsPage.module.css';
 
 export default function MarketingTermsPage() {
   return (
-    <div className={styles.contianer}>
+    <div className={styles.container}>
       <BackAppBar />
 
       <div className={styles.title}>마케팅 정보 수신 동의 약관</div>

--- a/src/page/alert/MarketingTermsPage/MarketingTermsPage.module.css
+++ b/src/page/alert/MarketingTermsPage/MarketingTermsPage.module.css
@@ -1,4 +1,4 @@
-.contianer {
+.container {
   --marketing-title-height: 6.9rem;
   padding-top: var(--default-appbar-height);
 
@@ -9,6 +9,9 @@
 .title {
   position: fixed;
   top: var(--default-appbar-height);
+  left: 0;
+  right: 0;
+  margin: 0 auto;
   height: var(--marketing-title-height);
   width: 100%;
   max-width: var(--default-width);

--- a/src/page/alert/MarketingTermsPage/MarketingTermsPage.module.css
+++ b/src/page/alert/MarketingTermsPage/MarketingTermsPage.module.css
@@ -1,15 +1,26 @@
 .contianer {
-  margin-bottom: 5rem;
+  --marketing-title-height: 6.9rem;
+  padding-top: var(--default-appbar-height);
+
+  display: flex;
+  flex-direction: column;
 }
 
 .title {
-  margin: 1rem var(--default-margin) 0;
+  position: fixed;
+  top: var(--default-appbar-height);
+  height: var(--marketing-title-height);
+  width: 100%;
+  max-width: var(--default-width);
+  background: #fff;
+  z-index: var(--z-index-appbar);
+  padding: 1.4rem var(--default-margin) 2.1rem;
 
   font: var(--text-title-1-bold);
 }
 
 .body {
-  margin: 2rem var(--default-margin) 0;
+  margin: var(--marketing-title-height) var(--default-margin) 5rem;
   padding: 1.4rem;
 
   background: var(--grey-1-1);

--- a/src/page/snorose/PolicyPage/PolicyPage.module.css
+++ b/src/page/snorose/PolicyPage/PolicyPage.module.css
@@ -1,4 +1,5 @@
 .container {
+  --policy-title-height: 6.9rem;
   padding-top: var(--default-appbar-height);
 
   display: flex;
@@ -6,11 +7,10 @@
 }
 
 .contentWrapper {
-  padding: 0 var(--default-margin) 5.4rem;
+  padding: var(--policy-title-height) var(--default-margin) 5.4rem;
 
   display: flex;
   flex-direction: column;
-  gap: 2.4rem;
 }
 .contentWrapper section {
   margin-bottom: 2rem;
@@ -32,6 +32,14 @@
 }
 
 .title {
+  position: fixed;
+  top: var(--default-appbar-height);
+  height: var(--policy-title-height);
+  width: 100%;
+  max-width: var(--default-width);
+  background: #fff;
+  z-index: var(--z-index-appbar);
+  padding: 1.4rem var(--default-margin) 2.1rem;
   font: var(--text-title-1-bold);
 }
 

--- a/src/page/snorose/PolicyPage/PrivacyPolicyPage.jsx
+++ b/src/page/snorose/PolicyPage/PrivacyPolicyPage.jsx
@@ -259,8 +259,8 @@ export default function PrivacyPolicyPage() {
     <div className={styles.container}>
       <CloseAppBar alignRight={true} />
 
+      <h1 className={styles.title}>개인정보 처리방침</h1>
       <section className={styles.contentWrapper}>
-        <h1 className={styles.title}>개인정보 처리방침</h1>
         <article className={styles.content}>{privacyPolicyContent}</article>
       </section>
     </div>

--- a/src/page/snorose/PolicyPage/ServicePolicyPage.jsx
+++ b/src/page/snorose/PolicyPage/ServicePolicyPage.jsx
@@ -288,8 +288,8 @@ export default function ServicePolicyPage() {
     <div className={styles.container}>
       <CloseAppBar alignRight={true} />
 
+      <h1 className={styles.title}>서비스 이용 약관</h1>
       <section className={styles.contentWrapper}>
-        <h1 className={styles.title}>서비스 이용 약관</h1>
         <article className={styles.content}>{ServicePolicyPageContent}</article>
       </section>
     </div>

--- a/src/shared/component/modal/ConfirmModal/ConfirmModal.module.css
+++ b/src/shared/component/modal/ConfirmModal/ConfirmModal.module.css
@@ -21,7 +21,7 @@
 .description {
   text-align: center;
   color: var(--grey-4);
-  font: var(--text-headline-2-reg);
+  font: var(--text-body-1-reg);
   white-space: pre-line;
 }
 
@@ -31,11 +31,11 @@
 
   button:first-child {
     color: var(--grey-3-1);
-    font: var(--text-body-1-reg);
+    font: var(--text-headline-2-reg);
   }
   button:last-child {
     color: var(--pink-3);
-    font: var(--text-body-1-med);
+    font: var(--text-headline-2-med);
   }
 }
 

--- a/src/shared/component/modal/ConfirmModal/ConfirmModal.module.css
+++ b/src/shared/component/modal/ConfirmModal/ConfirmModal.module.css
@@ -31,9 +31,11 @@
 
   button:first-child {
     color: var(--grey-3-1);
+    font: var(--text-body-1-reg);
   }
   button:last-child {
     color: var(--pink-3);
+    font: var(--text-body-1-med);
   }
 }
 
@@ -49,7 +51,6 @@
   justify-content: center;
   align-items: center;
   width: 100%;
-  font: var(--text-headline-2-med);
   cursor: pointer;
   transition: all 200ms ease-in-out;
 

--- a/src/shared/constant/modalText.js
+++ b/src/shared/constant/modalText.js
@@ -221,7 +221,7 @@ const CONFIRM_MODAL = {
   DISABLE_NOTIFICATION: {
     title: '알림을 끌까요?',
     description:
-      '알림을 끄시면 강등, 무통보 삭제 등의\n중요한 안내를 받지 못해요.',
+      '알림을 끄시면 강등, 무통보 삭제 등의\n중요한 안내를 받지 못해요',
     confirmText: '끄기',
     cancelText: '취소',
   },


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1515

- [Figma](https://www.figma.com/design/00Ywy8VC5KoHOSu01uC9sZ/-%EC%8A%A4%EB%85%B8%EB%A1%9C%EC%A6%88--%EC%9C%A0%EC%A0%80%EC%9B%B9-%EB%94%94%EC%9E%90%EC%9D%B8?node-id=9575-32757&t=NLMN9oJ3qEaixrSK-1)
- [Notion](https://www.notion.so/snorose/251019-27a7ef0aa3bf8036a9b8ff7cb1dc55aa?source=copy_link)

## 🎯 변경 사항

- **전체 작업 (1-28) 중 내 정보, 알림 부분 관련 수정사항을 우선 적용한 pr입니다**
### 내 정보, 알림 관련 변경 사항
1. 내 정보 - Navbar 제외 모든 요소들에 디자인 시스템 아닌 색 적용 관련 수정 -> 이미 교체되어 있었습니다!
2. 내 정보 - 서비스 이용 약관/개인정보 처리 방침 헤더 높이 수정 및 제목 fix하기
3. 내 정보 - 프로필 수정 완료 버튼 색상 변경 관련 -> 이미 수정되어 있었습니다!

---
24. 알림 - 새로운 알림이 없어요 폰트, 색상 수정
25. 알림 - 마케팅 정보 수신 동의 약관 -> 2와 동일하게 수정했습니다
26. 알림 설정 모달 . 제거 및 서브 버튼 굵기 수정

## 📸 스크린샷 (선택 사항)

| 개인정보 처리방침 | 서비스 이용 약관 |
| :----: | :---: |
| ![화면 기록 2026-04-04 오후 8 14 19](https://github.com/user-attachments/assets/2736951c-fd15-4956-8cb8-2d87ad7ca2a8)| ![화면 기록 2026-04-04 오후 8 15 03](https://github.com/user-attachments/assets/3b2af75b-5e42-4cf2-b391-ef674fe099d5)|
| 마케팅 수신 동의 | 알림 설정 모달 대신 다른 confirm모달 올립니다 font-weight 수정 확인용 |
|![화면 기록 2026-04-04 오후 8 16 15](https://github.com/user-attachments/assets/2b556f65-ae7d-45fc-b43f-be6ad17aa802)| <img width="300" alt="스크린샷 2026-04-04 오후 8 13 51" src="https://github.com/user-attachments/assets/59ba84e9-4fdc-42be-9e24-4173e50218d0" />|



## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
