### PR TITLE
[SNO-353] #1517 디자인 QA 나머지 부분 수정 반영

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
     />
     <meta
       name="description"

--- a/src/feature/attendance/component/Calendar/Calendar.style.jsx
+++ b/src/feature/attendance/component/Calendar/Calendar.style.jsx
@@ -7,6 +7,7 @@ import 'react-calendar/dist/Calendar.css';
 export const StyledCalendar = styled(Calendar)`
   .react-calendar__navigation {
     margin: 0;
+    background: #ffffff1a;
     border-radius: 0.5rem 0.5rem 0 0;
   }
 
@@ -43,6 +44,7 @@ export const StyledCalendar = styled(Calendar)`
   .react-calendar__viewContainer {
     padding-top: 1.6rem;
     border-radius: 0 0 0.5rem 0.5rem;
+    background: #ffffff1a;
   }
 
   // weekday

--- a/src/feature/attendance/component/Calendar/Calendar.style.jsx
+++ b/src/feature/attendance/component/Calendar/Calendar.style.jsx
@@ -7,7 +7,7 @@ import 'react-calendar/dist/Calendar.css';
 export const StyledCalendar = styled(Calendar)`
   .react-calendar__navigation {
     margin: 0;
-    background: #ffffff1a;
+    background: rgba(var(--white-rgb), 0.1);
     border-radius: 0.5rem 0.5rem 0 0;
   }
 
@@ -44,7 +44,7 @@ export const StyledCalendar = styled(Calendar)`
   .react-calendar__viewContainer {
     padding-top: 1.6rem;
     border-radius: 0 0 0.5rem 0.5rem;
-    background: #ffffff1a;
+    background: rgba(var(--white-rgb), 0.1);
   }
 
   // weekday

--- a/src/feature/my/component/PointLog/PointLog.jsx
+++ b/src/feature/my/component/PointLog/PointLog.jsx
@@ -4,8 +4,8 @@ import { format } from 'date-fns';
 
 import { POINT_CATEGORY_KOREAN_ENUM } from '@/feature/attendance/constant';
 
-import heartPlus from '@/assets/images/heartPlus.svg';
-import heartMinus from '@/assets/images/heartMinus.svg';
+import { ReactComponent as HeartPlus } from '@/assets/images/heartPlus.svg';
+import { ReactComponent as HeartMinus } from '@/assets/images/heartMinus.svg';
 
 import styles from './PointLog.module.css';
 
