### PR TITLE
[SNO-373] #1540 에디터 내 이미지 링크 삽입 가능

### DIFF
--- a/src/feature/editor/component/EditorContainer/EditorContainer.jsx
+++ b/src/feature/editor/component/EditorContainer/EditorContainer.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 
+import Image from '@tiptap/extension-image';
 import Link from '@tiptap/extension-link';
 import Placeholder from '@tiptap/extension-placeholder';
 import TextAlign from '@tiptap/extension-text-align';
@@ -18,7 +19,6 @@ import { Iframe } from '@/feature/editor/component/extensions/iframe-extension';
 import { formatEmbedUrl } from '../../utils/format-embed-url';
 import { FontSize } from '../extensions/font-size-extension';
 import LinkBubbleMenu from '../LinkBubbleMenu/LinkBubbleMenu';
-
 import styles from './EditorContainer.module.css';
 
 export default function EditorContainer({
@@ -52,6 +52,7 @@ export default function EditorContainer({
         alignments: ['left', 'center', 'right'],
       }),
       Iframe,
+      Image,
       TextStyle,
       Color,
       BackgroundColor,
@@ -68,6 +69,14 @@ export default function EditorContainer({
 
       const { $from, empty } = editor.state.selection;
 
+      const isImageUrl = (url) => {
+        return (
+          /\.(jpeg|jpg|gif|png|bmp|webp|svg)(\?.*)?$/i.test(url) ||
+          url.startsWith('https://picsum.photos') ||
+          url.startsWith('https://images.') ||
+          url.includes('/image')
+        );
+      };
       // 텍스트를 드래그한 상태면 메뉴 숨김
       if (!empty) {
         if (isLinkMenuOpen) setIsLinkMenuOpen(false);
@@ -91,10 +100,24 @@ export default function EditorContainer({
         const linkMark = nodeBefore.marks.find((m) => m.type.name === 'link');
 
         if (linkMark) {
+          const url = linkMark.attrs.href;
+
+          if (isImageUrl(url)) {
+            setTimeout(() => {
+                editor
+                  .chain()
+                  .focus()
+                  .extendMarkRange('link')
+                  .deleteSelection()
+                  .setImage({ src: url })
+                  .run();
+              }, 0);
+              return;
+          }
           // 화면상의 절대 좌표(픽셀)를 계산하여 팝업 띄울 위치 결정
           const coords = editor.view.coordsAtPos(checkPos);
 
-          if (!isLinkMenuOpen || linkMenuData.url !== linkMark.attrs.href) {
+          if (!isLinkMenuOpen || linkMenuData.url !== url) {
             setLinkMenuData({
               url: linkMark.attrs.href,
               pos: checkPos,

--- a/src/feature/editor/component/EditorContainer/EditorContainer.jsx
+++ b/src/feature/editor/component/EditorContainer/EditorContainer.jsx
@@ -21,13 +21,22 @@ import { FontSize } from '../extensions/font-size-extension';
 import LinkBubbleMenu from '../LinkBubbleMenu/LinkBubbleMenu';
 import styles from './EditorContainer.module.css';
 
-const isImageUrl = (url) => {
+const isImageUrl = async (url) => {
   if (!url) return false;
 
-  const hasImageExtension = /\.(jpeg|jpg|gif|png|bmp|webp|svg)(\?.*)?$/i.test(url);
-  const trustedDomains = ['imgur.com', 'flickr.com', 'postimages.org', 'picsum.photos'];
-  const isTrustedHost = trustedDomains.some((domain) => url.startsWith(domain));
-  return hasImageExtension || isTrustedHost;
+  if (/\.(jpeg|jpg|gif|png|bmp|webp|svg)(\?.*)?$/i.test(url)) return true;
+
+  const trustedDomains = ['imgur.com', 'flickr.com', 'postimages.org', 
+                          'picsum.photos', 'gstatic.com', 'googleusercontent.com'];
+  if (trustedDomains.some((domain) => url.includes(domain))) return true;
+
+  // 3. img 태그로 실제 로드 시도
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => resolve(true);
+    img.onerror = () => resolve(false);
+    img.src = url;
+  });
 };
 
 export default function EditorContainer({

--- a/src/feature/editor/component/EditorContainer/EditorContainer.jsx
+++ b/src/feature/editor/component/EditorContainer/EditorContainer.jsx
@@ -21,6 +21,15 @@ import { FontSize } from '../extensions/font-size-extension';
 import LinkBubbleMenu from '../LinkBubbleMenu/LinkBubbleMenu';
 import styles from './EditorContainer.module.css';
 
+const isImageUrl = (url) => {
+  if (!url) return false;
+
+  const hasImageExtension = /\.(jpeg|jpg|gif|png|bmp|webp|svg)(\?.*)?$/i.test(url);
+  const trustedDomains = ['imgur.com', 'flickr.com', 'postimages.org', 'picsum.photos'];
+  const isTrustedHost = trustedDomains.some((domain) => url.startsWith(domain));
+  return hasImageExtension || isTrustedHost;
+};
+
 export default function EditorContainer({
   placeholder,
   text,
@@ -69,14 +78,6 @@ export default function EditorContainer({
 
       const { $from, empty } = editor.state.selection;
 
-      const isImageUrl = (url) => {
-        return (
-          /\.(jpeg|jpg|gif|png|bmp|webp|svg)(\?.*)?$/i.test(url) ||
-          url.startsWith('https://picsum.photos') ||
-          url.startsWith('https://images.') ||
-          url.includes('/image')
-        );
-      };
       // 텍스트를 드래그한 상태면 메뉴 숨김
       if (!empty) {
         if (isLinkMenuOpen) setIsLinkMenuOpen(false);

--- a/src/feature/editor/lib/sanitize.js
+++ b/src/feature/editor/lib/sanitize.js
@@ -1,19 +1,24 @@
-// shared/lib/sanitize.js
 import DOMPurify from 'dompurify';
 
 export const sanitizeHtml = (html) => {
-  return DOMPurify.sanitize(html, {
-    ADD_TAGS: ['iframe'],
-    ADD_ATTR: [
-      'allow',
-      'allowfullscreen',
-      'frameborder',
-      'scrolling',
-      'src',
-      'width',
-      'height',
-    ],
-    ALLOWED_URI_REGEXP:
-    /^(https?:\/\/((www\.)?youtube\.com\/embed\/|(www\.)?instagram\.com\/(p|reel)\/[a-zA-Z0-9_-]+\/embed\/|(www\.)?tiktok\.com\/embed\/v2\/|platform\.twitter\.com\/embed\/Tweet\.html\?id=|(www\.)?tv\.naver\.com\/embed\/|maps\.google\.com\/maps\?.*output=embed|(www\.)?google\.com\/maps\/embed|(map\.)?naver\.com\/|naver\.me\/))/
+  DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+    if (node.tagName === 'IFRAME') {
+      const src = node.getAttribute('src') || '';
+
+      const iframeAllowed = /^https?:\/\/((www\.)?youtube\.com\/embed\/|(www\.)?instagram\.com\/(p|reel)\/[a-zA-Z0-9_-]+\/embed\/|(www\.)?tiktok\.com\/embed\/v2\/|platform\.twitter\.com\/embed\/Tweet\.html\?id=|(www\.)?tv\.naver\.com\/embed\/|maps\.google\.com\/maps\?.*output=embed|(www\.)?google\.com\/maps\/embed|(map\.)?naver\.com\/|naver\.me\/)/.test(src);
+      
+      if (!iframeAllowed) {
+        node.setAttribute('src', '');
+      }
+    }
   });
-}
+
+  const result = DOMPurify.sanitize(html, {
+    ADD_TAGS: ['iframe'],
+    ADD_ATTR: ['allow', 'allowfullscreen', 'frameborder', 'scrolling', 'src', 'width', 'height'],
+  });
+
+  DOMPurify.removeHooks('afterSanitizeAttributes');
+
+  return result;
+};

--- a/src/feature/editor/lib/sanitize.js
+++ b/src/feature/editor/lib/sanitize.js
@@ -1,24 +1,32 @@
 import DOMPurify from 'dompurify';
 
-export const sanitizeHtml = (html) => {
-  DOMPurify.addHook('afterSanitizeAttributes', (node) => {
-    if (node.tagName === 'IFRAME') {
-      const src = node.getAttribute('src') || '';
+const ALLOWED_IFRAME_SOURCES = [
+  /^https?:\/\/(www\.)?youtube\.com\/embed\//,
+  /^https?:\/\/(www\.)?instagram\.com\/(p|reel)\/[a-zA-Z0-9_-]+\/embed\//,
+  /^https?:\/\/(www\.)?tiktok\.com\/embed\/v2\//,
+  /^https?:\/\/platform\.twitter\.com\/embed\/Tweet\.html\?id=/,
+  /^https?:\/\/(www\.)?tv\.naver\.com\/embed\//,
+  /^https?:\/\/maps\.google\.com\/maps\?.*output=embed/,
+  /^https?:\/\/(www\.)?google\.com\/maps\/embed/,
+  /^https?:\/\/(map\.)?naver\.com\//,
+  /^https?:\/\/naver\.me\//,
+  /^https?:\/\/kko\.to\//
+];
 
-      const iframeAllowed = /^https?:\/\/((www\.)?youtube\.com\/embed\/|(www\.)?instagram\.com\/(p|reel)\/[a-zA-Z0-9_-]+\/embed\/|(www\.)?tiktok\.com\/embed\/v2\/|platform\.twitter\.com\/embed\/Tweet\.html\?id=|(www\.)?tv\.naver\.com\/embed\/|maps\.google\.com\/maps\?.*output=embed|(www\.)?google\.com\/maps\/embed|(map\.)?naver\.com\/|naver\.me\/|kko\.to\/)/.test(src);
-      
-      if (!iframeAllowed) {
-        node.setAttribute('src', '');
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if (node.tagName === 'IFRAME') {
+    const src = node.getAttribute('src') || '';
+
+    const isAllowed = ALLOWED_IFRAME_SOURCES.some((pattern) => pattern.test(src));
+      if (!isAllowed) {
+        node.removeAttribute('src');
       }
-    }
-  });
+  }
+})
 
-  const result = DOMPurify.sanitize(html, {
+export const sanitizeHtml = (html) => {
+  return DOMPurify.sanitize(html, {
     ADD_TAGS: ['iframe'],
     ADD_ATTR: ['allow', 'allowfullscreen', 'frameborder', 'scrolling', 'src', 'width', 'height'],
   });
-
-  DOMPurify.removeHooks('afterSanitizeAttributes');
-
-  return result;
 };

--- a/src/feature/editor/lib/sanitize.js
+++ b/src/feature/editor/lib/sanitize.js
@@ -5,7 +5,7 @@ export const sanitizeHtml = (html) => {
     if (node.tagName === 'IFRAME') {
       const src = node.getAttribute('src') || '';
 
-      const iframeAllowed = /^https?:\/\/((www\.)?youtube\.com\/embed\/|(www\.)?instagram\.com\/(p|reel)\/[a-zA-Z0-9_-]+\/embed\/|(www\.)?tiktok\.com\/embed\/v2\/|platform\.twitter\.com\/embed\/Tweet\.html\?id=|(www\.)?tv\.naver\.com\/embed\/|maps\.google\.com\/maps\?.*output=embed|(www\.)?google\.com\/maps\/embed|(map\.)?naver\.com\/|naver\.me\/)/.test(src);
+      const iframeAllowed = /^https?:\/\/((www\.)?youtube\.com\/embed\/|(www\.)?instagram\.com\/(p|reel)\/[a-zA-Z0-9_-]+\/embed\/|(www\.)?tiktok\.com\/embed\/v2\/|platform\.twitter\.com\/embed\/Tweet\.html\?id=|(www\.)?tv\.naver\.com\/embed\/|maps\.google\.com\/maps\?.*output=embed|(www\.)?google\.com\/maps\/embed|(map\.)?naver\.com\/|naver\.me\/|kko\.to\/)/.test(src);
       
       if (!iframeAllowed) {
         node.setAttribute('src', '');


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1540

- [Figma]()
- [Notion](https://www.notion.so/snorose/Work-Space-3230dfa391564128886246e5990a1131?p=3437ef0aa3bf8032b0fded478a4fadec&pm=s)

## 🎯 변경 사항

- 에디터 내에 외부 이미지 링크를 복사하면 바로 이미지로 변경되어 글 작성이 가능합니다 (현재 있는 이미지 첨부 기능과는 별개입니다)
- 카카오 맵 렌더링 추가

## 📸 스크린샷 (선택 사항)

| Before | After |
| :----: | :---: |
| <img src="https://github.com/user-attachments/assets/f87b25b0-596c-4f95-8ace-633a1e26ee2e" width="400"/> | <img src="https://github.com/user-attachments/assets/0a9c0e9d-754d-4b80-9199-662d558ae237" width="400"/> |


## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
- 다양한 이미지 링크들이 삽입될 수 있는 지 확인해주세요! 
- 이미지 링크 삽입을 위해 santize.js 파일들을 수정했습니다 보안 상의 문제는 없을 지 확인해주세요! 