### PR TITLE
[SNO-361] #1585 문의 삭제 API 연결

### DIFF
--- a/src/feature/board/component/PostModalRenderer/PostModalRenderer.jsx
+++ b/src/feature/board/component/PostModalRenderer/PostModalRenderer.jsx
@@ -1,9 +1,9 @@
 import { useLocation } from 'react-router-dom';
 
+import { ConfirmModal, MoreOptionModal } from '@/shared/component';
+import { CONFIRM_MODAL_TEXT, MORE_OPTION_MODAL_TEXT } from '@/shared/constant';
 import { useBoard } from '@/shared/hook';
-import { MoreOptionModal, ConfirmModal } from '@/shared/component';
 import { getBoard } from '@/shared/lib';
-import { MORE_OPTION_MODAL_TEXT, CONFIRM_MODAL_TEXT } from '@/shared/constant';
 
 export default function PostModalRenderer({
   modal,
@@ -13,7 +13,19 @@ export default function PostModalRenderer({
   handleShare,
 }) {
   const { pathname } = useLocation();
-  const currentBoard = getBoard(pathname.split('/')[2]);
+  const currentBoardId = pathname.startsWith('/inquiry')
+    ? 13
+    : getBoard(pathname.split('/')[2]).id;
+
+  const optionList =
+    currentBoardId === 13
+      ? MORE_OPTION_MODAL_TEXT.MY_POST_MORE_OPTION_LIST.slice(0, 2)
+      : MORE_OPTION_MODAL_TEXT.MY_POST_MORE_OPTION_LIST;
+
+  const functions =
+    currentBoardId === 13
+      ? [handleEdit, null]
+      : [handleEdit, null, handleShare];
 
   return (
     <>
@@ -37,8 +49,8 @@ export default function PostModalRenderer({
             return (
               <MoreOptionModal
                 title='내 게시글'
-                optionList={MORE_OPTION_MODAL_TEXT.MY_POST_MORE_OPTION_LIST}
-                functions={[handleEdit, null, handleShare]}
+                optionList={optionList}
+                functions={functions}
               />
             );
           // 이벤트 게시글 더보기 모달 (공유하기)
@@ -55,7 +67,7 @@ export default function PostModalRenderer({
             return (
               <ConfirmModal
                 modalText={
-                  [21, 22].includes(Number(currentBoard.id))
+                  [21, 22].includes(Number(currentBoardId))
                     ? CONFIRM_MODAL_TEXT.DELETE_POST
                     : CONFIRM_MODAL_TEXT.DELETE_POST_WITHOUT_POINT_DEDUCTION
                 }

--- a/src/feature/support/api/inquiry.ts
+++ b/src/feature/support/api/inquiry.ts
@@ -3,12 +3,6 @@ import type { Attachment } from '@/feature/attachment/types';
 import { putFileInBucket } from '@/apis';
 import { authAxios } from '@/axios';
 
-export const readInquiry = async (inquiryId: string) => {
-  const response = await authAxios.get(`/v1/inquiries/inquiry/${inquiryId}`);
-
-  return response.data.result;
-};
-
 export type InquiryCreateRequest = {
   title: string;
   content: string;
@@ -63,6 +57,12 @@ export const createInquiry = async ({
         throw new Error('잠시 후 다시 시도해주세요.');
     }
   }
+};
+
+export const readInquiry = async (postId: string) => {
+  const response = await authAxios.get(`/v1/inquiries/inquiry/${postId}`);
+
+  return response.data.result;
 };
 
 export type InquiryUpdateRequest = {
@@ -133,6 +133,27 @@ export const updateInquiry = async ({
         throw new Error('첨부파일은 최대 3개까지 업로드할 수 있어요');
       case 6102:
         throw new Error('답변 완료된 글은 수정할 수 없어요');
+    }
+  }
+};
+
+export const deleteInquiry = async (postId: string) => {
+  try {
+    const response = await authAxios.delete(`/v1/inquiries/inquiry/${postId}`);
+
+    return response.data.result;
+  } catch (error) {
+    const response = error?.response;
+
+    if (!response) {
+      throw new Error('네트워크 통신 중 오류가 발생했어요');
+    }
+
+    switch (response.data.code) {
+      case 6101:
+        throw new Error('존재하지 않는 게시글이에요');
+      case 6102:
+        throw new Error('답변 완료된 글은 삭제할 수 없어요');
       default:
         throw new Error('잠시 후 다시 시도해주세요.');
     }

--- a/src/feature/support/api/inquiry.ts
+++ b/src/feature/support/api/inquiry.ts
@@ -133,6 +133,8 @@ export const updateInquiry = async ({
         throw new Error('첨부파일은 최대 3개까지 업로드할 수 있어요');
       case 6102:
         throw new Error('답변 완료된 글은 수정할 수 없어요');
+      default:
+        throw new Error('잠시 후 다시 시도해주세요.');
     }
   }
 };

--- a/src/page/support/InquiryDetailPage.jsx
+++ b/src/page/support/InquiryDetailPage.jsx
@@ -2,7 +2,7 @@ import { Suspense, useContext } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 
 import {
   BackAppBar,
@@ -13,12 +13,12 @@ import {
 } from '@/shared/component';
 import { QUERY_KEY } from '@/shared/constant';
 import { ModalContext } from '@/shared/context/ModalContext';
+import { useToast } from '@/shared/hook';
 
 import { MeatBallIcon, PostActionBar } from '@/feature/board/component';
-import { useDeletePostHandler } from '@/feature/board/hook/useDeletePostHandler';
 import { PostDetailView } from '@/feature/board/ui';
 import { CommentInputContainer } from '@/feature/comment/component';
-import { readInquiry } from '@/feature/support/api';
+import { deleteInquiry, readInquiry } from '@/feature/support/api';
 import { INQUIRY_STATUS_MAP } from '@/feature/support/constant';
 
 import { NotFoundPage } from '@/page/etc';
@@ -34,8 +34,11 @@ export default function InquiryDetailPage() {
 }
 
 function InquiryDetailLoader() {
+  const navigate = useNavigate();
   const { postId } = useParams();
   const { setModal } = useContext(ModalContext);
+
+  const { toast } = useToast();
 
   const { data } = useSuspenseQuery({
     queryKey: QUERY_KEY.post(postId),
@@ -43,7 +46,15 @@ function InquiryDetailLoader() {
     staleTime: 1000 * 60 * 5,
   });
 
-  const { handleDelete } = useDeletePostHandler();
+  const { mutate: deleteInquiryMutate } = useMutation({
+    mutationFn: () => deleteInquiry(postId),
+    onSuccess: () => {
+      navigate(-1);
+    },
+    onError: (error) => {
+      toast({ message: error.message, variant: 'error' });
+    },
+  });
 
   const onMenuOpen = () => {
     const id = data.isWriter ? 'my-post-more-options' : 'post-more-options';
@@ -57,7 +68,7 @@ function InquiryDetailLoader() {
   return (
     <PostDetailView
       data={data}
-      deletePost={handleDelete}
+      deletePost={deleteInquiryMutate}
       PostActionBar={
         <PostActionBar>
           <PostActionBar.Comment {...data} />

--- a/src/shared/component/modal/ConfirmModal/ConfirmModal.jsx
+++ b/src/shared/component/modal/ConfirmModal/ConfirmModal.jsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
 
-import { ModalContext } from '@/shared/context/ModalContext';
 import { DimModalLayout } from '@/shared/component';
+import { ModalContext } from '@/shared/context/ModalContext';
 
 import styles from './ConfirmModal.module.css';
 
@@ -10,6 +10,11 @@ export default function ConfirmModal({ modalText, onConfirm, onCancel }) {
 
   const handleCancel = () => {
     onCancel?.() || setModal({ id: null, type: null });
+  };
+
+  const handleConfirm = () => {
+    onConfirm();
+    setModal({ id: null, type: null });
   };
 
   return (
@@ -36,7 +41,7 @@ export default function ConfirmModal({ modalText, onConfirm, onCancel }) {
         <div className={styles.buttonDivider} />
         <button
           className={`${styles.bottomButton} ${styles.rightHover}`}
-          onClick={onConfirm}
+          onClick={handleConfirm}
         >
           {modalText.confirmText}
         </button>


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1585

- [Notion](https://www.notion.so/snorose/2ec7ef0aa3bf800982a8f44c49ef05d1?source=copy_link)

## 🎯 변경 사항

### 문의 삭제 API 연동
- 문의 게시글을 삭제하기 위한 새로운 API 엔드포인트와 관련 로직을 추가했습니다.

### PostModalRenderer 개선
- 문의 게시판에 대한 모달 옵션을 동적으로 처리하도록 PostModalRenderer 컴포넌트를 수정하여, 문의 게시글의 편집 및 삭제 옵션을 적절하게 표시합니다.

### 문의 상세 페이지에 삭제 기능 통합
- 문의 상세 페이지에서 useMutation 훅을 사용하여 문의 삭제 API를 호출하고, 성공 시 페이지 이동 및 에러 발생 시 토스트 메시지를 표시하도록 기능을 통합했습니다.

### ConfirmModal 동작 개선
- ConfirmModal에서 확인 버튼 클릭 시 onConfirm 함수 호출 후 모달이 자동으로 닫히도록 로직을 개선했습니다.

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
