### PR TITLE
[SNO-241] #1304 비밀번호 변경 Input 컴포넌트 교체

### DIFF
--- a/src/page/user/ChangePwPage/ChangePwPage.jsx
+++ b/src/page/user/ChangePwPage/ChangePwPage.jsx
@@ -1,9 +1,15 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useMutation } from '@tanstack/react-query';
 
-import { ActionButton, BackAppBar, PwInput } from '@/shared/component';
+import {
+  ActionButton,
+  BackAppBar,
+  ErrorMessage,
+  Label,
+  PasswordInput,
+} from '@/shared/component';
 import { MUTATION_KEY, TOAST } from '@/shared/constant';
 import { useToast } from '@/shared/hook';
 
@@ -12,15 +18,12 @@ import { updatePassword } from '@/apis';
 import styles from './ChangePwPage.module.css';
 
 export default function ChangePwPage() {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [newPasswordCheck, setNewPasswordCheck] = useState('');
-  const [newPasswordError, setNewPasswordError] = useState('');
-  const [newPasswordCheckError, setNewPasswordCheckError] = useState('');
-  const [isPasswordValid, setIsPasswordValid] = useState(false);
-
-  const navigate = useNavigate();
-  const { toast } = useToast();
 
   const { mutate: updatePasswordMutate, isPending: isUpdatePasswordPending } =
     useMutation({
@@ -40,71 +43,52 @@ export default function ChangePwPage() {
     const specialCharRegex = /[!@#%^&*]/;
     const emojiRegex = /[\uD83C-\uDBFF\uDC00-\uDFFF]+/g;
 
-    if (
-      password.length < 8 ||
-      !spaceRegex.test(password) ||
-      !/[A-Za-z]/.test(password) ||
-      !/\d/.test(password) ||
-      !specialCharRegex.test(password) ||
-      emojiRegex.test(password)
-    ) {
-      setNewPasswordError(
-        '영어, 숫자, 특수문자(!@#%^&*)를 사용하여 8자 이상 16자 이하로 작성해주세요.'
-      );
-      setIsPasswordValid(false);
-    } else {
-      setNewPasswordError('');
-      setIsPasswordValid(true);
-    }
+    return (
+      password.length >= 8 &&
+      spaceRegex.test(password) &&
+      /[A-Za-z]/.test(password) &&
+      /\d/.test(password) &&
+      specialCharRegex.test(password) &&
+      !emojiRegex.test(password)
+    );
   };
 
-  const validatePasswordMatch = (passwordCheck, password) => {
-    if (passwordCheck !== password) {
-      setNewPasswordCheckError('비밀번호가 일치하지 않아요');
-    } else {
-      setNewPasswordCheckError('');
-    }
+  const validatePasswordMatch = (passwordCheck) => {
+    return passwordCheck === newPassword;
   };
 
-  const handleSubmitButtonClick = () => {
-    if (newPassword !== newPasswordCheck) {
-      return;
-    }
+  const inputProps = [
+    {
+      id: 'current-pw',
+      label: '현재 비밀번호',
+      placeholder: '기존 비밀번호를 입력하세요',
+      value: currentPassword,
+      onChange: setCurrentPassword,
+    },
+    {
+      id: 'new-pw',
+      label: '새 비밀번호',
+      placeholder: '새로운 비밀번호를 입력하세요',
+      value: newPassword,
+      onChange: setNewPassword,
+      validate: validatePasswordStrength,
+      errorMessage:
+        '영어, 숫자, 특수문자(!@#%^&*)를 사용하여 8자 이상 16자 이하로 작성해주세요.',
+    },
+    {
+      id: 'new-pw-check',
+      label: '새 비밀번호 확인',
+      placeholder: '새 비밀번호를 다시 입력하세요',
+      value: newPasswordCheck,
+      onChange: setNewPasswordCheck,
+      validate: validatePasswordMatch,
+      errorMessage: '비밀번호가 일치하지 않아요',
+    },
+  ];
 
-    updatePasswordMutate({
-      currentPassword,
-      newPassword,
-    });
-  };
-
-  const handleCurrentPasswordInputChange = (e) => {
-    setCurrentPassword(e.target.value);
-  };
-
-  const handleNewPasswordInputChange = (e) => {
-    setNewPassword(e.target.value);
-  };
-
-  const handleConfirmNewPasswordInputChange = (e) => {
-    setNewPasswordCheck(e.target.value);
-  };
-
-  useEffect(() => {
-    if (newPassword) {
-      validatePasswordStrength(newPassword);
-    } else {
-      setNewPasswordError('');
-      setIsPasswordValid(false);
-    }
-  }, [newPassword]);
-
-  useEffect(() => {
-    if (newPasswordCheck) {
-      validatePasswordMatch(newPasswordCheck, newPassword);
-    } else {
-      setNewPasswordCheckError('');
-    }
-  }, [newPasswordCheck, newPassword]);
+  const isPasswordValid =
+    validatePasswordStrength(newPassword) &&
+    validatePasswordMatch(newPasswordCheck);
 
   return (
     <main className={styles.changePasswordPage}>
@@ -115,12 +99,17 @@ export default function ChangePwPage() {
         <div className={styles.submitBtn}>
           <ActionButton
             type='button'
-            disabled={
-              isUpdatePasswordPending ||
-              newPassword !== newPasswordCheck ||
-              !isPasswordValid
-            }
-            onClick={handleSubmitButtonClick}
+            disabled={isUpdatePasswordPending || !isPasswordValid}
+            onClick={() => {
+              if (!isPasswordValid) {
+                return;
+              }
+
+              updatePasswordMutate({
+                currentPassword,
+                newPassword,
+              });
+            }}
           >
             완료
           </ActionButton>
@@ -130,29 +119,27 @@ export default function ChangePwPage() {
       <section className={styles.contentContainer}>
         <h1 className={styles.pageTitle}>비밀번호 변경</h1>
         <div className={styles.updatePasswordForm}>
-          <PwInput
-            title='현재 비밀번호'
-            placeholder='기존 비밀번호를 입력하세요'
-            value={currentPassword}
-            isStatic
-            onChange={handleCurrentPasswordInputChange}
-          />
+          {inputProps.map((props) => {
+            let status = 'default';
 
-          <PwInput
-            title='새 비밀번호'
-            placeholder='새로운 비밀번호를 입력하세요'
-            value={newPassword}
-            errorMessage={newPasswordError}
-            onChange={handleNewPasswordInputChange}
-          />
+            if ('validate' in props) {
+              status = props.validate(props.value) ? 'valid' : 'error';
+            }
 
-          <PwInput
-            title='새 비밀번호 확인'
-            placeholder='새 비밀번호를 다시 입력하세요'
-            value={newPasswordCheck}
-            errorMessage={newPasswordCheckError}
-            onChange={handleConfirmNewPasswordInputChange}
-          />
+            if (props.value === '') {
+              status = 'default';
+            }
+
+            return (
+              <div key={`change-pw-${props.id}`} className={styles.field}>
+                <Label htmlFor={props.id}>{props.label}</Label>
+                <PasswordInput status={status} {...props} />
+                {status === 'error' && (
+                  <ErrorMessage>{props.errorMessage}</ErrorMessage>
+                )}
+              </div>
+            );
+          })}
         </div>
       </section>
     </main>

--- a/src/page/user/ChangePwPage/ChangePwPage.jsx
+++ b/src/page/user/ChangePwPage/ChangePwPage.jsx
@@ -1,10 +1,11 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+
 import { useMutation } from '@tanstack/react-query';
 
-import { useToast } from '@/shared/hook';
 import { ActionButton, BackAppBar, PwInput } from '@/shared/component';
 import { MUTATION_KEY, TOAST } from '@/shared/constant';
+import { useToast } from '@/shared/hook';
 
 import { updatePassword } from '@/apis';
 

--- a/src/page/user/ChangePwPage/ChangePwPage.jsx
+++ b/src/page/user/ChangePwPage/ChangePwPage.jsx
@@ -100,7 +100,9 @@ export default function ChangePwPage() {
         <div className={styles.submitBtn}>
           <ActionButton
             type='button'
-            disabled={isUpdatePasswordPending || !isPasswordValid}
+            disabled={
+              isUpdatePasswordPending || !currentPassword || !isPasswordValid
+            }
             onClick={() => {
               if (!isPasswordValid) {
                 return;

--- a/src/page/user/ChangePwPage/ChangePwPage.jsx
+++ b/src/page/user/ChangePwPage/ChangePwPage.jsx
@@ -122,11 +122,11 @@ export default function ChangePwPage() {
       <section className={styles.contentContainer}>
         <h1 className={styles.pageTitle}>비밀번호 변경</h1>
         <div className={styles.updatePasswordForm}>
-          {inputProps.map((props) => {
+          {inputProps.map(({ label, validate, errorMessage, ...props }) => {
             let status = 'default';
 
-            if ('validate' in props) {
-              status = props.validate(props.value) ? 'valid' : 'error';
+            if (validate) {
+              status = validate(props.value) ? 'valid' : 'error';
             }
 
             if (props.value === '') {
@@ -135,10 +135,10 @@ export default function ChangePwPage() {
 
             return (
               <div key={`change-pw-${props.id}`} className={styles.field}>
-                <Label htmlFor={props.id}>{props.label}</Label>
+                <Label htmlFor={props.id}>{label}</Label>
                 <PasswordInput status={status} {...props} />
                 {status === 'error' && (
-                  <ErrorMessage>{props.errorMessage}</ErrorMessage>
+                  <ErrorMessage>{errorMessage}</ErrorMessage>
                 )}
               </div>
             );

--- a/src/page/user/ChangePwPage/ChangePwPage.jsx
+++ b/src/page/user/ChangePwPage/ChangePwPage.jsx
@@ -45,6 +45,7 @@ export default function ChangePwPage() {
 
     return (
       password.length >= 8 &&
+      password.length <= 16 &&
       spaceRegex.test(password) &&
       /[A-Za-z]/.test(password) &&
       /\d/.test(password) &&


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1304

## 🎯 변경 사항

- 비밀번호 변경 페이지의 입력 컴포넌트를 `PwInput`에서 `PasswordInput`으로 교체했습니다.
- 현재 비밀번호, 새 비밀번호, 새 비밀번호 확인 입력값을 `inputProps` 배열 기반으로 렌더링하도록 정리했습니다.
- 비밀번호 조건에 16자 이하 조건을 추가했습니다.

## 기타

- `PasswordInput`은 `onChange`에서 event가 아니라 value를 직접 전달하므로, 호출부에서도 `setState`를 바로 넘기는 방식으로 맞췄습니다.

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
