### PR TITLE
[SNO-456] 게시글 수정 페이지에서 제목 포커스 시 에디터 버튼 비활성화

### DIFF
--- a/src/page/board/EditPostPage/EditPostPage.jsx
+++ b/src/page/board/EditPostPage/EditPostPage.jsx
@@ -385,6 +385,7 @@ export function NewEditPostPage({ isNotice = false }) {
   const [userDisplay, setUserDisplay] = useState('');
   const [submitDisabled, setSubmitDisabled] = useState(false);
   const [isBlock, setIsBlock] = useState(false);
+  const [isTitleFocused, setIsTitleFocused] = useState(false);
 
   //'게시글 상세 조회' API에서 제공하는 기존 첨부파일 정보
   const [attachmentsInfo, setAttachmentsInfo] = useState([]);
@@ -393,13 +394,15 @@ export function NewEditPostPage({ isNotice = false }) {
   const [trashImageIndex, setTrashImageIndex] = useState(null);
   const trashImageConfirmModal = useModal();
 
+  const [editor, setEditor] = useState(null);
+
   // isBlock 업데이트
   useEffect(() => {
     if (!data || Object.keys(data).length === 0) return;
 
     setIsBlock(
       data.title !== title.trim() ||
-        data.content !== content.trim() ||
+        data.content !== editor?.getHTML() ||
         data.isNotice !== isNotice ||
         data.attachments !== attachmentsInfo
     );
@@ -443,6 +446,13 @@ export function NewEditPostPage({ isNotice = false }) {
     setAttachmentsInfo(data.attachments);
   }, [data]);
 
+  // 에디터에 기존 게시글 내용 반영
+  useEffect(() => {
+    if (!editor || !data?.content) return;
+
+    editor.commands.setContent(data.content);
+  }, [editor, data]);
+
   // 게시글 수정
   const mutation = useMutation({
     mutationKey: [MUTATION_KEY.editPost],
@@ -484,7 +494,7 @@ export function NewEditPostPage({ isNotice = false }) {
       boardId,
       postId,
       title,
-      content,
+      content: sanitizeHtml(preserveEmptyParagraphs(editor?.getHTML() ?? '')),
       isNotice,
       attachmentsInfo,
       deleteAttachments,
@@ -560,12 +570,29 @@ export function NewEditPostPage({ isNotice = false }) {
                 placeholder='제목을 입력해주세요'
                 value={title}
                 onChange={handleTitleChange}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+                    e.preventDefault();
+                  }
+                }}
+                onFocus={() => setIsTitleFocused(true)}
+                onBlur={() => setIsTitleFocused(false)}
               />
-              <TextareaAutosize
+              {/*<TextareaAutosize
                 className={styles.text}
                 placeholder='내용을 작성해주세요'
                 value={content}
                 onChange={(e) => setContent(e.target.value)}
+              />*/}
+              <EditorContainer
+                placeholder='내용'
+                onEditorReady={setEditor}
+                onChangeEditor={(editor) => {
+                  const sanitized = sanitizeHtml(
+                    preserveEmptyParagraphs(editor.getHTML())
+                  );
+                  setContent(sanitized);
+                }}
               />
               <AttachmentList
                 attachmentsInfo={attachmentsInfo}
@@ -606,6 +633,8 @@ export function NewEditPostPage({ isNotice = false }) {
         <AttachmentBar
           attachmentsInfo={attachmentsInfo}
           setAttachmentsInfo={setAttachmentsInfo}
+          editor={editor}
+          isTitleFocused={isTitleFocused}
         />
       </div>
 

--- a/src/page/board/EditPostPage/EditPostPage.jsx
+++ b/src/page/board/EditPostPage/EditPostPage.jsx
@@ -63,6 +63,7 @@ export default function EditPostPage() {
   const [userDisplay, setUserDisplay] = useState('');
   const [submitDisabled, setSubmitDisabled] = useState(false);
   const [isBlock, setIsBlock] = useState(false);
+  const [isTitleFocused, setIsTitleFocused] = useState(false);
 
   //'게시글 상세 조회' API에서 제공하는 기존 첨부파일 정보
   const [attachmentsInfo, setAttachmentsInfo] = useState([]);
@@ -264,6 +265,13 @@ export default function EditPostPage() {
                 placeholder='제목을 입력해주세요'
                 value={title}
                 onChange={handleTitleChange}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+                    e.preventDefault();
+                  }
+                }}
+                onFocus={() => setIsTitleFocused(true)}
+                onBlur={() => setIsTitleFocused(false)}
               />
               {/*<TextareaAutosize
                 className={styles.text}
@@ -329,6 +337,7 @@ export default function EditPostPage() {
           attachmentsInfo={attachmentsInfo}
           setAttachmentsInfo={setAttachmentsInfo}
           editor={editor}
+          isTitleFocused={isTitleFocused}
         />
       </div>
 

--- a/src/page/board/WritePostPage/WritePostPage.jsx
+++ b/src/page/board/WritePostPage/WritePostPage.jsx
@@ -503,6 +503,8 @@ export function NewWritePostPage({ isNotice = false }) {
 
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
+  const [isTitleFocused, setIsTitleFocused] = useState(false);
+  const [editor, setEditor] = useState(null);
 
   const [isBlock, setIsBlock] = useState(false);
 
@@ -727,12 +729,29 @@ export function NewWritePostPage({ isNotice = false }) {
                 placeholder='제목을 입력해주세요'
                 value={title}
                 onChange={handleTitleChange}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+                    e.preventDefault();
+                  }
+                }}
+                onFocus={() => setIsTitleFocused(true)}
+                onBlur={() => setIsTitleFocused(false)}
               />
-              <TextareaAutosize
+              {/*<TextareaAutosize
                 className={styles.text}
                 placeholder='내용을 작성해주세요'
                 value={content}
                 onChange={(e) => setContent(e.target.value)}
+              />*/}
+              <EditorContainer
+                placeholder='내용'
+                onEditorReady={(editorInstance) => setEditor(editorInstance)}
+                onChangeEditor={(editor) => {
+                  const sanitized = sanitizeHtml(
+                    preserveEmptyParagraphs(editor.getHTML())
+                  );
+                  setContent(sanitized);
+                }}
               />
               <AttachmentList
                 attachmentsInfo={attachmentsInfo}
@@ -773,6 +792,8 @@ export function NewWritePostPage({ isNotice = false }) {
         <AttachmentBar
           attachmentsInfo={attachmentsInfo}
           setAttachmentsInfo={setAttachmentsInfo}
+          editor={editor}
+          isTitleFocused={isTitleFocused}
         />
       </div>
 

--- a/src/page/board/WritePostPage/WritePostPage.jsx
+++ b/src/page/board/WritePostPage/WritePostPage.jsx
@@ -386,6 +386,11 @@ export default function WritePostPage() {
                 placeholder='제목을 입력해주세요'
                 value={title}
                 onChange={handleTitleChange}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+                    e.preventDefault();
+                  }
+                }}
                 onFocus={() => setIsTitleFocused(true)}
                 onBlur={() => setIsTitleFocused(false)}
               />


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1662 

## 🎯 변경 사항

- 게시글 수정 페이지에서 제목 포커스 시 에디터 버튼 비활성화
- 게시글 수정 페이지에서 내용 포커스 시 에디터 버튼 활성화
- 게시글 작성 및 수정 페이지에서 제목 엔터키 제한 (줄바꿈 안됨)
- NewWritePostPage, NewEditPostPage 컴포넌트에 에디터 관련 설정 동일하게 적용

## 📸 스크린샷 (선택 사항)

<img width="747" height="1072" alt="스크린샷 2026-05-31 오전 1 25 15" src="https://github.com/user-attachments/assets/52733bfa-e809-4d61-b397-c470a79ef97e" />

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
- 게시글 수정 페이지에서 제목과 내용 포커스 시 에디터 버튼 활성화 여부 확인해주세요!
- 게시글 작성 및 수정 페이지에서 제목 포커스 후 엔터키 눌러도 줄바꿈이 안되는 것 확인해주세요!