### PR TITLE
[SNO-426] 문의 및 신고 작성/수정 완료 확인 모달 표시

### DIFF
--- a/src/feature/support/ui/FileUploadSection.tsx
+++ b/src/feature/support/ui/FileUploadSection.tsx
@@ -14,11 +14,11 @@ const MAX_TOTAL_FILE_SIZE = 10 * 1024 * 1024;
 export default function FileUploadSection({
   currentFileCount,
   curruentTotalFileSize,
-  updateFiles,
+  setFiles,
 }: {
   currentFileCount: number;
   curruentTotalFileSize: number;
-  updateFiles: (file: UploadFile[]) => void;
+  setFiles: React.Dispatch<React.SetStateAction<UploadFile[]>>;
 }) {
   const id = useId();
   const { toast } = useToast();
@@ -89,9 +89,10 @@ export default function FileUploadSection({
             return;
           }
 
-          updateFiles(
-            selectedFiles.map((file) => ({ file, id: crypto.randomUUID() }))
-          );
+          setFiles((prev) => [
+            ...prev,
+            ...selectedFiles.map((file) => ({ file, id: crypto.randomUUID() })),
+          ]);
 
           e.target.value = '';
         }}

--- a/src/feature/support/ui/SupportFormView.tsx
+++ b/src/feature/support/ui/SupportFormView.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useContext } from 'react';
 
 import {
   CloseAppBar,
@@ -8,10 +8,10 @@ import {
   TextareaFieldBlue,
   TextFieldBlue,
 } from '@/shared/component';
+import { ModalContext } from '@/shared/context/ModalContext';
 import { useAuth } from '@/shared/hook';
 
-import type { Attachment, UploadFile } from '@/feature/attachment/types';
-import type { InquiryDTO, ReportDTO } from '@/feature/support/types';
+import { Attachment, UploadFile } from '@/feature/attachment/types';
 import { FileUploadSection, SubmitButton } from '@/feature/support/ui';
 
 import { Option } from '@/types';
@@ -19,7 +19,20 @@ import { Option } from '@/types';
 import styles from './SupportFormView.module.css';
 
 type SupportFormViewProps = {
-  submit: (values: SupportAllState) => void;
+  title: string;
+  content: string;
+  selectedOption?: Option;
+  attachments: Attachment[];
+  files: UploadFile[];
+  url?: string;
+
+  setTitle: React.Dispatch<React.SetStateAction<string>>;
+  setContent: React.Dispatch<React.SetStateAction<string>>;
+  setSelectedOption: React.Dispatch<React.SetStateAction<Option | undefined>>;
+  setAttachments: React.Dispatch<React.SetStateAction<Attachment[]>>;
+  setFiles: React.Dispatch<React.SetStateAction<UploadFile[]>>;
+  setUrl?: React.Dispatch<React.SetStateAction<string>>;
+
   options: readonly Option[];
   contentLabel: string;
   placeholders: {
@@ -27,50 +40,37 @@ type SupportFormViewProps = {
     title: string;
     content: string;
   };
-  post?: InquiryDTO | ReportDTO;
-  initialOption?: Option;
-  initialLink?: string;
+
+  modalId: string;
   showLinkField?: boolean;
   tag?: string;
 };
 
-export type SupportAllState = {
-  selectedOption: Option;
-  title: string;
-  url: string;
-  content: string;
-  attachments: Attachment[];
-  files: UploadFile[];
-};
-
 export default function SupportFormView({
-  post,
-  submit,
+  title,
+  content,
+  url,
+  selectedOption,
+  attachments,
+  files,
+
+  setTitle,
+  setContent,
+  setUrl,
+  setSelectedOption,
+  setAttachments,
+  setFiles,
+
   options,
   contentLabel,
   placeholders,
-  initialOption,
-  initialLink,
+
   tag,
   showLinkField = false,
+  modalId,
 }: SupportFormViewProps) {
   const { userInfo } = useAuth();
-
-  const [selectedOption, setSelectedOption] = useState<Option | undefined>(
-    initialOption
-  );
-  const [title, setTitle] = useState(post?.title ?? '');
-  const [url, setUrl] = useState(initialLink ?? '');
-  const [content, setContent] = useState(post?.content ?? '');
-  const [attachments, setAttachments] = useState<Attachment[]>(
-    post?.attachments ?? []
-  );
-  const [files, setFiles] = useState<UploadFile[]>([]);
-
-  const updateOption = (option: Option) => setSelectedOption(option);
-
-  const updateFiles = (files: UploadFile[]) =>
-    setFiles((prev) => [...prev, ...files]);
+  const { setModal } = useContext(ModalContext);
 
   const handleRemoveAttachment = (targetId: number) =>
     setAttachments((prev) => prev.filter(({ id }) => id !== targetId));
@@ -89,16 +89,9 @@ export default function SupportFormView({
     <div className={styles.container}>
       <CloseAppBar backgroundColor={'#eaf5fd'}>
         <SubmitButton
-          onClick={() =>
-            submit({
-              selectedOption: selectedOption!,
-              title,
-              url,
-              content,
-              attachments,
-              files,
-            })
-          }
+          onClick={() => {
+            setModal({ id: modalId, type: null });
+          }}
           disabled={disabled}
         >
           등록
@@ -117,7 +110,7 @@ export default function SupportFormView({
               key={option.key}
               id={option.key}
               selected={selectedOption?.key === option.key}
-              onClick={() => updateOption(option)}
+              onClick={() => setSelectedOption(option)}
             >
               {option.label}
             </DropdownBlue.Item>
@@ -165,7 +158,7 @@ export default function SupportFormView({
             (total, { file }) => total + file.size,
             0
           )}
-          updateFiles={updateFiles}
+          setFiles={setFiles}
         />
 
         <div className={styles.fileContainer}>

--- a/src/page/support/EditInquiryPage.tsx
+++ b/src/page/support/EditInquiryPage.tsx
@@ -1,11 +1,20 @@
+import { useContext, useState } from 'react';
 import { useLoaderData, useNavigate, useParams } from 'react-router-dom';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { BOARD_ID, QUERY_KEY, TOAST } from '@/shared/constant';
+import { ConfirmModal } from '@/shared/component';
+import {
+  BOARD_ID,
+  CONFIRM_MODAL_TEXT,
+  QUERY_KEY,
+  TOAST,
+} from '@/shared/constant';
+import { ModalContext } from '@/shared/context/ModalContext';
 import { useToast } from '@/shared/hook';
 
 import { mapFileToAttachment } from '@/feature/attachment/lib';
+import { Attachment, UploadFile } from '@/feature/attachment/types';
 import { updateInquiry } from '@/feature/support/api';
 import { INQUIRY_PLACEHOLDERS } from '@/feature/support/constant';
 import { INQUIRY_OPTIONS } from '@/feature/support/data';
@@ -13,6 +22,7 @@ import type { InquiryDTO } from '@/feature/support/types';
 import { SupportFormView } from '@/feature/support/ui';
 
 import { createThumbnail } from '@/apis';
+import { Option } from '@/types';
 
 export default function EditInquiryPage() {
   const post = useLoaderData() as InquiryDTO;
@@ -22,10 +32,27 @@ export default function EditInquiryPage() {
 
   const queryClient = useQueryClient();
 
+  const { modal, setModal } = useContext(ModalContext);
   const { toast } = useToast();
 
-  const { mutate: submit } = useMutation({
-    mutationFn: updateInquiry,
+  const { mutate: submitInquiry } = useMutation({
+    mutationFn: () => {
+      const originalIds = post.attachments.map((at) => at.id);
+      const remainingIds = new Set(attachments.map((at) => at.id));
+      const deletedIds = originalIds.filter((id) => !remainingIds.has(id));
+
+      return updateInquiry({
+        postId,
+        title,
+        content,
+        targetUrl: url,
+        inquiryCategory: selectedOption.key,
+        oldAttachments: attachments,
+        newAttachments: files.map(mapFileToAttachment),
+        deleteAttachments: deletedIds,
+      });
+    },
+
     onSuccess: (data) => {
       const { postId } = data;
 
@@ -43,40 +70,52 @@ export default function EditInquiryPage() {
 
       navigate(`/inquiry/${postId}`, { replace: true });
     },
+
     onError: (error) => {
       toast({ message: error.message, variant: 'error' });
     },
   });
 
-  const { dropdown, title, content } = INQUIRY_PLACEHOLDERS;
+  const [title, setTitle] = useState(post?.title ?? '');
+  const [content, setContent] = useState(post?.content ?? '');
+  const [url, setUrl] = useState(post.link ?? '');
+  const [selectedOption, setSelectedOption] = useState<Option | undefined>(
+    INQUIRY_OPTIONS.find((option) => option.key === post.inquiryCategory)
+  );
+  const [attachments, setAttachments] = useState<Attachment[]>(
+    post?.attachments ?? []
+  );
+  const [files, setFiles] = useState<UploadFile[]>([]);
 
   return (
-    <SupportFormView
-      post={post}
-      initialOption={INQUIRY_OPTIONS.find(
-        (option) => option.key === post.inquiryCategory
-      )}
-      initialLink={post.link}
-      submit={({ selectedOption, title, url, content, attachments, files }) => {
-        const originalIds = post.attachments.map((at) => at.id);
-        const remainingIds = new Set(attachments.map((at) => at.id));
-        const deletedIds = originalIds.filter((id) => !remainingIds.has(id));
+    <>
+      <SupportFormView
+        title={title}
+        content={content}
+        url={url}
+        selectedOption={selectedOption}
+        attachments={attachments}
+        files={files}
+        setTitle={setTitle}
+        setContent={setContent}
+        setUrl={setUrl}
+        setSelectedOption={setSelectedOption}
+        setAttachments={setAttachments}
+        setFiles={setFiles}
+        options={INQUIRY_OPTIONS}
+        contentLabel={'문의 내용'}
+        placeholders={INQUIRY_PLACEHOLDERS}
+        showLinkField
+        modalId='confirm-inquiry-update'
+      />
 
-        submit({
-          postId,
-          title,
-          content,
-          targetUrl: url,
-          inquiryCategory: selectedOption.key,
-          oldAttachments: attachments,
-          newAttachments: files.map(mapFileToAttachment),
-          deleteAttachments: deletedIds,
-        });
-      }}
-      options={INQUIRY_OPTIONS}
-      contentLabel={'문의 내용'}
-      placeholders={{ dropdown, title, content }}
-      showLinkField
-    />
+      {modal.id === 'confirm-inquiry-update' && (
+        <ConfirmModal
+          modalText={CONFIRM_MODAL_TEXT.INQUIRY_UPDATE}
+          onConfirm={submitInquiry}
+          onCancel={() => setModal({ id: null })}
+        />
+      )}
+    </>
   );
 }

--- a/src/page/support/EditInquiryPage.tsx
+++ b/src/page/support/EditInquiryPage.tsx
@@ -46,7 +46,7 @@ export default function EditInquiryPage() {
         title,
         content,
         targetUrl: url,
-        inquiryCategory: selectedOption.key,
+        inquiryCategory: selectedOption!.key,
         oldAttachments: attachments,
         newAttachments: files.map(mapFileToAttachment),
         deleteAttachments: deletedIds,

--- a/src/page/support/EditInquiryPage.tsx
+++ b/src/page/support/EditInquiryPage.tsx
@@ -42,7 +42,7 @@ export default function EditInquiryPage() {
       const deletedIds = originalIds.filter((id) => !remainingIds.has(id));
 
       return updateInquiry({
-        postId,
+        postId: postId!,
         title,
         content,
         targetUrl: url,

--- a/src/page/support/EditReportPage/EditReportPage.tsx
+++ b/src/page/support/EditReportPage/EditReportPage.tsx
@@ -1,11 +1,20 @@
+import { useContext, useState } from 'react';
 import { useLoaderData, useNavigate, useParams } from 'react-router-dom';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { BOARD_ID, QUERY_KEY, TOAST } from '@/shared/constant';
+import { ConfirmModal } from '@/shared/component';
+import {
+  BOARD_ID,
+  CONFIRM_MODAL_TEXT,
+  QUERY_KEY,
+  TOAST,
+} from '@/shared/constant';
+import { ModalContext } from '@/shared/context/ModalContext';
 import { useToast } from '@/shared/hook';
 
 import { mapFileToAttachment } from '@/feature/attachment/lib';
+import { Attachment, UploadFile } from '@/feature/attachment/types';
 import { updateReport } from '@/feature/support/api';
 import {
   REPORT_PLACEHOLDERS,
@@ -16,6 +25,7 @@ import type { ReportDTO } from '@/feature/support/types';
 import { SupportFormView } from '@/feature/support/ui';
 
 import { createThumbnail } from '@/apis';
+import { Option } from '@/types';
 
 export default function EditReportPage() {
   const post = useLoaderData() as ReportDTO;
@@ -26,10 +36,26 @@ export default function EditReportPage() {
 
   const queryClient = useQueryClient();
 
+  const { modal, setModal } = useContext(ModalContext);
   const { toast } = useToast();
 
-  const { mutate: submit } = useMutation({
-    mutationFn: updateReport,
+  const { mutate: submitReport } = useMutation({
+    mutationFn: () => {
+      const originalIds = post.attachments.map((at) => at.id);
+      const remainingIds = new Set(attachments.map((at) => at.id));
+      const deletedIds = originalIds.filter((id) => !remainingIds.has(id));
+
+      return updateReport({
+        postId,
+        title,
+        content,
+        reportCategory: selectedOption.key,
+        oldAttachments: attachments,
+        newAttachments: files.map(mapFileToAttachment),
+        deleteAttachments: deletedIds,
+      });
+    },
+
     onSuccess: (data) => {
       const { postId } = data;
 
@@ -47,39 +73,51 @@ export default function EditReportPage() {
 
       navigate(`/report/${postId}`, { replace: true });
     },
+
     onError: (error) => {
-      console.log(error);
       toast({ message: error.message, variant: 'error' });
     },
   });
 
-  const { dropdown, title, content } = REPORT_PLACEHOLDERS[reportType];
+  const [title, setTitle] = useState(post?.title ?? '');
+  const [content, setContent] = useState(post?.content ?? '');
+  const [selectedOption, setSelectedOption] = useState<Option | undefined>(
+    REPORT_OPTIONS[reportType].find(
+      (option) => option.key === post.inquiryCategory
+    )
+  );
+  const [attachments, setAttachments] = useState<Attachment[]>(
+    post?.attachments ?? []
+  );
+  const [files, setFiles] = useState<UploadFile[]>([]);
 
   return (
-    <SupportFormView
-      post={post}
-      initialOption={REPORT_OPTIONS[reportType].find(
-        (option) => option.key === post.inquiryCategory
-      )}
-      submit={({ title, content, selectedOption, attachments, files }) => {
-        const originalIds = post.attachments.map((at) => at.id);
-        const remainingIds = new Set(attachments.map((at) => at.id));
-        const deletedIds = originalIds.filter((id) => !remainingIds.has(id));
+    <>
+      <SupportFormView
+        title={title}
+        content={content}
+        selectedOption={selectedOption}
+        attachments={attachments}
+        files={files}
+        setTitle={setTitle}
+        setContent={setContent}
+        setSelectedOption={setSelectedOption}
+        setAttachments={setAttachments}
+        setFiles={setFiles}
+        options={REPORT_OPTIONS[reportType]}
+        contentLabel={'신고 내용'}
+        placeholders={REPORT_PLACEHOLDERS[reportType]}
+        tag={REPORT_TYPE_TAG[reportType]}
+        modalId='confirm-report-update'
+      />
 
-        submit({
-          postId,
-          title,
-          content,
-          reportCategory: selectedOption.key,
-          oldAttachments: attachments,
-          newAttachments: files.map(mapFileToAttachment),
-          deleteAttachments: deletedIds,
-        });
-      }}
-      options={REPORT_OPTIONS[reportType]}
-      contentLabel={'신고 내용'}
-      placeholders={{ dropdown, title, content }}
-      tag={REPORT_TYPE_TAG[reportType]}
-    />
+      {modal.id === 'confirm-report-update' && (
+        <ConfirmModal
+          modalText={CONFIRM_MODAL_TEXT.REPORT_UPDATE}
+          onConfirm={submitReport}
+          onCancel={() => setModal({ id: null })}
+        />
+      )}
+    </>
   );
 }

--- a/src/page/support/EditReportPage/EditReportPage.tsx
+++ b/src/page/support/EditReportPage/EditReportPage.tsx
@@ -46,10 +46,10 @@ export default function EditReportPage() {
       const deletedIds = originalIds.filter((id) => !remainingIds.has(id));
 
       return updateReport({
-        postId,
+        postId: postId!,
         title,
         content,
-        reportCategory: selectedOption.key,
+        reportCategory: selectedOption!.key,
         oldAttachments: attachments,
         newAttachments: files.map(mapFileToAttachment),
         deleteAttachments: deletedIds,

--- a/src/page/support/EditReportPage/EditReportPage.tsx
+++ b/src/page/support/EditReportPage/EditReportPage.tsx
@@ -67,7 +67,7 @@ export default function EditReportPage() {
            */
         });
 
-      toast({ message: TOAST.INQUIRY.update, variant: 'success' });
+      toast({ message: TOAST.REPORT.update, variant: 'success' });
 
       queryClient.invalidateQueries({ queryKey: QUERY_KEY.post(postId) });
 

--- a/src/page/support/WriteInquiryPage.tsx
+++ b/src/page/support/WriteInquiryPage.tsx
@@ -36,7 +36,7 @@ export default function WriteInquiryPage() {
       createInquiry({
         title,
         content,
-        inquiryCategory: selectedOption.key,
+        inquiryCategory: selectedOption!.key,
         target: url,
         attachments: files.map(mapFileToAttachment),
       }),

--- a/src/page/support/WriteInquiryPage.tsx
+++ b/src/page/support/WriteInquiryPage.tsx
@@ -1,27 +1,46 @@
+import { useContext, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { BOARD_ID, QUERY_KEY, TOAST } from '@/shared/constant';
+import { ConfirmModal } from '@/shared/component';
+import {
+  BOARD_ID,
+  CONFIRM_MODAL_TEXT,
+  QUERY_KEY,
+  TOAST,
+} from '@/shared/constant';
+import { ModalContext } from '@/shared/context/ModalContext';
 import { useToast } from '@/shared/hook';
 
 import { mapFileToAttachment } from '@/feature/attachment/lib';
+import { Attachment, UploadFile } from '@/feature/attachment/types';
 import { createInquiry } from '@/feature/support/api';
 import { INQUIRY_PLACEHOLDERS } from '@/feature/support/constant';
 import { INQUIRY_OPTIONS } from '@/feature/support/data';
 import { SupportFormView } from '@/feature/support/ui';
 
 import { createThumbnail } from '@/apis';
+import { Option } from '@/types';
 
 export default function WriteInquiryPage() {
   const navigate = useNavigate();
 
   const queryClient = useQueryClient();
 
+  const { modal, setModal } = useContext(ModalContext);
   const { toast } = useToast();
 
   const { mutate: submitInquiry } = useMutation({
-    mutationFn: createInquiry,
+    mutationFn: () =>
+      createInquiry({
+        title,
+        content,
+        inquiryCategory: selectedOption.key,
+        target: url,
+        attachments: files.map(mapFileToAttachment),
+      }),
+
     onSuccess: (data) => {
       const { postId } = data;
 
@@ -41,28 +60,50 @@ export default function WriteInquiryPage() {
 
       navigate(`/inquiry/${postId}`, { replace: true });
     },
+
     onError: (error) => {
       toast({ message: error.message, variant: 'error' });
     },
   });
 
-  const { dropdown, title, content } = INQUIRY_PLACEHOLDERS;
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [url, setUrl] = useState('');
+  const [selectedOption, setSelectedOption] = useState<Option | undefined>();
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const [files, setFiles] = useState<UploadFile[]>([]);
 
   return (
-    <SupportFormView
-      submit={({ title, content, selectedOption, url, files }) =>
-        submitInquiry({
-          title,
-          content,
-          inquiryCategory: selectedOption.key,
-          target: url,
-          attachments: files.map(mapFileToAttachment),
-        })
-      }
-      options={INQUIRY_OPTIONS}
-      contentLabel={'문의 내용'}
-      placeholders={{ dropdown, title, content }}
-      showLinkField
-    />
+    <>
+      <SupportFormView
+        title={title}
+        content={content}
+        url={url}
+        selectedOption={selectedOption}
+        attachments={attachments}
+        files={files}
+        setTitle={setTitle}
+        setContent={setContent}
+        setUrl={setUrl}
+        setSelectedOption={setSelectedOption}
+        setAttachments={setAttachments}
+        setFiles={setFiles}
+        options={INQUIRY_OPTIONS}
+        contentLabel={'문의 내용'}
+        placeholders={INQUIRY_PLACEHOLDERS}
+        showLinkField
+        modalId='confirm-inquiry-write'
+      />
+
+      {modal.id === 'confirm-inquiry-write' && (
+        <ConfirmModal
+          modalText={CONFIRM_MODAL_TEXT.INQUIRY_CREATE}
+          onConfirm={() => {
+            submitInquiry();
+          }}
+          onCancel={() => setModal({ id: null })}
+        />
+      )}
+    </>
   );
 }

--- a/src/page/support/WriteReportPage.tsx
+++ b/src/page/support/WriteReportPage.tsx
@@ -45,10 +45,10 @@ export default function WriteReportPage() {
     mutationFn: () =>
       createReport({
         reportType: REPORT_TYPE_MAP[reportType],
-        targetId,
+        targetId: targetId!,
         title,
         content,
-        reportCategory: selectedOption.key!,
+        reportCategory: selectedOption!.key,
         attachments: files.map(mapFileToAttachment),
       }),
 

--- a/src/page/support/WriteReportPage.tsx
+++ b/src/page/support/WriteReportPage.tsx
@@ -1,11 +1,20 @@
+import { useContext, useState } from 'react';
 import { useLoaderData, useNavigate, useSearchParams } from 'react-router-dom';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { BOARD_ID, QUERY_KEY, TOAST } from '@/shared/constant';
+import { ConfirmModal } from '@/shared/component';
+import {
+  BOARD_ID,
+  CONFIRM_MODAL_TEXT,
+  QUERY_KEY,
+  TOAST,
+} from '@/shared/constant';
+import { ModalContext } from '@/shared/context/ModalContext';
 import { useToast } from '@/shared/hook';
 
 import { mapFileToAttachment } from '@/feature/attachment/lib';
+import { Attachment, UploadFile } from '@/feature/attachment/types';
 import { createReport } from '@/feature/support/api';
 import {
   REPORT_PLACEHOLDERS,
@@ -19,6 +28,7 @@ import {
 import { SupportFormView } from '@/feature/support/ui';
 
 import { createThumbnail } from '@/apis';
+import { Option } from '@/types';
 
 export default function WriteReportPage() {
   const { reportType } = useLoaderData() as { reportType: ReportType };
@@ -28,10 +38,20 @@ export default function WriteReportPage() {
 
   const queryClient = useQueryClient();
 
+  const { modal, setModal } = useContext(ModalContext);
   const { toast } = useToast();
 
-  const { mutate: submit } = useMutation({
-    mutationFn: createReport,
+  const { mutate: submitReport } = useMutation({
+    mutationFn: () =>
+      createReport({
+        reportType: REPORT_TYPE_MAP[reportType],
+        targetId,
+        title,
+        content,
+        reportCategory: selectedOption.key!,
+        attachments: files.map(mapFileToAttachment),
+      }),
+
     onSuccess: (data) => {
       const { postId } = data;
 
@@ -51,30 +71,47 @@ export default function WriteReportPage() {
 
       navigate(`/report/${postId}`, { replace: true });
     },
+
     onError: (error) => {
       toast({ message: error.message, variant: 'error' });
     },
   });
 
-  const { dropdown, title, content } = REPORT_PLACEHOLDERS[reportType];
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [selectedOption, setSelectedOption] = useState<Option | undefined>();
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const [files, setFiles] = useState<UploadFile[]>([]);
+
   const targetId = searchParams.get('targetId');
 
   return (
-    <SupportFormView
-      submit={({ title, content, selectedOption, files }) =>
-        submit({
-          reportType: REPORT_TYPE_MAP[reportType],
-          targetId,
-          title,
-          content,
-          reportCategory: selectedOption.key!,
-          attachments: files.map(mapFileToAttachment),
-        })
-      }
-      options={REPORT_OPTIONS[reportType]}
-      contentLabel={'신고 내용'}
-      placeholders={{ dropdown, title, content }}
-      tag={REPORT_TYPE_TAG[reportType]}
-    />
+    <>
+      <SupportFormView
+        title={title}
+        content={content}
+        selectedOption={selectedOption}
+        attachments={attachments}
+        files={files}
+        setTitle={setTitle}
+        setContent={setContent}
+        setSelectedOption={setSelectedOption}
+        setAttachments={setAttachments}
+        setFiles={setFiles}
+        options={REPORT_OPTIONS[reportType]}
+        contentLabel={'신고 내용'}
+        placeholders={REPORT_PLACEHOLDERS[reportType]}
+        tag={REPORT_TYPE_TAG[reportType]}
+        modalId='confirm-report-write'
+      />
+
+      {modal.id === 'confirm-report-write' && (
+        <ConfirmModal
+          modalText={CONFIRM_MODAL_TEXT.REPORT_CREATE}
+          onConfirm={submitReport}
+          onCancel={() => setModal({ id: null })}
+        />
+      )}
+    </>
   );
 }

--- a/src/shared/constant/modalText.js
+++ b/src/shared/constant/modalText.js
@@ -175,6 +175,32 @@ const CONFIRM_MODAL = {
     cancelText: '취소',
   },
 
+  // 문의 및 신고 확인 모달
+  INQUIRY_CREATE: {
+    title: '문의글 작성을 완료할까요?',
+    description: '관리자 답변이 달리면 게시글 수정 및 삭제가 불가능해요',
+    confirmText: '완료',
+    cancelText: '취소',
+  },
+  INQUIRY_UPDATE: {
+    title: '문의글 수정을 완료할까요?',
+    description: '관리자 답변이 달리면 게시글 수정 및 삭제가 불가능해요',
+    confirmText: '완료',
+    cancelText: '취소',
+  },
+  REPORT_CREATE: {
+    title: '신고글 작성을 완료할까요?',
+    description: '관리자 답변이 달리면 게시글 수정 및 삭제가 불가능해요',
+    confirmText: '완료',
+    cancelText: '취소',
+  },
+  REPORT_UPDATE: {
+    title: '신고글 수정을 완료할까요?',
+    description: '관리자 답변이 달리면 게시글 수정 및 삭제가 불가능해요',
+    confirmText: '완료',
+    cancelText: '취소',
+  },
+
   // 유저 관련 확인 모달
   WITHDRAW_ACCOUNT: {
     title: '정말 탈퇴하시겠습니까?',


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1633

- [Notion](https://www.notion.so/snorose/35e7ef0aa3bf80fbb223cc145176ceaf?source=copy_link)
- [Notion](https://www.notion.so/snorose/35e7ef0aa3bf80108bc8d0c6092a6ca6?source=copy_link)
- [Notion](https://www.notion.so/snorose/35e7ef0aa3bf80659a77d993370040c3?source=copy_link) 
- [Notion](https://www.notion.so/snorose/35e7ef0aa3bf80a9940eed13cf2b1791?source=copy_link) 

## 🎯 변경 사항

### 확인 모달 도입
- 문의 및 신고 작성/수정 시 사용자의 실수를 방지하기 위해 완료 확인 모달을 추가했습니다.

### 상태 관리 리팩토링
- SupportFormView 내부에 있던 데이터 state를 상위 페이지로 이동시켜 UI state와 분리했습니다.

### 상수 및 타입 정의
- 문의 및 신고 작성/수정 확인 모달에 필요한 텍스트 상수를 추가했습니다.

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
