### PR TITLE
[SNO-393] #1556 비밀번호 찾기 시 아이디 입력창에서 특수문자 입력 제한 로직 제거

### DIFF
--- a/src/feature/account/lib/inputCheck.js
+++ b/src/feature/account/lib/inputCheck.js
@@ -39,9 +39,7 @@ export function validateId(value = '') {
 
   if (pathname === 'find-pw') {
     //비밀번호찾기에서는 특수문자 허용, 문자 개수 제한 validate 적용 안 함 (과거 회원 고려)
-    if (value.length > 0) {
-      return 'valid';
-    }
+    return 'valid';
   } else {
     if (format.test(value) && value.length >= 5 && value.length <= 30) {
       //그 외 페이지에서는 문자 개수 제한 validate 적용

--- a/src/feature/account/lib/inputCheck.js
+++ b/src/feature/account/lib/inputCheck.js
@@ -38,8 +38,8 @@ export function validateId(value = '') {
   }
 
   if (pathname === 'find-pw') {
-    //비밀번호찾기에서는 문자 개수 제한 validate 적용 안 함 (과거 회원 고려)
-    if (format.test(value)) {
+    //비밀번호찾기에서는 특수문자 허용, 문자 개수 제한 validate 적용 안 함 (과거 회원 고려)
+    if (value.length > 0) {
       return 'valid';
     }
   } else {

--- a/src/page/account/FindPwPage/FindPwPage.jsx
+++ b/src/page/account/FindPwPage/FindPwPage.jsx
@@ -137,8 +137,15 @@ export default function FindPwPage() {
                   <br />
                   아래 구글 폼을 작성해주시면 신속히 해결해드릴게요
                 </p>
-                  <a className={styles.googleFormBtn} href='https://forms.gle/PDmKuPUuUzKXTh8BA' target='_blank' rel='noopener noreferrer'>                  <Icon id='google-form' width={'1.6rem'} height={'1.6rem'} />
-구글 폼</a>
+                <a
+                  className={styles.googleFormBtn}
+                  href='https://forms.gle/PDmKuPUuUzKXTh8BA'
+                  target='_blank'
+                  rel='noopener noreferrer'
+                >
+                  <Icon id='google-form' width={'1.6rem'} height={'1.6rem'} />
+                  구글 폼
+                </a>
               </div>
             )}
           </div>

--- a/src/page/account/FindPwPage/FindPwPage.jsx
+++ b/src/page/account/FindPwPage/FindPwPage.jsx
@@ -40,7 +40,7 @@ export default function FindPwPage() {
       value: formData.loginId,
       onChange: (next) => setFormData((prev) => ({ ...prev, loginId: next })),
       validate: validateId,
-      message: '아이디는 영어, 숫자만 가능합니다',
+      message: '아이디를 입력해주세요',
     },
     {
       type: 'email',


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1556


## 🎯 변경 사항

- 비밀번호 찾기 시 아이디 입력창에서 특수문자 입력 제한 로직 제거
  - 아이디에 특수문자가 포함되어 있는경우 비밀번호 찾기가 불가합니다. 
  - (참고) 백엔드에서는 비밀번호 찾기시, 아이디 입력란에 특수문자 허용) 
## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
