### PR TITLE
[SNO-464] #1666 게시글 상세 제목 영역 레이아웃 조정

### DIFF
--- a/src/feature/board/ui/PostDetailView.jsx
+++ b/src/feature/board/ui/PostDetailView.jsx
@@ -62,7 +62,7 @@ export default function PostDetailView({
         <div className={styles.titleContainer}>
           <h1 className={styles.title}>{data.title}</h1>
           <span className={styles.views}>
-            {data.viewCount.toLocaleString()} views
+            {(data.viewCount ?? 0).toLocaleString()} views
           </span>
         </div>
 

--- a/src/feature/board/ui/PostDetailView.jsx
+++ b/src/feature/board/ui/PostDetailView.jsx
@@ -62,7 +62,7 @@ export default function PostDetailView({
         <div className={styles.titleContainer}>
           <h1 className={styles.title}>{data.title}</h1>
           <span className={styles.views}>
-            &nbsp;&nbsp;{data.viewCount.toLocaleString()} views
+            {data.viewCount.toLocaleString()} views
           </span>
         </div>
 

--- a/src/feature/board/ui/PostDetailView.module.css
+++ b/src/feature/board/ui/PostDetailView.module.css
@@ -56,20 +56,23 @@
   margin: 0.7rem 0 2.6rem 0;
 
   display: flex;
-  align-items: flex-end;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.4rem;
 }
 
 .title {
+  width: 100%;
   font: var(--text-title-1-bold);
   color: var(--grey-4);
+  word-break: keep-all;
+  overflow-wrap: break-word;
 }
 
 .views {
   white-space: nowrap;
   color: var(--blue-3);
   font-size: 1.1rem;
-  padding-left: 0.2rem;
-  padding-bottom: 0.7rem;
 }
 
 /* content */


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1666

- [Figma](https://www.figma.com/design/00Ywy8VC5KoHOSu01uC9sZ/-%EC%8A%A4%EB%85%B8%EB%A1%9C%EC%A6%88--%EC%9C%A0%EC%A0%80%EC%9B%B9-%EB%94%94%EC%9E%90%EC%9D%B8?node-id=9457-29421&m=dev)


## 🎯 변경 사항

- 조회수를 제목 아래로 이동
- 긴 제목이 단어 단위로 줄바꿈되도록 수정
- 조회수 기본값 처리로 렌더링 에러 방지

## 📸 스크린샷 (선택 사항)

| Before | After |
| :----: | :---: |
| <img width="293" height="633" alt="image" src="https://github.com/user-attachments/assets/2d72a610-c537-4bc9-a791-47a7f2571876" /> | <img width="293" height="633" alt="image" src="https://github.com/user-attachments/assets/82ff0f32-f88a-42a1-b031-129c0c5aad97" /> |


## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
