### PR TITLE
[SNO-453] #1677 외부 링크 안내 모달 권한 유지 및 모달 문구 변경

### DIFF
--- a/src/feature/board/ui/PostDetailView.jsx
+++ b/src/feature/board/ui/PostDetailView.jsx
@@ -39,7 +39,7 @@ export default function PostDetailView({
 }) {
 
   const { userInfo } = useAuth();
-  console.log('userInfo:', userInfo);
+
   const [linkModalOpen, setLinkModalOpen] = useState(false);
   const [selectedLink, setSelectedLink] = useState('');
   const [dontShowAgain, setDontShowAgain] = useState(false);

--- a/src/feature/board/ui/PostDetailView.jsx
+++ b/src/feature/board/ui/PostDetailView.jsx
@@ -39,15 +39,15 @@ export default function PostDetailView({
 }) {
 
   const { userInfo } = useAuth();
-
+  console.log('userInfo:', userInfo);
   const [linkModalOpen, setLinkModalOpen] = useState(false);
   const [selectedLink, setSelectedLink] = useState('');
   const [dontShowAgain, setDontShowAgain] = useState(false);
   const [clickedImageIndex, setClickedImageIndex] = useState(0);
 
   // userInfo 로딩 전이면 storageKey를 null로
-  const storageKey = userInfo?.encryptedUserId
-    ? `hideLinkAlert_${userInfo.encryptedUserId}`
+  const storageKey = userInfo?.loginId
+    ? `hideLinkAlert_${userInfo.loginId}`
     : null;
 
   const handleLinkClick = (event) => {

--- a/src/shared/component/modal/LinkAlertModal/LinkAlertModal.jsx
+++ b/src/shared/component/modal/LinkAlertModal/LinkAlertModal.jsx
@@ -14,9 +14,9 @@ export default function LinkAlertModal({
   return (
     <ConfirmModal
       modalText={{
-        title: '외부 링크로 연결할까요?',
+        title: '외부 링크로 이동할까요?',
         description:
-          '다른 사용자가 공유한 외부 링크의 <br />안전 여부는 스노로즈에서 내용을 <br />확인하기 어려우니 주의해주세요',
+          '다른 사용자가 게시한 외부 링크는<br /> 안전하지 않을 수 있어요',
         cancelText: '취소',
         confirmText: '연결',
       }}


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1677 

- [Figma](https://www.figma.com/design/00Ywy8VC5KoHOSu01uC9sZ/-%EC%8A%A4%EB%85%B8%EB%A1%9C%EC%A6%88--%EC%9C%A0%EC%A0%80%EC%9B%B9-%EB%94%94%EC%9E%90%EC%9D%B8?node-id=9457-18349&p=f&t=jhUUmjLa49gZe5TO-0)
- [Notion](https://app.notion.com/p/snorose/3707ef0aa3bf8069b8e9d443da6e941c)

## 🎯 변경 사항

- 링크 이동 모달의 문구를 변경하였습니다
- 기존에 값이 변경되는 encryptedUserId 기준으로 다시 보지 않기를 구현해서 다시보지 않기가 잘 반영되지 않는 문제들이 있었습니다. 기준을 loginId로 변경하였습니다. 

## 📸 스크린샷 (선택 사항)

| Before | After |
| :-----: | :----: |
| <img width="810" alt="before" src="https://github.com/user-attachments/assets/32c5c28a-9f7d-449f-bc37-644d7d6ded80" /> | <img width="589" alt="after" src="https://github.com/user-attachments/assets/a025ee26-db1d-4bda-acc1-0a1924f31839" /> |

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
- localStorage로 구현하였기 때문에 브라우저가 바뀌면 다시 창이 뜨게 됩니다. 이 점 참고해주세요! 