### PR TITLE
[SNO-443] #1646 이미지 용량 제한 정책 변경 대응

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17092,7 +17092,9 @@
       "license": "MIT"
     },
     "node_modules/react-refresh": {
-      "version": "0.14.2",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
+      "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,9 @@
     "typescript": "^4.9.5",
     "webpack": "^5.97.1"
   },
+  "overrides": {
+    "react-refresh": "0.11.0"
+  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/src/feature/support/ui/FileUploadSection.tsx
+++ b/src/feature/support/ui/FileUploadSection.tsx
@@ -9,15 +9,13 @@ import type { UploadFile } from '@/feature/attachment/types';
 import styles from './FileUploadSection.module.css';
 
 const MAX_FILE_COUNT = 3;
-const MAX_TOTAL_FILE_SIZE = 10 * 1024 * 1024;
+const MAX_FILE_SIZE = 7 * 1024 * 1024;
 
 export default function FileUploadSection({
   currentFileCount,
-  curruentTotalFileSize,
   setFiles,
 }: {
   currentFileCount: number;
-  curruentTotalFileSize: number;
   setFiles: React.Dispatch<React.SetStateAction<UploadFile[]>>;
 }) {
   const id = useId();
@@ -52,15 +50,13 @@ export default function FileUploadSection({
             return;
           }
 
-          const selectedFilesSize = selectedFiles.reduce(
-            (total, { size }) => total + size,
-            0
-          );
-          if (curruentTotalFileSize + selectedFilesSize > MAX_TOTAL_FILE_SIZE) {
+          const selectedFileSizes = selectedFiles.map((file) => file.size);
+
+          if (selectedFileSizes.some((size) => size > MAX_FILE_SIZE)) {
             e.target.value = '';
 
             toast({
-              message: '10MB까지 올릴 수 있어요',
+              message: `${MAX_FILE_SIZE / (1024 * 1024)}MB 이하의 이미지만 업로드할 수 있어요`,
               variant: 'info',
             });
 

--- a/src/feature/support/ui/SupportFormView.tsx
+++ b/src/feature/support/ui/SupportFormView.tsx
@@ -154,10 +154,6 @@ export default function SupportFormView({
 
         <FileUploadSection
           currentFileCount={attachments.length + files.length}
-          curruentTotalFileSize={files.reduce(
-            (total, { file }) => total + file.size,
-            0
-          )}
           setFiles={setFiles}
         />
 


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1646

- [Notion](https://www.notion.so/snorose/10MB-3607ef0aa3bf80969ed4f574d55832b8?source=copy_link)

## 🎯 변경 사항

### react-refresh 버전 충돌 문제
- CRA가 내부적으로 react-refresh 0.11.0 버전을 사용 중인데, react-refresh을 최신 버전으로 올릴 경우 충돌이 발생
- react-refresh가 자동으로 버전 업데이트가 되지 않도록 0.11.0 버전으로 고정되도록 package.json, package-lock.json 수정

### 이미지 용량 유효성 검사 로직 수정
- FileUploadSection 컴포넌트에서 전체 파일 용량이 아닌 선택 파일 개별 용량이 7MB를 넘지 않는지 확인하는 로직으로 수정

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
