### PR TITLE
[SNO-396] #1572 글 제목과 본문을 세로축 가운데가 아닌 상단으로 위치 수정

### DIFF
--- a/src/feature/board/component/PostBar/PostBar.module.css
+++ b/src/feature/board/component/PostBar/PostBar.module.css
@@ -13,7 +13,7 @@
   margin-bottom: 0.5rem;
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
 }
 
 .text {


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1572


## 🎯 변경 사항

- 글 제목과 본문을 세로축 가운데가 아닌 상단으로 위치 수정

## 📸 스크린샷 (선택 사항)

| Before | After |
| :----: | :---: |
| <img width="300"  alt="image" src="https://github.com/user-attachments/assets/482abe37-dd27-4c5c-ba20-e906fb8a3620" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/5e082b9d-cc53-4941-a8fc-5a204583a037" /> |

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
