### PR TITLE
[SNO-445] AttachmentBar 동작 개선

### DIFF
--- a/src/feature/attachment/hook/useAttachmentBarPosition.js
+++ b/src/feature/attachment/hook/useAttachmentBarPosition.js
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 
-const IOS_KEYBOARD_TOOLBAR = 44;
+const IOS_KEYBOARD_TOOLBAR = 55;
 const VV_EVENTS = ['resize', 'scroll'];
 const DOC_EVENTS = ['focusin', 'focusout'];
 
@@ -12,22 +12,23 @@ const isAndroid = () => /Android/i.test(navigator.userAgent);
 
 const getIOSToolbarOffset = () => {
   const el = document.activeElement;
-  if (!el || el.isContentEditable) return 0;
-  if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') {
+  if (!el) return 0;
+  if (
+    el.isContentEditable ||
+    el.tagName === 'INPUT' ||
+    el.tagName === 'TEXTAREA'
+  ) {
     return IOS_KEYBOARD_TOOLBAR;
   }
   return 0;
 };
 
 const computeIOSOffset = (vv) =>
-  Math.max(
-    0,
-    window.innerHeight - vv.height - vv.offsetTop - getIOSToolbarOffset()
-  );
+  Math.max(0, window.innerHeight - vv.height - getIOSToolbarOffset());
 
 const computeAndroidOffset = (vv) => {
   const keyboardHeight = window.innerHeight - vv.height;
-  return keyboardHeight > 0 ? keyboardHeight - vv.offsetTop : 0;
+  return keyboardHeight > 0 ? Math.max(0, keyboardHeight - vv.offsetTop) : 0;
 };
 
 export function useAttachmentBarPosition() {

--- a/src/feature/attachment/hook/useAttachmentBarPosition.js
+++ b/src/feature/attachment/hook/useAttachmentBarPosition.js
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 
-const IOS_KEYBOARD_TOOLBAR = 55;
+const IOS_KEYBOARD_TOOLBAR = 55; // iOS Safari: 키보드 액세서리 바 보정값
 const VV_EVENTS = ['resize', 'scroll'];
 const DOC_EVENTS = ['focusin', 'focusout'];
 
@@ -10,21 +10,29 @@ const isIOS = () =>
 
 const isAndroid = () => /Android/i.test(navigator.userAgent);
 
-const getIOSToolbarOffset = () => {
+// iOS Chrome(CriOS)은 Safari와 달리 키보드 위에 자체 toolbar(뒤로/앞으로/완료)가 떠서 바를 가린다.
+const isIOSChrome = () => isIOS() && /CriOS/.test(navigator.userAgent);
+
+// 액세서리 바/toolbar는 편집 가능한 요소(input/textarea/contentEditable) 포커스 시에만 뜬다.
+const isEditableFocused = () => {
   const el = document.activeElement;
-  if (!el) return 0;
-  if (
-    el.isContentEditable ||
-    el.tagName === 'INPUT' ||
-    el.tagName === 'TEXTAREA'
-  ) {
-    return IOS_KEYBOARD_TOOLBAR;
-  }
-  return 0;
+  return (
+    !!el &&
+    (el.isContentEditable ||
+      el.tagName === 'INPUT' ||
+      el.tagName === 'TEXTAREA')
+  );
 };
 
-const computeIOSOffset = (vv) =>
-  Math.max(0, window.innerHeight - vv.height - getIOSToolbarOffset());
+// iOS Safari: visualViewport에 액세서리 바가 포함되지 않아 생기는 간격만큼 내려준다.
+const computeIOSOffset = (vv) => {
+  const toolbar = isEditableFocused() ? IOS_KEYBOARD_TOOLBAR : 0;
+  return Math.max(0, window.innerHeight - vv.height - toolbar);
+};
+
+// iOS Chrome: Safari의 액세서리 바 보정(-IOS_KEYBOARD_TOOLBAR) 없이 키보드 바로 위에 붙는다.
+const computeIOSChromeOffset = (vv) =>
+  Math.max(0, window.innerHeight - vv.height);
 
 const computeAndroidOffset = (vv) => {
   const keyboardHeight = window.innerHeight - vv.height;
@@ -38,11 +46,13 @@ export function useAttachmentBarPosition() {
     const vv = window.visualViewport;
     if (!vv) return;
 
-    const computeOffset = isIOS()
-      ? computeIOSOffset
-      : isAndroid()
-        ? computeAndroidOffset
-        : null;
+    const computeOffset = isIOSChrome()
+      ? computeIOSChromeOffset
+      : isIOS()
+        ? computeIOSOffset
+        : isAndroid()
+          ? computeAndroidOffset
+          : null;
     if (!computeOffset) return;
 
     const bar = attachmentBarRef.current;

--- a/src/feature/board/component/AttachmentBar/AttachmentBar.jsx
+++ b/src/feature/board/component/AttachmentBar/AttachmentBar.jsx
@@ -33,7 +33,9 @@ export default function AttachmentBar({
 
   return (
     <div ref={attachmentBarRef} className={styles.bar}>
-      {isEditorOpen && editor && <FixedMenuEditor editor={editor} isTitleFocused={isTitleFocused} />}
+      {isEditorOpen && editor && (
+        <FixedMenuEditor editor={editor} isTitleFocused={isTitleFocused} />
+      )}
       <div className={styles.attachmentBar}>
         <Icon
           id={isImageIconHighlighted ? 'image-fill' : 'image'}
@@ -80,6 +82,7 @@ export default function AttachmentBar({
           height={21}
           className={styles.image}
           onClick={() => setIsEditorOpen((prev) => !prev)}
+          onMouseDown={(e) => e.preventDefault()}
         />
       </div>
     </div>

--- a/src/feature/board/component/AttachmentBar/AttachmentBar.jsx
+++ b/src/feature/board/component/AttachmentBar/AttachmentBar.jsx
@@ -33,8 +33,8 @@ export default function AttachmentBar({
 
   return (
     <div ref={attachmentBarRef} className={styles.bar}>
-      {isEditorOpen && editor && (
-        <FixedMenuEditor editor={editor} isTitleFocused={isTitleFocused} />
+      {isEditorOpen && editor && !isTitleFocused && (
+        <FixedMenuEditor editor={editor} />
       )}
       <div className={styles.attachmentBar}>
         <Icon
@@ -77,11 +77,16 @@ export default function AttachmentBar({
         />
 
         <Icon
-          id={isEditorOpen ? 'open-editor-fill' : 'open-editor'}
+          id={
+            isEditorOpen && !isTitleFocused ? 'open-editor-fill' : 'open-editor'
+          }
           width={27}
           height={21}
-          className={styles.image}
-          onClick={() => setIsEditorOpen((prev) => !prev)}
+          className={`${styles.image} ${isTitleFocused ? styles.disabled : ''}`}
+          onClick={() => {
+            if (isTitleFocused) return;
+            setIsEditorOpen((prev) => !prev);
+          }}
           onMouseDown={(e) => e.preventDefault()}
         />
       </div>

--- a/src/feature/board/component/AttachmentBar/AttachmentBar.module.css
+++ b/src/feature/board/component/AttachmentBar/AttachmentBar.module.css
@@ -6,6 +6,7 @@
   bottom: 0;
   z-index: 100;
 }
+
 .attachmentBar {
   height: 7rem;
   background-color: var(--blue-0);
@@ -13,13 +14,21 @@
   display: flex;
   align-items: center;
 }
+
 .image {
   margin-right: 2.4rem;
   cursor: pointer;
 }
+
+.disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
 .imageInput {
   display: none;
 }
+
 .videoInput {
   display: none;
 }

--- a/src/feature/editor/component/FixedMenuEditor/FixedMenuEditor.jsx
+++ b/src/feature/editor/component/FixedMenuEditor/FixedMenuEditor.jsx
@@ -20,7 +20,7 @@ const PRESET_BG_COLORS = [
   { label: '파랑', value: 'var(--blue-2)' },
 ];
 
-export default function FixedMenuEditor({ editor, isTitleFocused }) {
+export default function FixedMenuEditor({ editor }) {
   const editorState = useEditorState({
     editor,
     selector: (ctx) => ({
@@ -77,10 +77,8 @@ export default function FixedMenuEditor({ editor, isTitleFocused }) {
         e.preventDefault();
       }}
     >
-      {isTitleFocused && <div className={styles.toolbarBlocker} />}
       <div ref={headingRef} className={styles.headingWrapper}>
         <button
-          disabled={isTitleFocused}
           className={styles.headingButton}
           onClick={() => setHeadingOpen((prev) => !prev)}
         >
@@ -101,7 +99,6 @@ export default function FixedMenuEditor({ editor, isTitleFocused }) {
               <button
                 key={option.value}
                 className={`${styles.headingOption} ${getCurrentHeading() === option.value ? styles.headingOptionActive : ''}`}
-                disabled={isTitleFocused}
                 onClick={() => {
                   if (option.value === 'paragraph') {
                     editor.chain().focus().setParagraph().run();
@@ -125,7 +122,6 @@ export default function FixedMenuEditor({ editor, isTitleFocused }) {
       <div ref={textColorRef} className={styles.colorPickerWrapper}>
         {/* 폰트 색상 토글 버튼 */}
         <button
-          disabled={isTitleFocused}
           onClick={() => setShowTextColor((prev) => !prev)}
           style={{ color: textColor || 'var(--grey-4)' }}
         >
@@ -138,7 +134,6 @@ export default function FixedMenuEditor({ editor, isTitleFocused }) {
           {/* 색상 없음 */}
           <button
             className={styles.colorSwatchNone}
-            disabled={isTitleFocused}
             title='색상 없음'
             onClick={() => {
               setTextColor('');
@@ -151,7 +146,6 @@ export default function FixedMenuEditor({ editor, isTitleFocused }) {
           {/* 고정 색상 */}
           {PRESET_COLORS.map((color) => (
             <button
-              disabled={isTitleFocused}
               key={color.label}
               className={`${styles.colorSwatch} ${textColor === color.value ? styles.selected : ''}`}
               style={{ backgroundColor: color.value }}
@@ -171,7 +165,6 @@ export default function FixedMenuEditor({ editor, isTitleFocused }) {
 
       <div ref={bgColorRef} className={styles.colorPickerWrapper}>
         <button
-          disabled={isTitleFocused}
           onClick={() => setShowBgColor((prev) => !prev)}
           style={{
             '--bg-icon-fill': bgColor || '#E6F7B1',
@@ -185,7 +178,6 @@ export default function FixedMenuEditor({ editor, isTitleFocused }) {
           className={`${styles.colorPaletteInline} ${showBgColor ? styles.open : ''}`}
         >
           <button
-            disabled={isTitleFocused}
             className={styles.colorSwatchNone}
             title='배경색 없음'
             onClick={() => {
@@ -203,7 +195,6 @@ export default function FixedMenuEditor({ editor, isTitleFocused }) {
           {/* 고정 색상 */}
           {PRESET_BG_COLORS.map((color) => (
             <button
-              disabled={isTitleFocused}
               key={color.label}
               className={`${styles.colorSwatch} ${bgColor === color.value ? styles.selected : ''}`}
               style={{ backgroundColor: color.value }}
@@ -224,7 +215,6 @@ export default function FixedMenuEditor({ editor, isTitleFocused }) {
       <button
         aria-label='굵게'
         onClick={() => editor.chain().focus().toggleBold().run()}
-        disabled={isTitleFocused}
         style={editorState.isBold ? { '--icon-stroke': 'var(--blue-4)' } : {}}
       >
         <Icon id='bold' width={24} height={24} />
@@ -233,7 +223,6 @@ export default function FixedMenuEditor({ editor, isTitleFocused }) {
       <button
         aria-label='밑줄'
         onClick={() => editor.chain().focus().toggleUnderline().run()}
-        disabled={isTitleFocused}
         style={
           editorState.isUnderline ? { '--icon-stroke': 'var(--blue-4)' } : {}
         }
@@ -244,7 +233,6 @@ export default function FixedMenuEditor({ editor, isTitleFocused }) {
       <button
         aria-label='취소선'
         onClick={() => editor.chain().focus().toggleStrike().run()}
-        disabled={isTitleFocused}
         style={editorState.isStrike ? { '--icon-stroke': 'var(--blue-4)' } : {}}
       >
         <Icon id='strikethrough' width={24} height={24} />

--- a/src/feature/editor/component/FixedMenuEditor/FixedMenuEditor.jsx
+++ b/src/feature/editor/component/FixedMenuEditor/FixedMenuEditor.jsx
@@ -51,12 +51,6 @@ export default function FixedMenuEditor({ editor, isTitleFocused }) {
     return 'paragraph';
   };
 
-  const handleMouseDown = (e) => {
-    if (isTitleFocused) {
-      e.preventDefault();
-    }
-  };
-
   useEffect(() => {
     const handleClickOutside = (event) => {
       [
@@ -77,7 +71,12 @@ export default function FixedMenuEditor({ editor, isTitleFocused }) {
   if (!editor) return null;
 
   return (
-    <div className={styles.toolbar} onMouseDown={handleMouseDown}>
+    <div
+      className={styles.toolbar}
+      onMouseDown={(e) => {
+        e.preventDefault();
+      }}
+    >
       {isTitleFocused && <div className={styles.toolbarBlocker} />}
       <div ref={headingRef} className={styles.headingWrapper}>
         <button

--- a/src/feature/editor/component/FixedMenuEditor/FixedMenuEditor.module.css
+++ b/src/feature/editor/component/FixedMenuEditor/FixedMenuEditor.module.css
@@ -17,15 +17,6 @@
   position: relative;
 }
 
-.toolbarBlocker {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: 999;
-}
-
 .toolbar {
   height: 60px;
   gap: 20px;

--- a/src/feature/editor/constant/embed-sources.js
+++ b/src/feature/editor/constant/embed-sources.js
@@ -13,7 +13,7 @@ export const EMBED_SOURCES = [
   },
   {
     name: 'instagram-reel',
-    sourcePattern: /instagram\.com\/reel\/([a-zA-Z0-9_-]+)/,
+    sourcePattern: /instagram\.com\/reels?\/([a-zA-Z0-9_-]+)/,
     toEmbedUrl: (_url, match) =>
       `https://www.instagram.com/reel/${match[1]}/embed/`,
     embedUrlPattern:


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1659 

- [Notion](https://www.notion.so/snorose/AttachmentBar-3687ef0aa3bf80cd9b17d3682a37aa28?source=copy_link)

## 🎯 변경 사항

- 임베드 허용 리스트 내 인스타 릴스 링크 정규식 수정 (reel, reels 허용)
- 텍스트 드래그 > 스타일 적용을 위해 에디터바 클릭해도 텍스트에 포커스 유지
- iOS/AOS 환경에서 키보드 사용 시 AttachmentBar 표시 위치 개선
- iOS Chrome 브라우저 한정 AttachmentBar 위치 계산 분기 처리
- 제목 포커스 시 AttachmentBar의 에디터 버튼 비활성화 표시

## 📸 스크린샷 (선택 사항)

| 제목 포커스 시 | 내용 포커스 시 |
| :----: | :---: |
| <img width="1206" height="2622" alt="IMG_1948" src="https://github.com/user-attachments/assets/08014cec-9497-432c-9189-eb8f861d15bb" /> | <img width="1206" height="2622" alt="IMG_1949" src="https://github.com/user-attachments/assets/2088f1e7-f759-445d-97e9-1c24b0655d32" /> |


## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
- 인스타 릴스 링크 두 형식(reel, reels) 모두 붙여넣기 시 버블 메뉴 표시되는지 확인해주세요!
- 텍스트 드래그 > 스타일 적용을 위해 에디터바 클릭해도 텍스트에 포커스 유지되는지 확인해주세요!
- AOS 환경에서 키보드 사용 시 AttachmentBar 표시 위치 적절한지 확인해주세요! (iOS는 Safari와 Chrome 브라우저에서 확인 완료했습니다)
- 제목 포커스 시 AttachmentBar의 에디터 버튼 비활성화된 것을 확인해주세요!
- 내용 포커스 시 AttachmentBar의 에디터 버튼이 활성화되고 에디터바가 표시되는지 확인해주세요!