### PR TITLE
[SNO-431] #1644 제목 포커스 시 에디터 버튼 비활성화

### DIFF
--- a/src/feature/board/component/AttachmentBar/AttachmentBar.jsx
+++ b/src/feature/board/component/AttachmentBar/AttachmentBar.jsx
@@ -15,6 +15,7 @@ export default function AttachmentBar({
   attachmentsInfo,
   setAttachmentsInfo,
   editor,
+  isTitleFocused,
 }) {
   const img = useRef();
   const vid = useRef();
@@ -32,7 +33,7 @@ export default function AttachmentBar({
 
   return (
     <div ref={attachmentBarRef} className={styles.bar}>
-      {isEditorOpen && editor && <FixedMenuEditor editor={editor} />}
+      {isEditorOpen && editor && <FixedMenuEditor editor={editor} isTitleFocused={isTitleFocused} />}
       <div className={styles.attachmentBar}>
         <Icon
           id={isImageIconHighlighted ? 'image-fill' : 'image'}

--- a/src/feature/editor/component/FixedMenuEditor/FixedMenuEditor.jsx
+++ b/src/feature/editor/component/FixedMenuEditor/FixedMenuEditor.jsx
@@ -20,7 +20,7 @@ const PRESET_BG_COLORS = [
   { label: '파랑', value: 'var(--blue-2)' },
 ];
 
-export default function FixedMenuEditor({ editor }) {
+export default function FixedMenuEditor({ editor, isTitleFocused }) {
   const editorState = useEditorState({
     editor,
     selector: (ctx) => ({
@@ -51,6 +51,19 @@ export default function FixedMenuEditor({ editor }) {
     return 'paragraph';
   };
 
+  const handleMouseDown = (e) => {
+    if (isTitleFocused) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  };
+
+  const runIfEditorFocused = (callback) => {
+    if (isTitleFocused) return;
+
+    callback();
+  };
+
   useEffect(() => {
     const handleClickOutside = (event) => {
       [
@@ -71,9 +84,11 @@ export default function FixedMenuEditor({ editor }) {
   if (!editor) return null;
 
   return (
-    <div className={styles.toolbar}>
+    <div className={styles.toolbar} onMouseDown={handleMouseDown}>
+      {isTitleFocused && <div className={styles.toolbarBlocker} />}
       <div ref={headingRef} className={styles.headingWrapper}>
         <button
+          disabled={isTitleFocused}
           className={styles.headingButton}
           onClick={() => setHeadingOpen((prev) => !prev)}
         >
@@ -94,6 +109,7 @@ export default function FixedMenuEditor({ editor }) {
               <button
                 key={option.value}
                 className={`${styles.headingOption} ${getCurrentHeading() === option.value ? styles.headingOptionActive : ''}`}
+                disabled={isTitleFocused}
                 onClick={() => {
                   if (option.value === 'paragraph') {
                     editor.chain().focus().setParagraph().run();
@@ -117,6 +133,7 @@ export default function FixedMenuEditor({ editor }) {
       <div ref={textColorRef} className={styles.colorPickerWrapper}>
         {/* 폰트 색상 토글 버튼 */}
         <button
+          disabled={isTitleFocused}
           onClick={() => setShowTextColor((prev) => !prev)}
           style={{ color: textColor || 'var(--grey-4)' }}
         >
@@ -129,6 +146,7 @@ export default function FixedMenuEditor({ editor }) {
           {/* 색상 없음 */}
           <button
             className={styles.colorSwatchNone}
+            disabled={isTitleFocused}
             title='색상 없음'
             onClick={() => {
               setTextColor('');
@@ -141,6 +159,7 @@ export default function FixedMenuEditor({ editor }) {
           {/* 고정 색상 */}
           {PRESET_COLORS.map((color) => (
             <button
+              disabled={isTitleFocused}
               key={color.label}
               className={`${styles.colorSwatch} ${textColor === color.value ? styles.selected : ''}`}
               style={{ backgroundColor: color.value }}
@@ -160,6 +179,7 @@ export default function FixedMenuEditor({ editor }) {
 
       <div ref={bgColorRef} className={styles.colorPickerWrapper}>
         <button
+          disabled={isTitleFocused}
           onClick={() => setShowBgColor((prev) => !prev)}
           style={{
             '--bg-icon-fill': bgColor || '#E6F7B1',
@@ -173,6 +193,7 @@ export default function FixedMenuEditor({ editor }) {
           className={`${styles.colorPaletteInline} ${showBgColor ? styles.open : ''}`}
         >
           <button
+            disabled={isTitleFocused}
             className={styles.colorSwatchNone}
             title='배경색 없음'
             onClick={() => {
@@ -190,6 +211,7 @@ export default function FixedMenuEditor({ editor }) {
           {/* 고정 색상 */}
           {PRESET_BG_COLORS.map((color) => (
             <button
+              disabled={isTitleFocused}
               key={color.label}
               className={`${styles.colorSwatch} ${bgColor === color.value ? styles.selected : ''}`}
               style={{ backgroundColor: color.value }}
@@ -209,7 +231,8 @@ export default function FixedMenuEditor({ editor }) {
 
       <button
         aria-label='굵게'
-        onClick={() => editor.chain().focus().toggleBold().run()}
+        onClick={() => runIfEditorFocused(() => editor.chain().focus().toggleBold().run())}
+        disabled={isTitleFocused}
         style={editorState.isBold ? { '--icon-stroke': 'var(--blue-4)' } : {}}
       >
         <Icon id='bold' width={24} height={24} />
@@ -217,7 +240,8 @@ export default function FixedMenuEditor({ editor }) {
 
       <button
         aria-label='밑줄'
-        onClick={() => editor.chain().focus().toggleUnderline().run()}
+        onClick={() => runIfEditorFocused(() => editor.chain().focus().toggleUnderline().run())}
+        disabled={isTitleFocused}
         style={
           editorState.isUnderline ? { '--icon-stroke': 'var(--blue-4)' } : {}
         }
@@ -227,7 +251,8 @@ export default function FixedMenuEditor({ editor }) {
 
       <button
         aria-label='취소선'
-        onClick={() => editor.chain().focus().toggleStrike().run()}
+        onClick={() => runIfEditorFocused(() => editor.chain().focus().toggleStrike().run())}
+        disabled={isTitleFocused}
         style={editorState.isStrike ? { '--icon-stroke': 'var(--blue-4)' } : {}}
       >
         <Icon id='strikethrough' width={24} height={24} />

--- a/src/feature/editor/component/FixedMenuEditor/FixedMenuEditor.jsx
+++ b/src/feature/editor/component/FixedMenuEditor/FixedMenuEditor.jsx
@@ -54,14 +54,7 @@ export default function FixedMenuEditor({ editor, isTitleFocused }) {
   const handleMouseDown = (e) => {
     if (isTitleFocused) {
       e.preventDefault();
-      e.stopPropagation();
     }
-  };
-
-  const runIfEditorFocused = (callback) => {
-    if (isTitleFocused) return;
-
-    callback();
   };
 
   useEffect(() => {
@@ -231,7 +224,7 @@ export default function FixedMenuEditor({ editor, isTitleFocused }) {
 
       <button
         aria-label='굵게'
-        onClick={() => runIfEditorFocused(() => editor.chain().focus().toggleBold().run())}
+        onClick={() => editor.chain().focus().toggleBold().run()}
         disabled={isTitleFocused}
         style={editorState.isBold ? { '--icon-stroke': 'var(--blue-4)' } : {}}
       >
@@ -240,7 +233,7 @@ export default function FixedMenuEditor({ editor, isTitleFocused }) {
 
       <button
         aria-label='밑줄'
-        onClick={() => runIfEditorFocused(() => editor.chain().focus().toggleUnderline().run())}
+        onClick={() => editor.chain().focus().toggleUnderline().run()}
         disabled={isTitleFocused}
         style={
           editorState.isUnderline ? { '--icon-stroke': 'var(--blue-4)' } : {}
@@ -251,7 +244,7 @@ export default function FixedMenuEditor({ editor, isTitleFocused }) {
 
       <button
         aria-label='취소선'
-        onClick={() => runIfEditorFocused(() => editor.chain().focus().toggleStrike().run())}
+        onClick={() => editor.chain().focus().toggleStrike().run()}
         disabled={isTitleFocused}
         style={editorState.isStrike ? { '--icon-stroke': 'var(--blue-4)' } : {}}
       >

--- a/src/feature/editor/component/FixedMenuEditor/FixedMenuEditor.module.css
+++ b/src/feature/editor/component/FixedMenuEditor/FixedMenuEditor.module.css
@@ -8,6 +8,24 @@
   height: 0;
 }
 
+.toolbar button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.toolbar {
+  position: relative;
+}
+
+.toolbarBlocker {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 999;
+}
+
 .toolbar {
   height: 60px;
   gap: 20px;

--- a/src/page/board/WritePostPage/WritePostPage.jsx
+++ b/src/page/board/WritePostPage/WritePostPage.jsx
@@ -79,6 +79,7 @@ export default function WritePostPage() {
 
   const textId = pathname.split('/')[2];
   const currentBoard = getBoard(textId);
+  const [isTitleFocused, setIsTitleFocused] = useState(false);
   const [boardTitle, setBoardTitle] = useState(
     currentBoard?.title ?? '게시판을 선택해주세요'
   );
@@ -385,6 +386,8 @@ export default function WritePostPage() {
                 placeholder='제목을 입력해주세요'
                 value={title}
                 onChange={handleTitleChange}
+                onFocus={() => setIsTitleFocused(true)}
+                onBlur={() => setIsTitleFocused(false)}
               />
               {/*<TextareaAutosize
                   className={styles.text}
@@ -449,6 +452,7 @@ export default function WritePostPage() {
           attachmentsInfo={attachmentsInfo}
           setAttachmentsInfo={setAttachmentsInfo}
           editor={editor}
+          isTitleFocused={isTitleFocused}
         />
       </div>
 


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1644 

- [Figma](https://www.notion.so/snorose/3627ef0aa3bf80afb5bfdd164afe05b6)
- [Notion]()

## 🎯 변경 사항

- 제목에 커서 올릴 시, 에디터 클릭 비활성화 
- 에디터 비활성화 시, UI로 표시 (오퍼시티 변화를 줌)

## 📸 스크린샷 (선택 사항)
| Before | After |
| :----: | :---: |
| <img src="https://github.com/user-attachments/assets/819c5d45-69fd-4ff4-ad7c-76dc146460bc" width="400" /> | <img src="https://github.com/user-attachments/assets/04c7a0f0-ccd9-4ba0-a113-255297349cca" width="400" /> |

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? 
- 갤럭시 모바일과 window pc에서 되는 것 확인했습니다. 다른 환경 테스트 가능하면 진행해주세요.
- 에디터 버튼이 비활성화 되는지 확인해주세요
- 오퍼시티를 줘서 UI 적으로 비활성화가 된 것을 눈으로 보이게 했는데 UI가 괜찮은지 확인해주세요 