### PR TITLE
[SNO-488] #1725 FAQ 안내서 링크 클릭 UI 제공

### DIFF
--- a/src/feature/support/constant/faqList.js
+++ b/src/feature/support/constant/faqList.js
@@ -41,9 +41,10 @@ export const faqList = [
         ],
       },
       {
-        title: `⭐️ 더욱 자세한 사항은
-스노로즈 안내서 이용 꿀팁 페이지를 참고해 주세요.
-https://app.notion.com/p/snorose/3617ef0aa3bf8093b37cc88a54ac493c?v=3327ef0aa3bf81e48750000c0f590556&source=copy_link#38d7ef0aa3bf80d4a063e1c1d41ed257`,
+        title: `⭐️ 더욱 자세한 사항은`,
+        linkText: '스노로즈 안내서 이용 꿀팁 페이지 (링크)',
+        link: 'https://app.notion.com/p/snorose/3617ef0aa3bf8093b37cc88a54ac493c?v=3327ef0aa3bf81e48750000c0f590556&source=copy_link#38d7ef0aa3bf80d4a063e1c1d41ed257',
+        suffix: '를 참고해 주세요.',
       },
     ],
   },

--- a/src/feature/support/constant/faqList.js
+++ b/src/feature/support/constant/faqList.js
@@ -40,6 +40,11 @@ export const faqList = [
           `'알림 받기' 토글이 켜져 있고, 브라우저/기기 알림 권한이 '허용' 상태인지 확인해주세요.`,
         ],
       },
+      {
+        title: `⭐️ 더욱 자세한 사항은
+스노로즈 안내서 이용 꿀팁 페이지를 참고해 주세요.
+https://app.notion.com/p/snorose/3617ef0aa3bf8093b37cc88a54ac493c?v=3327ef0aa3bf81e48750000c0f590556&source=copy_link#38d7ef0aa3bf80d4a063e1c1d41ed257`,
+      },
     ],
   },
   {

--- a/src/page/support/FAQPage/FAQPage.jsx
+++ b/src/page/support/FAQPage/FAQPage.jsx
@@ -60,26 +60,45 @@ export default function FAQPage() {
             onClick={() => toggle(index)}
           >
             <div className={style.noticeBody}>
-              {faq.content.map(({ title, list, listStyle }, contentIndex) => (
-                <div key={contentIndex}>
-                  {title && (
-                    <h3 className={style.title}>
-                      {renderTextWithLinks(title)}
-                    </h3>
-                  )}
-                  {list && (
-                    <ul
-                      className={
-                        listStyle === 'none' ? style.listStyleNone : undefined
-                      }
-                    >
-                      {list.map((item, itemIndex) => (
-                        <li key={itemIndex}>{renderTextWithLinks(item)}</li>
-                      ))}
-                    </ul>
-                  )}
-                </div>
-              ))}
+              {faq.content.map(
+                (
+                  { title, list, listStyle, linkText, link, suffix },
+                  contentIndex
+                ) => (
+                  <div key={contentIndex}>
+                    {title && (
+                      <h3 className={style.title}>
+                        {renderTextWithLinks(title)}
+                        {link && (
+                          <>
+                            {' '}
+                            <a
+                              className={style.faqLink}
+                              href={link}
+                              target='_blank'
+                              rel='noreferrer noopener'
+                            >
+                              <span className={style.linkText}>{linkText}</span>
+                            </a>
+                            {suffix}
+                          </>
+                        )}
+                      </h3>
+                    )}
+                    {list && (
+                      <ul
+                        className={
+                          listStyle === 'none' ? style.listStyleNone : undefined
+                        }
+                      >
+                        {list.map((item, itemIndex) => (
+                          <li key={itemIndex}>{renderTextWithLinks(item)}</li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                )
+              )}
             </div>
           </Accordion>
         ))}

--- a/src/page/support/FAQPage/FAQPage.module.css
+++ b/src/page/support/FAQPage/FAQPage.module.css
@@ -24,6 +24,16 @@
   text-underline-offset: 0.2em;
 }
 
+.faqLink {
+  color: var(--blue-3);
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+}
+
+.faqLink:hover {
+  color: var(--blue-4);
+}
+
 /* notice */
 .notice {
   margin: 0 var(--default-margin) 5rem;


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1725


## 🎯 변경 사항

- FAQ에 스노로즈 안내서 이용 꿀팁 페이지 외부 링크 추가
- 안내서 링크 클릭 동작 및 호버 스타일 제공
  - 안내서 링크가 너무 길어서, 링크 클릭 동작 기능 추가했습니다. 
  - 안내서 링크: https://app.notion.com/p/snorose/3617ef0aa3bf8093b37cc88a54ac493c?v=3327ef0aa3bf81e48750000c0f590556&source=copy_link#38d7ef0aa3bf80d4a063e1c1d41ed257'

## 📸 스크린샷 (선택 사항)


| Before | After |
| :----: | :---: |
|  <img width="1710" height="2206" alt="image" src="https://github.com/user-attachments/assets/1488622f-c52f-4c01-9dc0-811681b1ab6f" />| <img width="1844" height="2206" alt="image" src="https://github.com/user-attachments/assets/7474ab66-249b-4625-9c6c-4b4773367df2" /> |


## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)

FAQ 안내서 링크의 외부 페이지 이동 및 링크 스타일을 확인해 주세요.