@@ -16,11 +16,11 @@ const PointLog = forwardRef((props, ref) => {
   return (
     <li ref={ref} className={styles.pointBox}>
       <div className={styles.pointIconContentWrapper}>
-        <img
-          src={difference > 0 ? heartPlus : heartMinus}
-          alt={difference > 0 ? '포인트 증가' : '포인트 감소'}
-          className={styles.pointIcon}
-        />
+        {difference > 0 ? (
+          <HeartPlus className={styles.pointIcon} aria-label='포인트 증가' />
+        ) : (
+          <HeartMinus className={styles.pointIcon} aria-label='포인트 감소' />
+        )}
         <div className={styles.pointContent}>
           <h2
             className={`${styles.pointTitle} ${difference < 0 ? styles.negative : ''}`}

--- a/src/feature/my/component/PointLog/PointLog.jsx
+++ b/src/feature/my/component/PointLog/PointLog.jsx
@@ -17,9 +17,19 @@ const PointLog = forwardRef((props, ref) => {
     <li ref={ref} className={styles.pointBox}>
       <div className={styles.pointIconContentWrapper}>
         {difference > 0 ? (
-          <HeartPlus className={styles.pointIcon} aria-label='포인트 증가' />
+          <HeartPlus
+            className={styles.pointIcon}
+            role='img'
+            focusable='false'
+            aria-label='포인트 증가'
+          />
         ) : (
-          <HeartMinus className={styles.pointIcon} aria-label='포인트 감소' />
+          <HeartMinus
+            className={styles.pointIcon}
+            role='img'
+            focusable='false'
+            aria-label='포인트 감소'
+          />
         )}
         <div className={styles.pointContent}>
           <h2

--- a/src/page/home/AttendancePage/AttendancePage.module.css
+++ b/src/page/home/AttendancePage/AttendancePage.module.css
@@ -3,7 +3,7 @@
 .top {
   display: flex;
   flex-direction: column;
-  background-color: var(--blue-4);
+  background: var(--gradient-3);
   border-radius: 0 0 1.5rem 1.5rem;
 }
 
@@ -23,11 +23,11 @@
 
 .attendanceButton {
   margin: 2.6rem var(--default-margin);
-  padding: 1.3rem 0;
+  padding: 1.6rem 0;
   background: var(--blue-0);
   border-radius: 0.5rem;
-  font-weight: 500;
-  font-size: 1.4rem;
+  font: var(--text-headline-2-med);
+  letter-spacing: -0.05rem;
   text-align: center;
   color: var(--blue-4);
 

--- a/src/page/user/PointLogListPage/PointLogListPage.jsx
+++ b/src/page/user/PointLogListPage/PointLogListPage.jsx
@@ -10,7 +10,7 @@ import {
   PointLogListErrorFallback,
 } from '@/feature/my/component';
 
-import pointCircleBlue from '@/assets/images/pointCircleBlue.svg';
+import { ReactComponent as PointCircleBlue } from '@/assets/images/pointCircleBlue.svg';
 
 import styles from './PointLogListPage.module.css';
 
@@ -27,7 +27,7 @@ export default function PointLogListPage() {
         <div className={styles.topContainer}>
           <h1 className={styles.title}>보유 포인트</h1>
           <div className={styles.totalPointWrapper}>
-            <img src={pointCircleBlue} alt='총 포인트' />
+            <PointCircleBlue aria-label='총 포인트' />
             <span className={styles.totalPoints}>
               {userInfo?.balance.toLocaleString()}
             </span>

--- a/src/page/user/PointLogListPage/PointLogListPage.jsx
+++ b/src/page/user/PointLogListPage/PointLogListPage.jsx
@@ -27,7 +27,11 @@ export default function PointLogListPage() {
         <div className={styles.topContainer}>
           <h1 className={styles.title}>보유 포인트</h1>
           <div className={styles.totalPointWrapper}>
-            <PointCircleBlue aria-label='총 포인트' />
+            <PointCircleBlue
+              role='img'
+              aria-label='총 포인트'
+              focusable='false'
+            />
             <span className={styles.totalPoints}>
               {userInfo?.balance.toLocaleString()}
             </span>

--- a/src/shared/component/layout/Navbar/Navbar.module.css
+++ b/src/shared/component/layout/Navbar/Navbar.module.css
@@ -1,8 +1,8 @@
 .nav {
   width: 100%;
-  height: 7.5rem;
+  height: calc(7.5rem + env(safe-area-inset-bottom, 0px));
   max-width: var(--default-width);
-  padding: 1.3rem 3.6rem;
+  padding: 1.3rem 3.6rem calc(1.3rem + env(safe-area-inset-bottom, 0px));
   border-radius: 1rem 1rem 0 0;
   position: fixed;
   bottom: 0;

--- a/src/style/variable.css
+++ b/src/style/variable.css
@@ -41,6 +41,7 @@
     #c5d2ff 29.14%,
     #82b5ff 100%
   );
+  --gradient-3: radial-gradient(#0046b9 0%, var(--blue-4) 100%);
   --gradient-4: radial-gradient(
     90.86% 179.08% at 81.32% 31.28%,
     var(--blue-1) 37.32%,


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1517

- [Figma](https://www.figma.com/design/aRfdn4KwX3l8jLW5EnL8Pa/Snorose-Design-System?node-id=0-1&t=THUjlOVgOccVs4wf-1)
- [Notion](https://www.notion.so/snorose/251019-27a7ef0aa3bf8036a9b8ff7cb1dc55aa?source=copy_link)

## 🎯 변경 사항

- **전체 작업 (1-28) 중 나머지 부분(svg, navbar, 수정사항을 우선 적용한 pr입니다**
11. Navbar handler UI 유무에 따라 다른 Navbar 적용
16. 출석 체크 페이지 캘린더 배경색 변경, 버튼 높이 확인
27. 보유 포인트 페이지 아이콘 화질 저하 문제 수정
> 

## 📸 스크린샷 (선택 사항)

| 화질 수정 Before | 화질 수정 After |
| :----: | :---: |
| <img width="300" alt="IMG_1354" src="https://github.com/user-attachments/assets/6d8f46ca-e60a-4304-b8fa-b77efbcd2f43" /> | <img width="300" alt="IMG_1353" src="https://github.com/user-attachments/assets/c0bc6ac2-7f8e-45f3-81dc-67524edb2708" />|
|Nav bar Before |Nav bar After |
|<img width="300" alt="IMG_1355" src="https://github.com/user-attachments/assets/128106d9-199e-4fab-897d-e290122dc328" />|<img width="300" alt="IMG_1359" src="https://github.com/user-attachments/assets/f8da7920-1be8-4ab1-9a63-d93d95c394b4" />|
|캘린더 배경 및 버튼 수정 Before |캘린더 배경 및 버튼 수정 After |
|<img width="300" alt="IMG_1356" src="https://github.com/user-attachments/assets/cc4de0b9-b3d3-43e5-a4e6-4e7d86d34f45" />| <img width="300" alt="IMG_1358" src="https://github.com/user-attachments/assets/178a0279-05a0-43a1-9d6e-31eabecc8ab7" />|




## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
- 기존에 디자인 시스템에 해주신 navbar는 21px이 차이나지만, `env(safe-area-inset-bottom)`을 적용하여 디바이스마다 다르게 적용됩니다. 
>저만 처음 알았는지 모르겠지만 너무 신기해요 링크 첨부합니다 https://developer.mozilla.org/ko/docs/Web/CSS/Reference/Values/env
- ReactComponent 방식은 SVG가 HTML에 직접 삽입되어서, 브라우저가 기기 픽셀 밀도(DPR)에 맞춰 filter 포함 전체를 실제 해상도로 렌더링한다고 하여 이렇게 수정했습니다.