### PR TITLE
[SNO-435] 버블 메뉴 표시 위치 수정

### DIFF
--- a/src/feature/editor/component/EditorContainer/EditorContainer.jsx
+++ b/src/feature/editor/component/EditorContainer/EditorContainer.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef } from 'react';
 
 import TipTapImage from '@tiptap/extension-image';
 import Link from '@tiptap/extension-link';
@@ -11,6 +11,7 @@ import {
   TextStyle,
 } from '@tiptap/extension-text-style';
 import { EditorContent, useEditor } from '@tiptap/react';
+import { BubbleMenu } from '@tiptap/react/menus';
 import StarterKit from '@tiptap/starter-kit';
 
 import { EnterKeyHandler } from '@/feature/editor/component/extensions/enterkey-handler-extension';
@@ -24,18 +25,38 @@ import { FontSize } from '../extensions/font-size-extension';
 import LinkBubbleMenu from '../LinkBubbleMenu/LinkBubbleMenu';
 import styles from './EditorContainer.module.css';
 
+// 커서 바로 앞 링크 마크 정보를 찾아 { url, pos } 반환 (없으면 null)
+function getLinkAtCursor(editor) {
+  const { $from, empty } = editor.state.selection;
+  if (!empty) return null;
+
+  let pos = $from.pos;
+  let nodeBefore = $from.nodeBefore;
+
+  // URL 입력 후 스페이스로 막 생성된 링크는 끝이 공백이므로 한 칸 당겨 검사
+  if (nodeBefore?.isText && nodeBefore.text.endsWith(' ')) {
+    nodeBefore = editor.state.doc.resolve(pos - 1).nodeBefore;
+    pos -= 1;
+  }
+
+  const linkMark = nodeBefore?.marks?.find((m) => m.type.name === 'link');
+  if (!linkMark) return null;
+
+  return { url: linkMark.attrs.href, pos };
+}
+
 export default function EditorContainer({
   placeholder,
   text,
   onChangeEditor,
   onEditorReady,
 }) {
-  const [isLinkMenuOpen, setIsLinkMenuOpen] = useState(false);
-  const [linkMenuData, setLinkMenuData] = useState({
-    url: '',
-    pos: null,
-    coords: null,
-  });
+  // 클릭 핸들러가 참조할 현재 링크 정보 { url, pos }
+  const linkInfoRef = useRef(null);
+  // '링크' 버튼으로 닫은 항목을 기억해 같은 링크엔 메뉴를 다시 띄우지 않기 위한 키
+  const dismissedKeyRef = useRef(null);
+  // BubbleMenu의 바깥 floating 요소(position:fixed)를 가리킴
+  const bubbleMenuRef = useRef(null);
 
   useIframeAutoResize();
 
@@ -68,75 +89,38 @@ export default function EditorContainer({
         placeholder,
       }),
     ],
