### PR TITLE
[SNO-368] #1535 문의 작성 에러 핸들링

### DIFF
--- a/src/feature/support/api/inquiry.ts
+++ b/src/feature/support/api/inquiry.ts
@@ -18,26 +18,43 @@ export const createInquiry = async ({
   target,
   attachments = [],
 }: InquiryWriteRequest) => {
-  const response = await authAxios.post('/v1/inquiries/inquiry', {
-    title,
-    target,
-    content,
-    inquiryCategory,
-    attachments: attachments.map(({ fileName, fileComment, type }) => ({
-      fileName,
-      fileComment,
-      type,
-    })),
-  });
+  try {
+    const response = await authAxios.post('/v1/inquiries/inquiry', {
+      title,
+      target,
+      content,
+      inquiryCategory,
+      attachments: attachments.map(({ fileName, fileComment, type }) => ({
+        fileName,
+        fileComment,
+        type,
+      })),
+    });
 
-  const { postId, attachmentUrlList } = response.data.result;
+    const { postId, attachmentUrlList } = response.data.result;
 
-  if (attachmentUrlList.length > 0) {
-    const files = attachments.map(({ file }) => file);
-    await putFileInBucket(attachmentUrlList, files);
+    if (attachmentUrlList.length > 0) {
+      await putFileInBucket(
+        attachmentUrlList,
+        attachments.map(({ file }) => file)
+      );
+    }
+
+    return { postId };
+  } catch (error) {
+    const { response } = error;
+
+    if (!response) {
+      throw new Error('네트워크 통신 중 오류가 발생했어요');
+    }
+
+    switch (response.status) {
+      case 403:
+        throw new Error('문의 작성 권한이 없어요');
+      default:
+        throw new Error('잠시 후 다시 시도해주세요.');
+    }
   }
-
-  return { postId };
 };
 
 export const fetchInquiry = async (inquiryId) => {

--- a/src/feature/support/api/inquiry.ts
+++ b/src/feature/support/api/inquiry.ts
@@ -42,13 +42,15 @@ export const createInquiry = async ({
 
     return { postId };
   } catch (error) {
-    const { response } = error;
+    const response = error?.response;
 
     if (!response) {
       throw new Error('네트워크 통신 중 오류가 발생했어요');
     }
 
     switch (response.status) {
+      case 400:
+        throw new Error('첨부파일은 최대 3개까지 업로드할 수 있어요');
       case 403:
         throw new Error('문의 작성 권한이 없어요');
       default:

--- a/src/mock/handler/inquiry.ts
+++ b/src/mock/handler/inquiry.ts
@@ -21,15 +21,15 @@ export const inquiryHandlers = [
     }
 
     // 성공
-    // return HttpResponse.json({
-    //   isSuccess: true,
-    //   code: 1000,
-    //   message: '요청에 성공하였습니다.',
-    //   result: {
-    //     postId: 11368,
-    //     attachmentUrlList: [],
-    //   },
-    // });
+    return HttpResponse.json({
+      isSuccess: true,
+      code: 1000,
+      message: '요청에 성공하였습니다.',
+      result: {
+        postId: 11368,
+        attachmentUrlList: [],
+      },
+    });
 
     // 실패 - 권한 없음
     // return HttpResponse.json(
@@ -42,6 +42,6 @@ export const inquiryHandlers = [
     // );
 
     // 실패 - 네트워크 오류
-    return HttpResponse.error();
+    // return HttpResponse.error();
   }),
 ];

--- a/src/mock/handler/inquiry.ts
+++ b/src/mock/handler/inquiry.ts
@@ -21,14 +21,27 @@ export const inquiryHandlers = [
     }
 
     // 성공
-    return HttpResponse.json({
-      isSuccess: true,
-      code: 1000,
-      message: '요청에 성공하였습니다.',
-      result: {
-        postId: 11368,
-        attachmentUrlList: [],
-      },
-    });
+    // return HttpResponse.json({
+    //   isSuccess: true,
+    //   code: 1000,
+    //   message: '요청에 성공하였습니다.',
+    //   result: {
+    //     postId: 11368,
+    //     attachmentUrlList: [],
+    //   },
+    // });
+
+    // 실패 - 권한 없음
+    // return HttpResponse.json(
+    //   {
+    //     isSuccess: false,
+    //     code: 2007,
+    //     message: '유저의 권한이 없습니다.',
+    //   },
+    //   { status: 403 }
+    // );
+
+    // 실패 - 네트워크 오류
+    return HttpResponse.error();
   }),
 ];

--- a/src/page/support/WriteInquiryPage/WriteInquiryPage.tsx
+++ b/src/page/support/WriteInquiryPage/WriteInquiryPage.tsx
@@ -11,6 +11,7 @@ import {
   TextareaFieldBlue,
   TextFieldBlue,
 } from '@/shared/component';
+import { BOARD_ID } from '@/shared/constant';
 import { useAuth, useToast } from '@/shared/hook';
 
 import { mapFileToAttachment } from '@/feature/attachment/lib';
@@ -20,6 +21,7 @@ import { INQUIRY_PLACEHOLDERS } from '@/feature/support/constant';
 import { INQUIRY_OPTIONS } from '@/feature/support/data';
 import { FileUploadSection, SubmitButton } from '@/feature/support/ui';
 
