### PR TITLE
[SNO-466] #1683 인앱 브라우저 환경에서 AttachmentBar 가리는 현상 해결

### DIFF
--- a/src/feature/attachment/hook/useAttachmentBarPosition.js
+++ b/src/feature/attachment/hook/useAttachmentBarPosition.js
@@ -13,6 +13,14 @@ const isAndroid = () => /Android/i.test(navigator.userAgent);
 // iOS Chrome(CriOS)은 Safari와 달리 키보드 위에 자체 toolbar(뒤로/앞으로/완료)가 떠서 바를 가린다.
 const isIOSChrome = () => isIOS() && /CriOS/.test(navigator.userAgent);
 
+// iOS 인앱 브라우저(네이버/카카오톡/인스타그램)도 키보드 위에 자체 InputAccessoryView(완료 등)가 떠서 바를 가린다.
+const IOS_INAPP_BROWSER_PATTERNS = [/NAVER\(inapp/i, /KAKAOTALK/i, /Instagram/i];
+const isIOSInAppBrowser = () =>
+  isIOS() && IOS_INAPP_BROWSER_PATTERNS.some((re) => re.test(navigator.userAgent));
+
+// iOS Chrome / 인앱 브라우저처럼 키보드 위에 자체 toolbar가 떠서 Safari식 보정이 필요 없는 환경.
+const hasOwnKeyboardToolbar = () => isIOSChrome() || isIOSInAppBrowser();
+
 // 액세서리 바/toolbar는 편집 가능한 요소(input/textarea/contentEditable) 포커스 시에만 뜬다.
 const isEditableFocused = () => {
   const el = document.activeElement;
@@ -30,8 +38,8 @@ const computeIOSOffset = (vv) => {
   return Math.max(0, window.innerHeight - vv.height - toolbar);
 };
 
-// iOS Chrome: Safari의 액세서리 바 보정(-IOS_KEYBOARD_TOOLBAR) 없이 키보드 바로 위에 붙는다.
-const computeIOSChromeOffset = (vv) =>
+// iOS Chrome / 인앱 브라우저: Safari의 액세서리 바 보정(-IOS_KEYBOARD_TOOLBAR) 없이 키보드 바로 위에 붙는다.
+const computeKeyboardTopOffset = (vv) =>
   Math.max(0, window.innerHeight - vv.height);
 
 const computeAndroidOffset = (vv) => {
@@ -46,8 +54,8 @@ export function useAttachmentBarPosition() {
     const vv = window.visualViewport;
     if (!vv) return;
 
-    const computeOffset = isIOSChrome()
-      ? computeIOSChromeOffset
+    const computeOffset = hasOwnKeyboardToolbar()
+      ? computeKeyboardTopOffset
       : isIOS()
         ? computeIOSOffset
         : isAndroid()


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1683

- [Notion](https://app.notion.com/p/snorose/Naver-AttachmentBar-3717ef0aa3bf808c9a7fd32107e47dae?source=copy_link)

## 🎯 변경 사항

인앱 브라우저 환경에서 키보드 위 자체 InputAccessoryView로 인해 AttachmentBar가 가려지지 않는 현상을 해결하였습니다.

## 📸 스크린샷 (선택 사항)

| 네이버 | 카카오톡 |
| :----: | :---: |
| <img width="1206" height="2378" alt="image" src="https://github.com/user-attachments/assets/febced21-6a20-4870-bc65-19ee82d4bb92" /> | <img width="1206" height="2321" alt="image" src="https://github.com/user-attachments/assets/404980d8-c889-4ac5-981d-f4203ac0ca9d" /> |

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
- 갤럭시 웹 브라우저(삼성 인터넷, 크롬) 환경과 인앱 브라우저(네이버, 카카오톡, 인스타그램) 환경에서 AttachmentBar 가려지는 현상 발생하지 않는지 확인해주세요!
- iOS 웹 브라우저(Safari, 크롬) 환경과 인앱 브라우저(네이버, 카카오톡, 인스타그램) 환경에서 Attachmentbar가 가려지지 않는 것은 확인하였습니다.