### PR TITLE
[SNO-365] #1594 신고 삭제 API 연동

### DIFF
--- a/src/feature/support/api/report.ts
+++ b/src/feature/support/api/report.ts
@@ -136,3 +136,26 @@ export const updateReport = async ({
     }
   }
 };
+
+export const deleteReport = async (postId: string) => {
+  try {
+    const response = await authAxios.delete(`/v1/reports/report/${postId}`);
+
+    return response.data.result;
+  } catch (error) {
+    const response = error?.response;
+
+    if (!response) {
+      throw new Error('네트워크 통신 중 오류가 발생했어요');
+    }
+
+    switch (response.data.code) {
+      case 6101:
+        throw new Error('존재하지 않는 게시글이에요');
+      case 6102:
+        throw new Error('답변 완료된 글은 삭제할 수 없어요');
+      default:
+        throw new Error('잠시 후 다시 시도해주세요.');
+    }
+  }
+};

--- a/src/mock/handler/report.ts
+++ b/src/mock/handler/report.ts
@@ -173,7 +173,7 @@ export const reportHandlers = [
     // return HttpResponse.error();
   }),
 
-  http.delete('*/v1/reports/report/:reoprtId', async () => {
+  http.delete('*/v1/reports/report/:reportId', async () => {
     // 성공
     return HttpResponse.json({
       isSuccess: true,

--- a/src/mock/handler/report.ts
+++ b/src/mock/handler/report.ts
@@ -71,7 +71,7 @@ export const reportHandlers = [
         content: '신고 내용',
         reportType: 'COMMENT',
         reportCategory: 'COMMENT_INSULT_OR_DEFAMATION',
-        status: 'COMPLETED',
+        status: 'PENDING',
         commentCount: 0,
         createdAt: '2025-08-30T22:47:09.234619',
         updatedAt: null,
@@ -164,6 +164,51 @@ export const reportHandlers = [
     //   {
     //     isSuccess: false,
     //     code: 12,
+    //     message: '해당 게시글을 찾을 수 없습니다',
+    //   },
+    //   { status: 500 }
+    // );
+
+    // 실패 - 네트워크 오류
+    // return HttpResponse.error();
+  }),
+
+  http.delete('*/v1/reports/report/:reoprtId', async () => {
+    // 성공
+    return HttpResponse.json({
+      isSuccess: true,
+      code: 1000,
+      message: '요청에 성공하였습니다.',
+      result: {
+        postId: 3,
+      },
+    });
+
+    // 실패 - 답변 완료인 경우
+    // return HttpResponse.json(
+    //   {
+    //     isSuccess: false,
+    //     code: 6102,
+    //     message: '답변 완료된 글을 삭제할 수 없습니다.',
+    //   },
+    //   { status: 403 }
+    // );
+
+    // 실패 - 없거나 삭제된 경우
+    // return HttpResponse.json(
+    //   {
+    //     isSuccess: false,
+    //     code: 6101,
+    //     message: '해당 게시글을 찾을 수 없습니다',
+    //   },
+    //   { status: 404 }
+    // );
+
+    // 실패 - 서버 오류
+    // return HttpResponse.json(
+    //   {
+    //     isSuccess: false,
+    //     code: 3031,
     //     message: '해당 게시글을 찾을 수 없습니다',
     //   },
     //   { status: 500 }

--- a/src/page/support/InquiryDetailPage.jsx
+++ b/src/page/support/InquiryDetailPage.jsx
@@ -21,8 +21,6 @@ import { CommentInputContainer } from '@/feature/comment/component';
 import { deleteInquiry, readInquiry } from '@/feature/support/api';
 import { INQUIRY_STATUS_MAP } from '@/feature/support/constant';
 
-import { NotFoundPage } from '@/page/etc';
-
 export default function InquiryDetailPage() {
   return (
     <ErrorBoundary FallbackComponent={ErrorFallback}>

--- a/src/page/support/ReportDetailPage.jsx
+++ b/src/page/support/ReportDetailPage.jsx
@@ -2,7 +2,7 @@ import { Suspense, useContext } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 
 import {
   BackAppBar,
@@ -13,12 +13,12 @@ import {
 } from '@/shared/component';
 import { NOTICE_MODAL_TEXT, QUERY_KEY } from '@/shared/constant';
 import { ModalContext } from '@/shared/context/ModalContext';
+import { useToast } from '@/shared/hook';
 
 import { MeatBallIcon, PostActionBar } from '@/feature/board/component';
-import { useDeletePostHandler } from '@/feature/board/hook/useDeletePostHandler';
 import { PostDetailView } from '@/feature/board/ui';
 import { CommentInputContainer } from '@/feature/comment/component';
-import { readReport } from '@/feature/support/api';
+import { deleteReport, readReport } from '@/feature/support/api';
 import { REPORT_STATUS_MAP } from '@/feature/support/constant';
 
 export default function ReportDetailPage() {
@@ -32,8 +32,11 @@ export default function ReportDetailPage() {
 }
 
 function ReportDetailLoader() {
+  const navigate = useNavigate();
   const { postId } = useParams();
   const { setModal } = useContext(ModalContext);
+
+  const { toast } = useToast();
 
   const { data } = useSuspenseQuery({
     queryKey: QUERY_KEY.post(postId),
@@ -41,7 +44,15 @@ function ReportDetailLoader() {
     staleTime: 1000 * 60 * 5,
   });
 
-  const { handleDelete } = useDeletePostHandler();
+  const { mutate: deleteReportMutate } = useMutation({
+    mutationFn: deleteReport,
+    onSuccess: () => {
+      navigate(-1);
+    },
+    onError: (error) => {
+      toast({ message: error.message, variant: 'error' });
+    },
+  });
 
   const onMenuOpen = () => {
     const id = data.isWriter ? 'my-post-more-options' : 'post-more-options';
@@ -55,7 +66,7 @@ function ReportDetailLoader() {
   return (
     <PostDetailView
       data={data}
-      deletePost={handleDelete}
+      deletePost={deleteReportMutate}
       PostActionBar={
         <PostActionBar>
           <PostActionBar.Comment {...data} />

--- a/src/page/support/ReportDetailPage.jsx
+++ b/src/page/support/ReportDetailPage.jsx
@@ -45,7 +45,7 @@ function ReportDetailLoader() {
   });
 
   const { mutate: deleteReportMutate } = useMutation({
-    mutationFn: deleteReport,
+    mutationFn: () => deleteReport(postId),
     onSuccess: () => {
       navigate(-1);
     },


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1594

- [Notion](https://www.notion.so/snorose/2ec7ef0aa3bf809ea1dccec85ae39ad7?source=copy_link)

## 🎯 변경 사항

### 신고 삭제 API 연동
- 신고 삭제 기능을 위한 새로운 API 클라이언트 함수 deleteReport가 추가되었습니다.
- ReportDetailPage에 useMutation 훅을 사용하여 삭제 요청을 관리하며, 성공 시 이전 페이지로 이동하고 실패 시 토스트 메시지로 사용자에게 알립니다. 기존의 useDeletePostHandler는 제거되었습니다.

### Mock API 핸들러 추가 및 수정
- 개발 및 테스트를 위해 src/mock/handler/report.ts에 신고 삭제를 위한 DELETE 요청 핸들러가 추가되었습니다.

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