+import { createThumbnail } from '@/apis';
 import { Option } from '@/types';
 
 import styles from './WriteInquiryPage.module.css';
@@ -32,7 +34,14 @@ export default function WriteInquiryPage() {
     mutationFn: createInquiry,
     onSuccess: (data) => {
       const { postId } = data;
+
       navigate(`/inquiry/${postId}`, { replace: true });
+
+      createThumbnail(BOARD_ID.inquiryAndReport, postId) //
+        .catch((error) => {
+          // 썸네일 생성 실패는 치명적이지 않으므로, 에러를 사용자에게 알리지 않고 조용히 실패 처리합니다.
+          // 에러 로그 수집 (모니터링: sentry)
+        });
     },
     onError: (error) => {
       toast({ message: error.message, variant: 'error' });

--- a/src/page/support/WriteInquiryPage/WriteInquiryPage.tsx
+++ b/src/page/support/WriteInquiryPage/WriteInquiryPage.tsx
@@ -11,7 +11,7 @@ import {
   TextareaFieldBlue,
   TextFieldBlue,
 } from '@/shared/component';
-import { useAuth } from '@/shared/hook';
+import { useAuth, useToast } from '@/shared/hook';
 
 import { mapFileToAttachment } from '@/feature/attachment/lib';
 import type { UploadFile } from '@/feature/attachment/types';
@@ -26,12 +26,16 @@ import styles from './WriteInquiryPage.module.css';
 
 export default function WriteInquiryPage() {
   const navigate = useNavigate();
+  const { toast } = useToast();
 
   const { mutate: submitInquiry } = useMutation({
     mutationFn: createInquiry,
     onSuccess: (data) => {
       const { postId } = data;
       navigate(`/inquiry/${postId}`, { replace: true });
+    },
+    onError: (error) => {
+      toast({ message: error.message, variant: 'error' });
     },
   });
 

--- a/src/page/support/WriteInquiryPage/WriteInquiryPage.tsx
+++ b/src/page/support/WriteInquiryPage/WriteInquiryPage.tsx
@@ -39,8 +39,10 @@ export default function WriteInquiryPage() {
 
       createThumbnail(BOARD_ID.inquiryAndReport, postId) //
         .catch((error) => {
-          // 썸네일 생성 실패는 치명적이지 않으므로, 에러를 사용자에게 알리지 않고 조용히 실패 처리합니다.
-          // 에러 로그 수집 (모니터링: sentry)
+          /**
+           * TODO: 썸네일 생성 실패는 치명적이지 않으므로, 에러를 사용자에게 알리지 않고 조용히 실패 처리합니다.
+           * 에러 로그 수집 (모니터링: sentry)
+           */
         });
     },
     onError: (error) => {

--- a/src/shared/constant/board.js
+++ b/src/shared/constant/board.js
@@ -1,19 +1,19 @@
 import besookt from '@/assets/images/besookt-board-page.svg';
+import event from '@/assets/images/event-board-page.svg';
+import eventMain from '@/assets/images/event-main.svg';
 import financeAudit from '@/assets/images/financeAudit-board-page.svg';
 import firstSnow from '@/assets/images/firstSnow-board-page.svg';
+import firstSnowMain from '@/assets/images/firstSnow-main.svg';
 import graduationPreparation from '@/assets/images/graduationPreparation-board-page.svg';
 import largeSnow from '@/assets/images/largeSnow-board-page.svg';
-import permanentSnow from '@/assets/images/permanentSnow-board-page.svg';
-import studentCouncil from '@/assets/images/studentCouncil-board-page.svg';
-import event from '@/assets/images/event-board-page.svg';
-
-import firstSnowMain from '@/assets/images/firstSnow-main.svg';
 import largeSnowMain from '@/assets/images/largeSnow-main.svg';
+import permanentSnow from '@/assets/images/permanentSnow-board-page.svg';
 import permanentSnowMain from '@/assets/images/permanentSnow-main.svg';
-import eventMain from '@/assets/images/event-main.svg';
+import studentCouncil from '@/assets/images/studentCouncil-board-page.svg';
 
 export const BOARD_ID = Object.freeze({
   all: 0, // 프론트에서만 사용하는 보드 ID
+  inquiryAndReport: 13,
   event: 14,
   besookt: 20,
   'first-snow': 21,


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1535 

- [Notion](https://www.notion.so/snorose/2ec7ef0aa3bf802f9358db3338150ec0?source=copy_link)

## 🎯 변경 사항

### 에러 핸들링 강화
- 문의 작성 API 호출 시 발생하는 다양한 에러 상황(네트워크 오류, 권한 부족, 파일 업로드 제한 등)을 구체적으로 처리하도록 로직을 개선했습니다.

### 사용자 피드백 개선
- 문의 작성 실패 시 토스트 메시지를 통해 사용자에게 명확한 에러 원인을 안내하도록 UI 로직을 추가했습니다.

### 썸네일 생성 로직 추가
- 문의 작성 성공 시 썸네일 생성 API를 호출하도록 연동했습니다.

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
