### PR TITLE
[SNO-360] #1559 문의 수정 API 연결

### DIFF
--- a/src/feature/support/InquiryUpdateErrorPage.tsx
+++ b/src/feature/support/InquiryUpdateErrorPage.tsx
@@ -1,0 +1,38 @@
+import {
+  isRouteErrorResponse,
+  useNavigate,
+  useRouteError,
+} from 'react-router-dom';
+
+import { NoticeModal } from '@/shared/component';
+import { NOTICE_MODAL_TEXT } from '@/shared/constant';
+
+export default function InquiryUpdateErrorPage() {
+  const error = useRouteError();
+  const navigate = useNavigate();
+
+  if (isRouteErrorResponse(error)) {
+    const errorData = error.data as { code?: number };
+
+    switch (errorData.code) {
+      case 2007:
+        return (
+          <NoticeModal
+            modalText={NOTICE_MODAL_TEXT.NOT_POST_AUTHOR}
+            onConfirm={() => navigate(-1)}
+          />
+        );
+      case 6102:
+        return (
+          <NoticeModal
+            modalText={NOTICE_MODAL_TEXT.ALREADY_ANSWERED}
+            onConfirm={() => navigate(-1)}
+          />
+        );
+      default:
+        throw error;
+    }
+  }
+
+  throw error;
+}

--- a/src/feature/support/api/inquiry.ts
+++ b/src/feature/support/api/inquiry.ts
@@ -4,7 +4,7 @@ import { putFileInBucket } from '@/apis';
 import { authAxios } from '@/axios';
 
 export const readInquiry = async (inquiryId: string) => {
-  const response = await authAxios.get(`/v1/inquiries/${inquiryId}`);
+  const response = await authAxios.get(`/v1/inquiries/inquiry/${inquiryId}`);
 
   return response.data.result;
 };
