### PR TITLE
[SNO-401] #1622 AttachmentBar이 키보드 생성 시 같이 올라가도록 수정

### DIFF
--- a/src/feature/attachment/hook/attachment.js
+++ b/src/feature/attachment/hook/attachment.js
@@ -1,44 +1,21 @@
-import { useEffect, useRef } from 'react';
 import { useToast } from '@/shared/hook';
-import { ATTACHMENT_SIZE_LIMIT } from '@/shared/constant';
+
 import {
+  checkIfFilesContainUnusableChar,
+  checkIfImage,
+  checkIfVideo,
+  checkImageQuantity,
+  checkImageSize,
+  checkVideoQuantity,
+  checkVideoSize,
   combineFilters,
   filterOversizedImage,
   filterOversizedVideo,
   filterUnusableCharNamedAtts,
-  checkIfImage,
-  checkImageQuantity,
-  checkImageSize,
-  checkIfVideo,
-  checkVideoQuantity,
-  checkVideoSize,
-  checkIfFilesContainUnusableChar,
 } from '@/feature/attachment/lib';
 
 export function useAttachmentUpload({ attachmentsInfo, setAttachmentsInfo }) {
   const { toast } = useToast();
-  const attachmentBarRef = useRef();
-
-  useEffect(() => {
-    const vv = window.visualViewport;
-    const handler = () => {
-      requestAnimationFrame(() => {
-        const keyboardHeight = window.innerHeight - vv.height;
-        const offsetTop = vv.offsetTop;
-
-        attachmentBarRef.current.style.transform =
-          keyboardHeight > 0
-            ? `translateY(-${keyboardHeight - offsetTop}px)`
-            : `translateY(0px)`;
-      });
-    };
-    vv.addEventListener('resize', handler);
-    vv.addEventListener('scroll', handler);
-    return () => {
-      vv.removeEventListener('resize', handler);
-      vv.removeEventListener('scroll', handler);
-    };
-  }, [attachmentBarRef]);
 
   const changeImageUpload = (e) => {
     const newFiles = Array.from(e.target.files);
@@ -121,7 +98,6 @@ export function useAttachmentUpload({ attachmentsInfo, setAttachmentsInfo }) {
   };
 
   return {
-    attachmentBarRef,
     changeImageUpload,
     changeVideoUpload,
   };

--- a/src/feature/attachment/hook/attachment.js
+++ b/src/feature/attachment/hook/attachment.js
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { useToast } from '@/shared/hook';
 import { ATTACHMENT_SIZE_LIMIT } from '@/shared/constant';
 import {
@@ -16,6 +17,29 @@ import {
 
 export function useAttachmentUpload({ attachmentsInfo, setAttachmentsInfo }) {
   const { toast } = useToast();
+  const attachmentBarRef = useRef();
+
+  useEffect(() => {
+    const vv = window.visualViewport;
+    const handler = () => {
+      requestAnimationFrame(() => {
+        const keyboardHeight = window.innerHeight - vv.height;
+        const offsetTop = vv.offsetTop;
+
+        attachmentBarRef.current.style.transform =
+          keyboardHeight > 0
+            ? `translateY(-${keyboardHeight - offsetTop}px)`
+            : `translateY(0px)`;
+      });
+    };
+    vv.addEventListener('resize', handler);
+    vv.addEventListener('scroll', handler);
+    return () => {
+      vv.removeEventListener('resize', handler);
+      vv.removeEventListener('scroll', handler);
+    };
+  }, [attachmentBarRef]);
+
   const changeImageUpload = (e) => {
     const newFiles = Array.from(e.target.files);
     const filteredFileArray = combineFilters(
@@ -97,6 +121,7 @@ export function useAttachmentUpload({ attachmentsInfo, setAttachmentsInfo }) {
   };
 
   return {
+    attachmentBarRef,
     changeImageUpload,
     changeVideoUpload,
   };

--- a/src/feature/attachment/hook/index.js
+++ b/src/feature/attachment/hook/index.js
@@ -1,2 +1,3 @@
 export * from './attachment';
+export * from './useAttachmentBarPosition';
 export { default as useGuide } from './useGuide';

--- a/src/feature/attachment/hook/useAttachmentBarPosition.js
+++ b/src/feature/attachment/hook/useAttachmentBarPosition.js
@@ -1,0 +1,69 @@
+import { useEffect, useRef } from 'react';
+
+const IOS_KEYBOARD_TOOLBAR = 44;
+const VV_EVENTS = ['resize', 'scroll'];
+const DOC_EVENTS = ['focusin', 'focusout'];
+
+const isIOS = () =>
+  /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+  (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+
+const isAndroid = () => /Android/i.test(navigator.userAgent);
+
+const getIOSToolbarOffset = () => {
+  const el = document.activeElement;
+  if (!el || el.isContentEditable) return 0;
+  if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') {
+    return IOS_KEYBOARD_TOOLBAR;
+  }
+  return 0;
+};
+
+const computeIOSOffset = (vv) =>
+  Math.max(
+    0,
+    window.innerHeight - vv.height - vv.offsetTop - getIOSToolbarOffset()
+  );
+
+const computeAndroidOffset = (vv) => {
+  const keyboardHeight = window.innerHeight - vv.height;
+  return keyboardHeight > 0 ? keyboardHeight - vv.offsetTop : 0;
+};
+
+export function useAttachmentBarPosition() {
+  const attachmentBarRef = useRef(null);
+
+  useEffect(() => {
+    const vv = window.visualViewport;
+    if (!vv) return;
+
+    const computeOffset = isIOS()
+      ? computeIOSOffset
+      : isAndroid()
+        ? computeAndroidOffset
+        : null;
+    if (!computeOffset) return;
+
+    const bar = attachmentBarRef.current;
+
+    const updatePosition = () => {
+      if (!bar) return;
+      bar.style.transform = `translateY(-${computeOffset(vv)}px)`;
+    };
+
+    const handler = () => requestAnimationFrame(updatePosition);
+    VV_EVENTS.forEach((e) => vv.addEventListener(e, handler));
+    DOC_EVENTS.forEach((e) => document.addEventListener(e, handler));
+    updatePosition();
+
+    return () => {
+      VV_EVENTS.forEach((e) => vv.removeEventListener(e, handler));
+      DOC_EVENTS.forEach((e) => document.removeEventListener(e, handler));
+      if (bar) {
+        bar.style.transform = '';
+      }
+    };
+  }, []);
+
+  return attachmentBarRef;
+}

--- a/src/feature/board/component/AttachmentBar/AttachmentBar.jsx
+++ b/src/feature/board/component/AttachmentBar/AttachmentBar.jsx
@@ -3,7 +3,10 @@ import { React, useRef, useState } from 'react';
 import { Icon } from '@/shared/component';
 import { ATTACHMENT_EXTENSION_LIMIT } from '@/shared/constant';
 
-import { useAttachmentUpload } from '@/feature/attachment/hook';
+import {
+  useAttachmentBarPosition,
+  useAttachmentUpload,
+} from '@/feature/attachment/hook';
 import { FixedMenuEditor } from '@/feature/editor/component';
 
 import styles from './AttachmentBar.module.css';
@@ -16,11 +19,11 @@ export default function AttachmentBar({
   const img = useRef();
   const vid = useRef();
 
-  const { attachmentBarRef, changeImageUpload, changeVideoUpload } =
-    useAttachmentUpload({
-      attachmentsInfo,
-      setAttachmentsInfo,
-    });
+  const attachmentBarRef = useAttachmentBarPosition();
+  const { changeImageUpload, changeVideoUpload } = useAttachmentUpload({
+    attachmentsInfo,
+    setAttachmentsInfo,
+  });
 
   //이미지*영상* 에디터 첨부 버튼의 UI 상태를 좌우함
   const [isImageIconHighlighted, setIsImageIconHighlighted] = useState(false);

--- a/src/feature/board/component/AttachmentBar/AttachmentBar.jsx
+++ b/src/feature/board/component/AttachmentBar/AttachmentBar.jsx
@@ -8,14 +8,19 @@ import { FixedMenuEditor } from '@/feature/editor/component';
 
 import styles from './AttachmentBar.module.css';
 
-export default function AttachmentBar({ attachmentsInfo, setAttachmentsInfo, editor }) {
+export default function AttachmentBar({
+  attachmentsInfo,
+  setAttachmentsInfo,
+  editor,
+}) {
   const img = useRef();
   const vid = useRef();
 
-  const { changeImageUpload, changeVideoUpload } = useAttachmentUpload({
-    attachmentsInfo,
-    setAttachmentsInfo,
-  });
+  const { attachmentBarRef, changeImageUpload, changeVideoUpload } =
+    useAttachmentUpload({
+      attachmentsInfo,
+      setAttachmentsInfo,
+    });
 
   //이미지*영상* 에디터 첨부 버튼의 UI 상태를 좌우함
   const [isImageIconHighlighted, setIsImageIconHighlighted] = useState(false);
@@ -23,10 +28,8 @@ export default function AttachmentBar({ attachmentsInfo, setAttachmentsInfo, edi
   const [isEditorOpen, setIsEditorOpen] = useState(false);
 
   return (
-    <div className={styles.bar}>
-      {isEditorOpen && editor && (
-        <FixedMenuEditor editor={editor} />
-      )}
+    <div ref={attachmentBarRef} className={styles.bar}>
+      {isEditorOpen && editor && <FixedMenuEditor editor={editor} />}
       <div className={styles.attachmentBar}>
         <Icon
           id={isImageIconHighlighted ? 'image-fill' : 'image'}
@@ -72,9 +75,8 @@ export default function AttachmentBar({ attachmentsInfo, setAttachmentsInfo, edi
           width={27}
           height={21}
           className={styles.image}
-          onClick={() => setIsEditorOpen(prev => !prev)}
+          onClick={() => setIsEditorOpen((prev) => !prev)}
         />
-        
       </div>
     </div>
   );


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1622

- [Notion](https://www.notion.so/snorose/AttachmentBar-3537ef0aa3bf80449b2fc244cd78dc5f?source=copy_link)

## 🎯 변경 사항

- 대상 기능: AttachmentBar와 에디터
- 변경 이유: 모바일 환경에서도 에디터 활용이 용이하도록 
AttachmentBar이 키보드 생성 시 같이 올라가도록 수정했습니다.

작업 내역: https://capprojectfactory.tistory.com/143


## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
- 다양한 기종에서 동일하게 잘 작동하는지 확인해주세요!
    -  갤럭시 노트 9에서는 약간 버벅거리면서 작동
    - 갤럭시 탭 S7 FE에서는 버벅거림 없이 잘 작동
