### PR TITLE
[SNO-395] #1562 게시글 바 내에 메타 정보가 많을 경우 줄바꿈 되는 이슈 해결

### DIFF
--- a/src/feature/board/component/PostBar/PostBar.jsx
+++ b/src/feature/board/component/PostBar/PostBar.jsx
@@ -28,21 +28,20 @@ export default function PostBar({
 }) {
   return (
     <div className={`${styles.container} ${className}`}>
-      <div className={styles.body}>
-        <div>
-          <Meta
-            userRoleId={userRoleId}
-            userDisplay={userDisplay}
-            createdAt={createdAt}
-            isEdited={isEdited}
-          >
-            {children}
-          </Meta>
+      <Meta
+        userRoleId={userRoleId}
+        userDisplay={userDisplay}
+        createdAt={createdAt}
+        isEdited={isEdited}
+      >
+        {children}
+      </Meta>
 
+      <div className={styles.body}>
+        <div className={styles.text}>
           <div className={styles.title}>{title}</div>
           <div className={styles.content}>{content}</div>
         </div>
-
         {hasMediaAttachment && <Thumbnail thumbnailUrl={thumbnailUrl} />}
       </div>
 
@@ -61,15 +60,16 @@ function Meta({ userRoleId, userDisplay, createdAt, isEdited, children }) {
   const showBadge =
     userRoleId === ROLE.official ||
     (userRoleId === ROLE.admin && userDisplay !== '익명송이');
+  const truncatedUserDisplay =
+    userDisplay?.length > 6 ? `${userDisplay.slice(0, 6)}...` : userDisplay;
 
   return (
     <div className={styles.meta}>
       <img className={styles.cloudLogoIcon} src={cloudLogo} alt='로고' />
-      <div>{userDisplay}</div>
+      <div>{truncatedUserDisplay}</div>
       {showBadge && <Badge className={styles.badge} userRoleId={userRoleId} />}
       <div className={styles.dot}>·</div>
       <div>{DateTime.formatAdaptive(createdAt)}</div>
-      {isEdited && <div>(수정됨)</div>}
       {children}
     </div>
   );

--- a/src/feature/board/component/PostBar/PostBar.jsx
+++ b/src/feature/board/component/PostBar/PostBar.jsx
@@ -14,7 +14,6 @@ export default function PostBar({
   userRoleId,
   userDisplay,
   createdAt,
-  isEdited,
   title,
   content,
   hasMediaAttachment,
@@ -32,7 +31,6 @@ export default function PostBar({
         userRoleId={userRoleId}
         userDisplay={userDisplay}
         createdAt={createdAt}
-        isEdited={isEdited}
       >
         {children}
       </Meta>
@@ -56,7 +54,7 @@ export default function PostBar({
   );
 }
 
-function Meta({ userRoleId, userDisplay, createdAt, isEdited, children }) {
+function Meta({ userRoleId, userDisplay, createdAt, children }) {
   const showBadge =
     userRoleId === ROLE.official ||
     (userRoleId === ROLE.admin && userDisplay !== '익명송이');

--- a/src/feature/board/component/PostBar/PostBar.module.css
+++ b/src/feature/board/component/PostBar/PostBar.module.css
@@ -11,13 +11,14 @@
 
 .body {
   margin-bottom: 0.5rem;
-
   display: flex;
   justify-content: space-between;
+  align-items: center;
+}
 
-  & > div:first-child {
-    flex: 1;
-  }
+.text {
+  flex: 1;
+  min-width: 0;
 }
 
 .meta {
@@ -72,6 +73,7 @@
 .thumbnail {
   width: 7.4rem;
   margin-left: 2rem;
+  flex-shrink: 0;
 
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1562


## 🎯 변경 사항

- 게시글 바 날짜 영역에서 '(수정됨)' 문구 삭제
- 메타정보와 이미지가 동일한 선상에 위치하지 않도록 수정
- 닉네임이 6자를 초과하는 경우 말줄임으로 표시

## 📸 스크린샷 (선택 사항)

| Before | After |
| :----: | :---: |
|  <img width="300"  alt="image" src="https://github.com/user-attachments/assets/9e14245d-e5b6-4cd8-9089-e510ac624fb8" />|<img width="300" alt="image" src="https://github.com/user-attachments/assets/7a50914b-fb44-41b4-a961-a0db83284264" />|


## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