+    editorProps: {
+      // 외부(예: 노션) 붙여넣기 시 인라인 font-size를 제거해
+      // 에디터 기본 폰트 크기를 따르도록 정규화
+      transformPastedHTML(html) {
+        if (typeof window === 'undefined' || !html) return html;
+
+        const doc = new DOMParser().parseFromString(html, 'text/html');
+        doc.querySelectorAll('[style]').forEach((el) => {
+          el.style.removeProperty('font-size');
+          if (!el.getAttribute('style')) el.removeAttribute('style');
+        });
+        return doc.body.innerHTML;
+      },
+    },
     immediatelyRender: false,
     onUpdate: ({ editor }) => {
       if (onChangeEditor) onChangeEditor(editor);
 
-      const { $from, empty } = editor.state.selection;
-
-      // 텍스트를 드래그한 상태면 메뉴 숨김
-      if (!empty) {
-        if (isLinkMenuOpen) setIsLinkMenuOpen(false);
-        return;
+      // 이미지 URL 링크는 메뉴 없이 즉시 이미지로 변환
+      // (임베드 메뉴 노출 여부는 BubbleMenu의 shouldShow가 담당)
+      const link = getLinkAtCursor(editor);
+      if (link && isImageUrl(link.url)) {
+        setTimeout(() => {
+          editor
+            .chain()
+            .focus()
+            .extendMarkRange('link')
+            .deleteSelection()
+            .setImage({ src: link.url })
+            .run();
+        }, 0);
       }
-
-      let checkPos = $from.pos;
-      let nodeBefore = $from.nodeBefore;
-
-      // 1. 방금 스페이스바를 눌러 링크가 생성된 경우 감지 로직
-      // (URL을 치고 스페이스바를 누르면 텍스트 노드가 공백(' ')으로 끝남)
-      if (nodeBefore && nodeBefore.isText && nodeBefore.text.endsWith(' ')) {
-        // 공백 바로 직전(URL 텍스트)의 노드를 가져오기 위해 위치를 1칸 당김
-        const resolved = editor.state.doc.resolve(checkPos - 1);
-        nodeBefore = resolved.nodeBefore;
-        checkPos = checkPos - 1;
-      }
-
-      // 2. 커서 바로 앞의 노드에 'link' 마크가 있는지 검사
-      if (nodeBefore && nodeBefore.marks) {
-        const linkMark = nodeBefore.marks.find((m) => m.type.name === 'link');
-
-        if (linkMark) {
-          const url = linkMark.attrs.href;
-
-          if (isImageUrl(url)) {
-            setTimeout(() => {
-              editor
-                .chain()
-                .focus()
-                .extendMarkRange('link')
-                .deleteSelection()
-                .setImage({ src: url })
-                .run();
-            }, 0);
-            return;
-          }
-
-          if (!isAllowedEmbedUrl(formatEmbedUrl(url))) {
-            if (isLinkMenuOpen) setIsLinkMenuOpen(false);
-            return;
-          }
-
-          // 화면상의 절대 좌표(픽셀)를 계산하여 팝업 띄울 위치 결정
-          const coords = editor.view.coordsAtPos(checkPos);
-
-          if (!isLinkMenuOpen || linkMenuData.url !== url) {
-            setLinkMenuData({
-              url: linkMark.attrs.href,
-              pos: checkPos,
-              coords: {
-                top: coords.top,
-                left: coords.left + 8,
-              },
-            });
-            setIsLinkMenuOpen(true);
-          }
-          return; // 메뉴를 띄웠으므로 조기 종료
-        }
-      }
-
-      // 3. 링크 영역을 벗어나서 다른 글씨를 계속 치면 자연스럽게 메뉴 숨김
-      if (isLinkMenuOpen) setIsLinkMenuOpen(false);
     },
     onCreate: ({ editor }) => {
       if (onEditorReady) onEditorReady(editor);
@@ -151,13 +135,45 @@ export default function EditorContainer({
     }
   }, [editor, text]);
 
+  // React BubbleMenu는 className/style을 '안쪽 콘텐츠 div'에 적용한다.
+  // 실제로 position:fixed로 위치가 잡히는 '바깥 floating 요소'에 z-index를 직접
+  // 지정해야 AttachmentBar(z-index:100) 위로 올라온다.
+  useEffect(() => {
+    bubbleMenuRef.current?.classList.add(styles.linkBubbleMenu);
+  }, [editor]);
+
+  // 메뉴를 띄울지 결정 + 클릭 핸들러용 링크 정보 저장
+  const shouldShowBubble = ({ editor }) => {
+    const link = getLinkAtCursor(editor);
+
+    // 링크가 없거나 / 이미지이거나 / 임베드 불가 URL이면 숨김
+    if (
+      !link ||
+      isImageUrl(link.url) ||
+      !isAllowedEmbedUrl(formatEmbedUrl(link.url))
+    ) {
+      linkInfoRef.current = null;
+      return false;
+    }
+
+    linkInfoRef.current = link;
+    // '링크' 버튼으로 닫은 동일 링크면 다시 띄우지 않음
+    return dismissedKeyRef.current !== `${link.pos}:${link.url}`;
+  };
+
   const handleKeepText = () => {
-    setIsLinkMenuOpen(false); // 메뉴 닫기
-    editor.commands.focus(); // 에디터 포커스 유지
+    const link = linkInfoRef.current;
+    if (link) dismissedKeyRef.current = `${link.pos}:${link.url}`;
+    // 버튼 클릭으로 blur된 에디터를 다시 포커스 → focus 이벤트로 BubbleMenu가
+    // shouldShow를 재평가 → dismissedKey 일치로 메뉴 닫힘
+    editor.commands.focus();
   };
 
   const handleConvertIframe = () => {
-    const url = linkMenuData.url;
+    const link = linkInfoRef.current;
+    if (!link) return;
+
+    const { url, pos } = link;
     const formattedUrl = formatEmbedUrl(url);
     const embedSource = EMBED_SOURCES.find((s) => s.sourcePattern.test(url));
 
@@ -165,7 +181,7 @@ export default function EditorContainer({
       .chain()
       .focus()
       // 1. 커서를 방금 작성된 링크 내부로 강제 이동
-      .setTextSelection(linkMenuData.pos - 1)
+      .setTextSelection(pos - 1)
       // 2. 링크 전체 영역을 블록 지정
       .extendMarkRange('link')
       // 3. 해당 텍스트 삭제
@@ -179,11 +195,9 @@ export default function EditorContainer({
         },
       })
       .run();
-      setTimeout(() => {
-        editor.commands.focus('end');
-      }, 0);
-
-    setIsLinkMenuOpen(false);
+    setTimeout(() => {
+      editor.commands.focus('end');
+    }, 0);
   };
 
   return (
@@ -194,12 +208,24 @@ export default function EditorContainer({
         <EditorContent editor={editor} />
       </div>
 
-      {isLinkMenuOpen && linkMenuData.coords && (
-        <LinkBubbleMenu
-          coords={linkMenuData.coords}
-          onKeepText={handleKeepText}
-          onConvertIframe={handleConvertIframe}
-        />
+      {editor && (
+        <BubbleMenu
+          ref={bubbleMenuRef}
+          editor={editor}
+          shouldShow={shouldShowBubble}
+          options={{
+            placement: 'bottom-start',
+            strategy: 'fixed', // 모바일 키보드 대응
+            offset: 8,
+            flip: true,
+            shift: { padding: 8 }, // 화면 가장자리 넘침 자동 보정
+          }}
+        >
+          <LinkBubbleMenu
+            onKeepText={handleKeepText}
+            onConvertIframe={handleConvertIframe}
+          />
+        </BubbleMenu>
       )}
     </>
   );

--- a/src/feature/editor/component/EditorContainer/EditorContainer.jsx
+++ b/src/feature/editor/component/EditorContainer/EditorContainer.jsx
@@ -202,9 +202,7 @@ export default function EditorContainer({
 
   return (
     <>
-      <div
-        className={styles.editor}
-      >
+      <div className={styles.editor}>
         <EditorContent editor={editor} />
       </div>
 
@@ -218,7 +216,16 @@ export default function EditorContainer({
             strategy: 'fixed', // 모바일 키보드 대응
             offset: 8,
             flip: true,
-            shift: { padding: 8 }, // 화면 가장자리 넘침 자동 보정
+            shift: { padding: 8 },
+            onShow: () => {
+              requestAnimationFrame(() => {
+                if (editor && !editor.isDestroyed) {
+                  editor.view.dispatch(
+                    editor.state.tr.setMeta('bubbleMenu', 'updatePosition')
+                  );
+                }
+              });
+            },
           }}
         >
           <LinkBubbleMenu

--- a/src/feature/editor/component/EditorContainer/EditorContainer.module.css
+++ b/src/feature/editor/component/EditorContainer/EditorContainer.module.css
@@ -1,6 +1,11 @@
 :global(.ProseMirror:focus) {
   outline: none;
 }
+
+.linkBubbleMenu {
+  z-index: var(--z-index-dropdown);
+}
+
 .editor {
   font: var(--text-headline-2-reg);
   color: var(--grey-4);

--- a/src/feature/editor/component/LinkBubbleMenu/LinkBubbleMenu.jsx
+++ b/src/feature/editor/component/LinkBubbleMenu/LinkBubbleMenu.jsx
@@ -1,21 +1,67 @@
-import React from 'react';
+import React, { useLayoutEffect, useRef, useState } from 'react';
 
 import styles from './LinkBubbleMenu.module.css';
+
+// 메뉴와 화면 가장자리 사이 최소 여백(px)
+const VIEWPORT_MARGIN = 8;
 
 export default function LinkBubbleMenu({
   coords,
   onKeepText,
   onConvertIframe,
 }) {
+  const menuRef = useRef(null);
+  const [position, setPosition] = useState({
+    top: coords?.top ?? 0,
+    left: coords?.left ?? 0,
+  });
+
+  // 메뉴 위치 보정
+  // - 모바일 키보드 등으로 비주얼 뷰포트가 이동/축소된 만큼 offset 보정 (position: fixed 기준 보정)
+  // - 메뉴 실제 너비를 측정해 화면 오른쪽 끝을 넘어가지 않도록 left clamp
+  useLayoutEffect(() => {
+    if (!coords) return;
+
+    const updatePosition = () => {
+      if (!menuRef.current) return;
+
+      const vv = window.visualViewport;
+      const offsetTop = vv?.offsetTop ?? 0;
+      const offsetLeft = vv?.offsetLeft ?? 0;
+      const viewportWidth = vv?.width ?? window.innerWidth;
+
+      const menuWidth = menuRef.current.offsetWidth;
+      const minLeft = offsetLeft + VIEWPORT_MARGIN;
+      const maxLeft = offsetLeft + viewportWidth - menuWidth - VIEWPORT_MARGIN;
+
+      setPosition({
+        top: coords.top + offsetTop,
+        left: Math.max(minLeft, Math.min(coords.left + offsetLeft, maxLeft)),
+      });
+    };
+
+    updatePosition();
+
+    // 키보드가 오르내리거나 화면이 스크롤될 때도 위치를 따라가도록
+    const vv = window.visualViewport;
+    vv?.addEventListener('resize', updatePosition);
+    vv?.addEventListener('scroll', updatePosition);
+    return () => {
+      vv?.removeEventListener('resize', updatePosition);
+      vv?.removeEventListener('scroll', updatePosition);
+    };
+  }, [coords]);
+
   // 좌표 정보가 없으면 렌더링하지 않음
   if (!coords) return null;
 
   return (
     <div
+      ref={menuRef}
       className={styles.container}
       style={{
-        top: coords.top,
-        left: coords.left,
+        top: position.top,
+        left: position.left,
       }}
       // 메뉴를 클릭해도 에디터의 커서가 깜빡임을 유지하도록 방지
       onMouseDown={(e) => e.preventDefault()}

--- a/src/feature/editor/component/LinkBubbleMenu/LinkBubbleMenu.jsx
+++ b/src/feature/editor/component/LinkBubbleMenu/LinkBubbleMenu.jsx
@@ -1,71 +1,10 @@
-import React, { useLayoutEffect, useRef, useState } from 'react';
+import React from 'react';
 
 import styles from './LinkBubbleMenu.module.css';
 
-// 메뉴와 화면 가장자리 사이 최소 여백(px)
-const VIEWPORT_MARGIN = 8;
-
-export default function LinkBubbleMenu({
-  coords,
-  onKeepText,
-  onConvertIframe,
-}) {
-  const menuRef = useRef(null);
-  const [position, setPosition] = useState({
-    top: coords?.top ?? 0,
-    left: coords?.left ?? 0,
-  });
-
-  // 메뉴 위치 보정
-  // - 모바일 키보드 등으로 비주얼 뷰포트가 이동/축소된 만큼 offset 보정 (position: fixed 기준 보정)
-  // - 메뉴 실제 너비를 측정해 화면 오른쪽 끝을 넘어가지 않도록 left clamp
-  useLayoutEffect(() => {
-    if (!coords) return;
-
-    const updatePosition = () => {
-      if (!menuRef.current) return;
-
-      const vv = window.visualViewport;
-      const offsetTop = vv?.offsetTop ?? 0;
-      const offsetLeft = vv?.offsetLeft ?? 0;
-      const viewportWidth = vv?.width ?? window.innerWidth;
-
-      const menuWidth = menuRef.current.offsetWidth;
-      const minLeft = offsetLeft + VIEWPORT_MARGIN;
-      const maxLeft = offsetLeft + viewportWidth - menuWidth - VIEWPORT_MARGIN;
-
-      setPosition({
-        top: coords.top + offsetTop,
-        left: Math.max(minLeft, Math.min(coords.left + offsetLeft, maxLeft)),
-      });
-    };
-
-    updatePosition();
-
-    // 키보드가 오르내리거나 화면이 스크롤될 때도 위치를 따라가도록
-    const vv = window.visualViewport;
-    vv?.addEventListener('resize', updatePosition);
-    vv?.addEventListener('scroll', updatePosition);
-    return () => {
-      vv?.removeEventListener('resize', updatePosition);
-      vv?.removeEventListener('scroll', updatePosition);
-    };
-  }, [coords]);
-
-  // 좌표 정보가 없으면 렌더링하지 않음
-  if (!coords) return null;
-
+export default function LinkBubbleMenu({ onKeepText, onConvertIframe }) {
   return (
-    <div
-      ref={menuRef}
-      className={styles.container}
-      style={{
-        top: position.top,
-        left: position.left,
-      }}
-      // 메뉴를 클릭해도 에디터의 커서가 깜빡임을 유지하도록 방지
-      onMouseDown={(e) => e.preventDefault()}
-    >
+    <div className={styles.container}>
       <span className={styles.header}>첨부 방식</span>
 
       <button onClick={onKeepText} className={styles.button}>

--- a/src/feature/editor/component/LinkBubbleMenu/LinkBubbleMenu.module.css
+++ b/src/feature/editor/component/LinkBubbleMenu/LinkBubbleMenu.module.css
@@ -1,9 +1,6 @@
 .container {
   width: 11rem;
-  position: fixed;
-  z-index: var(--z-index-dropdown);
   background-color: var(--white);
-  /* border: 0.1rem solid var(--blue-2); */
   box-shadow: 0 0 2rem var(--grey-3);
   border-radius: 0.5rem;
   display: flex;
@@ -23,6 +20,7 @@
 .button {
   width: 100%;
   font-size: var(--text-body-2-reg);
+  color: var(--grey-4);
   text-align: left;
   padding: 1rem;
   border-bottom: 0.1rem solid var(--blue-2);


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1654
Close #1655 

- [버블 메뉴 표시 위치 수정](https://www.notion.so/snorose/3627ef0aa3bf8061b5aafc0729c60887?source=copy_link)
- [iOS 한정 외부 링크 붙여넣기 시 폰트 스타일 적용되는 현상 해결](https://www.notion.so/snorose/3627ef0aa3bf80b4857fe1de5f06ea21?source=copy_link)

## 🎯 변경 사항

1. 버블 메뉴가 화면 오른쪽 끝/모바일 키보드에서 어긋남 → TipTap BubbleMenu로 교체
- 기존: coordsAtPos로 좌표를 직접 계산 + position: fixed → 오른쪽 끝 넘침, 모바일 키보드 시 위치 어긋남
- 변경: @tiptap/react/menus의 <BubbleMenu> 사용. Floating UI가 shift(가장자리 넘침)/flip/strategy:'fixed'(키보드)로 위치를 자동 처리
링크 감지 로직을 getLinkAtCursor() 헬퍼로 추출, 노출 조건은 shouldShowBubble(커서 뒤 링크 + 임베드 허용 URL), 클릭 핸들러용 정보는 linkInfoRef로 전달
onUpdate는 이미지 자동변환만 남기고 슬림화
2. "링크" 버튼 눌러도 메뉴가 안 닫힘
- 원인: onMouseDown preventDefault 때문에 에디터가 blur 안 됨 → BubbleMenu의 shouldShow 재평가 트리거(focus 이벤트)가 안 걸림
- 수정: preventDefault 제거 + dismissedKeyRef로 "닫은 링크 기억". handleKeepText의 focus()가 재평가를 일으켜 닫힘
3. iOS Safari에서 버튼 글자가 파란색
- 원인: reset.css가 button에 color를 안 줘서 iOS 기본 버튼색(파랑) 적용
- 수정: .button에 color: var(--grey-4) 명시
4. 노션 링크 붙여넣기 시 폰트가 작음
- 원인: FontSize 확장이 인라인 style.fontSize를 그대로 파싱
- 수정: editorProps.transformPastedHTML로 붙여넣기 HTML의 인라인 font-size 제거

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
- X 게시물, 인스타 게시물, 인스타 릴스, 틱톡, 유튜브 영상, 유튜브 숏츠, 네이버 TV 링크 입력 시 버블 메뉴 위치 잘 출력되는지 확인해주세요! **(특히 모바일!!!!)**
- 노션에 있는 링크 붙여넣기 시 폰트 스타일 작아지는지 확인해주세요!