@@ -59,6 +59,67 @@ export const createInquiry = async ({
         throw new Error('첨부파일은 최대 3개까지 업로드할 수 있어요');
       case 403:
         throw new Error('문의 작성 권한이 없어요');
+      default:
+        throw new Error('잠시 후 다시 시도해주세요.');
+    }
+  }
+};
+
+export type InquirUpdateRequest = {
+  postId: string;
+  title: string;
+  content: string;
+  inquiryCategory: string;
+  targetUrl?: string;
+  oldAttachments?: Attachment[];
+  newAttachments?: (Attachment & { file: File })[];
+  deleteAttachments?: number[];
+};
+
+export const updateInquiry = async ({
+  postId,
+  title,
+  content,
+  inquiryCategory,
+  targetUrl,
+  oldAttachments = [],
+  newAttachments = [],
+  deleteAttachments = [],
+}: InquirUpdateRequest) => {
+  try {
+    const response = await authAxios.patch(`/v1/inquiries/inquiry/${postId}`, {
+      title,
+      content,
+      inquiryCategory,
+      targetUrl,
+      finalAttachments: [...oldAttachments, ...newAttachments],
+      deleteAttachments,
+    });
+
+    const { inquiryId, attachmentUrlList } = response.data.result;
+
+    if (attachmentUrlList.length > 0) {
+      await putFileInBucket(
+        attachmentUrlList,
+        newAttachments.map(({ file }) => file)
+      );
+    }
+
+    return { postId: inquiryId };
+  } catch (error) {
+    const response = error?.response;
+
+    if (!response) {
+      throw new Error('네트워크 통신 중 오류가 발생했어요');
+    }
+
+    switch (response.data.code) {
+      case 2007:
+        throw new Error('수정 권한이 없어요');
+      case 3032:
+        throw new Error('첨부파일은 최대 3개까지 업로드할 수 있어요');
+      case 6102:
+        throw new Error('답변 완료된 글은 수정할 수 없어요');
       default:
         throw new Error('잠시 후 다시 시도해주세요.');
     }

--- a/src/feature/support/api/inquiry.ts
+++ b/src/feature/support/api/inquiry.ts
@@ -65,7 +65,7 @@ export const createInquiry = async ({
   }
 };
 
-export type InquirUpdateRequest = {
+export type InquiryUpdateRequest = {
   postId: string;
   title: string;
   content: string;
@@ -85,7 +85,7 @@ export const updateInquiry = async ({
   oldAttachments = [],
   newAttachments = [],
   deleteAttachments = [],
-}: InquirUpdateRequest) => {
+}: InquiryUpdateRequest) => {
   try {
     const response = await authAxios.patch(`/v1/inquiries/inquiry/${postId}`, {
       title,

--- a/src/feature/support/api/inquiry.ts
+++ b/src/feature/support/api/inquiry.ts
@@ -92,7 +92,20 @@ export const updateInquiry = async ({
       content,
       inquiryCategory,
       targetUrl,
-      finalAttachments: [...oldAttachments, ...newAttachments],
+      finalAttachments: [
+        ...oldAttachments.map(({ id, fileName, fileComment, type }) => ({
+          id,
+          fileName,
+          fileComment,
+          type,
+        })),
+        ...newAttachments.map(({ id, fileName, fileComment, type }) => ({
+          id,
+          fileName,
+          fileComment,
+          type,
+        })),
+      ],
       deleteAttachments,
     });
 

--- a/src/feature/support/loader.ts
+++ b/src/feature/support/loader.ts
@@ -44,9 +44,12 @@ export const inquiryEditLoader = async ({ params }: LoaderFunctionArgs) => {
 
     return post;
   } catch (error) {
-    switch (error.response.status) {
+    const status = error.response?.status;
+    const code = error.response?.data?.code;
+
+    switch (status) {
       case 403:
-        throw json({ code: error.response?.data?.code }, { status: 403 });
+        throw json({ code }, { status: 403 });
       case 404:
         throw new Response('Not Found', { status: 404 });
       default:

--- a/src/feature/support/loader.ts
+++ b/src/feature/support/loader.ts
@@ -44,9 +44,9 @@ export const inquiryEditLoader = async ({ params }: LoaderFunctionArgs) => {
 
     return post;
   } catch (error) {
-    switch (error.data) {
+    switch (error.response.status) {
       case 403:
-        throw json({ code: error.data.code }, { status: 403 });
+        throw json({ code: error.response?.data?.code }, { status: 403 });
       case 404:
         throw new Response('Not Found', { status: 404 });
       default:

--- a/src/feature/support/loader.ts
+++ b/src/feature/support/loader.ts
@@ -1,7 +1,8 @@
-import { LoaderFunctionArgs, redirect } from 'react-router-dom';
+import { json, LoaderFunctionArgs, redirect } from 'react-router-dom';
 
+import { readInquiry } from '@/feature/support/api';
 import { REPORT_PARAMS_SCHEMA, ReportType } from '@/feature/support/data';
-import type { InquiryDTO, ReportDTO } from '@/feature/support/types';
+import type { ReportDTO } from '@/feature/support/types';
 
 export type ReportParamsLoaderData = Awaited<
   ReturnType<typeof validateReportWriteLoader>
@@ -35,37 +36,23 @@ function validateReportWriteParams(type: string, params: URLSearchParams) {
   }
 }
 
-/**
- * TODO:
- * - 존재하지 않는 inquiryId로 접근 시 404 처리
- * - 권한이 없는 inquryId로 접근 시 403 처리
- * - 답변 완료 후에는 접근 불가
- */
-
 export const inquiryEditLoader = async ({ params }: LoaderFunctionArgs) => {
-  const { inquiryId } = params;
-  // const result = await fetch(`/v1/inquiries/${inquiryId}`);
+  const { postId } = params;
 
-  const post: InquiryDTO = {
-    postId: 15,
-    userRoleId: 4,
-    isWriter: false,
-    userId: '629j3YCdF2F+NPCBzMf0Rg==',
-    userDisplay: '눈송',
-    title: '시험후기 문의',
-    link: 'https://www.snorose.com/...',
-    content: '문의 내용',
-    category: 'EXAM_REVIEW_INQUIRY',
-    status: 'PENDING',
-    commentCount: 0,
-    createdAt: '2025-08-30T22:47:09.234619',
-    updatedAt: null,
-    isEdited: true,
-    isWriterWithdrawn: false,
-    attachments: [],
-  };
+  try {
+    const post = await readInquiry(postId);
 
-  return post;
+    return post;
+  } catch (error) {
+    switch (error.data) {
+      case 403:
+        throw json({ code: error.data.code }, { status: 403 });
+      case 404:
+        throw new Response('Not Found', { status: 404 });
+      default:
+        throw new Response('Internal Server Error', { status: 500 });
+    }
+  }
 };
 
 /**

--- a/src/feature/support/types.ts
+++ b/src/feature/support/types.ts
@@ -1,17 +1,17 @@
+import { Attachment } from '@/feature/attachment/types';
 import { REPORT_OPTIONS } from '@/feature/support/data';
 
-import { Attachment } from '@/feature/attachment/types';
-
 export type InquiryDTO = {
+  group: 'INQUIRY';
   postId: number;
   userRoleId: number;
   isWriter: boolean;
-  userId: string;
+  encryptedUserId: string;
   userDisplay: string;
   title: string;
   link: string;
   content: string;
-  category:
+  inquiryCategory:
     | 'EXAM_REVIEW_INQUIRY'
     | 'EVENT_INQUIRY'
     | 'NOTICE_INQUIRY'
@@ -20,6 +20,7 @@ export type InquiryDTO = {
   commentCount: number;
   createdAt: string;
   updatedAt: string | null;
+  isNotice: boolean;
   isEdited: boolean;
   isWriterWithdrawn: boolean;
   attachments: Attachment[];

--- a/src/page/support/EditInquiryPage.tsx
+++ b/src/page/support/EditInquiryPage.tsx
@@ -1,12 +1,46 @@
-import { useLoaderData } from 'react-router-dom';
+import { useLoaderData, useNavigate, useParams } from 'react-router-dom';
 
+import { useMutation } from '@tanstack/react-query';
+
+import { BOARD_ID } from '@/shared/constant';
+import { useToast } from '@/shared/hook';
+
+import { mapFileToAttachment } from '@/feature/attachment/lib';
+import { updateInquiry } from '@/feature/support/api';
 import { INQUIRY_PLACEHOLDERS } from '@/feature/support/constant';
 import { INQUIRY_OPTIONS } from '@/feature/support/data';
 import type { InquiryDTO } from '@/feature/support/types';
 import { SupportFormView } from '@/feature/support/ui';
 
+import { createThumbnail } from '@/apis';
+
 export default function EditInquiryPage() {
   const post = useLoaderData() as InquiryDTO;
+
+  const { postId } = useParams();
+  const navigate = useNavigate();
+
+  const { toast } = useToast();
+
+  const { mutate: submit } = useMutation({
+    mutationFn: updateInquiry,
+    onSuccess: (data) => {
+      const { postId } = data;
+
+      navigate(`/inquiry/${postId}`, { replace: true });
+
+      createThumbnail(BOARD_ID.inquiryAndReport, postId) //
+        .catch((error) => {
+          /**
+           * TODO: 썸네일 생성 실패는 치명적이지 않으므로, 에러를 사용자에게 알리지 않고 조용히 실패 처리합니다.
+           * 에러 로그 수집 (모니터링: sentry)
+           */
+        });
+    },
+    onError: (error) => {
+      toast({ message: error.message, variant: 'error' });
+    },
+  });
 
   const { dropdown, title, content } = INQUIRY_PLACEHOLDERS;
 
@@ -14,10 +48,25 @@ export default function EditInquiryPage() {
     <SupportFormView
       post={post}
       initialOption={INQUIRY_OPTIONS.find(
-        (option) => option.key === post.category
+        (option) => option.key === post.inquiryCategory
       )}
       initialLink={post.link}
-      submit={() => alert('submit!')}
+      submit={({ selectedOption, title, url, content, attachments, files }) => {
+        const originalIds = post.attachments.map((at) => at.id);
+        const remainingIds = new Set(attachments.map((at) => at.id));
+        const deletedIds = originalIds.filter((id) => !remainingIds.has(id));
+
+        submit({
+          postId,
+          title,
+          content,
+          targetUrl: url,
+          inquiryCategory: selectedOption.key,
+          oldAttachments: attachments,
+          newAttachments: files.map(mapFileToAttachment),
+          deleteAttachments: deletedIds,
+        });
+      }}
       options={INQUIRY_OPTIONS}
       contentLabel={'문의 내용'}
       placeholders={{ dropdown, title, content }}

--- a/src/router.js
+++ b/src/router.js
@@ -3,6 +3,7 @@ import { attendanceLoader } from '@/shared/loader';
 import { AppLayout, NavbarLayout } from '@/shared/ui';
 
 import { CheckExamPeriodRoute } from '@/feature/exam/lib';
+import InquiryUpdateErrorPage from '@/feature/support/InquiryUpdateErrorPage';
 import {
   inquiryEditLoader,
   reportEditLoader,
@@ -487,6 +488,11 @@ export const routeList = [
           },
           {
             path: ':postId/edit',
+            errorElement: (
+              <AppLayout>
+                <InquiryUpdateErrorPage />
+              </AppLayout>
+            ),
             element: (
               <ProtectedRoute>
                 <EditInquiryPage />

--- a/src/shared/constant/modalText.js
+++ b/src/shared/constant/modalText.js
@@ -222,6 +222,16 @@ const NOTICE_MODAL = {
     description: '이미 인증을 완료했거나 인증 대상이 아니에요.',
     confirmText: '홈으로 이동',
   },
+  ALREADY_ANSWERED: {
+    title: '이미 답변이 완료되었어요',
+    description: '답변이 등록된 문의글은 수정할 수 없어요',
+    confirmText: '돌아가기',
+  },
+  NOT_POST_AUTHOR: {
+    title: '접근 권한이 없어요',
+    description: '작성자 본인만 수정할 수 있어요',
+    confirmText: '돌아가기',
+  },
   MAEKETING_NOTICE_MODAL: {
     id: 'marketing-notice',
     title: (isMarketingAgreed) =>


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1559

- [Notion](https://www.notion.so/snorose/2ec7ef0aa3bf80afaca3e0928451ea9f?source=copy_link)

## 🎯 변경 사항

### 문의 수정 API 연동
- 문의 수정 기능을 위한 새로운 API 연동 로직이 추가되었으며, 기존 문의 조회 API의 엔드포인트 경로가 수정되었습니다.

###문의 수정 에러 페이지 추가
- 문의 수정 시 발생할 수 있는 특정 에러(작성자 권한 없음, 이미 답변 완료)를 처리하기 위한 전용 에러 페이지 컴포넌트가 추가되었습니다.

### 문의 수정 로더 개선
- 문의 수정 페이지 로더가 실제 API를 통해 데이터를 불러오고, 403(권한 없음) 및 404(찾을 수 없음)와 같은 HTTP 에러를 적절히 처리하도록 개선되었습니다.

### 문의 데이터 타입 정의 업데이트
- 문의(Inquiry) 데이터 전송 객체(DTO)의 필드명이 백엔드 변경사항에 맞춰 업데이트되었으며, 새로운 필드가 추가되었습니다.


## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
