### PR TITLE
[SNO-485] #1727 검색 결과 로딩 문구 제거 및 아이콘 크기 조정

### DIFF
--- a/src/feature/search/component/SearchResultList/SearchResultListSuspense.jsx
+++ b/src/feature/search/component/SearchResultList/SearchResultListSuspense.jsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react';
-import { useSearchParams } from 'react-router-dom';
 import { ErrorBoundary } from 'react-error-boundary';
+import { useSearchParams } from 'react-router-dom';
+
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
 
 import { FetchLoading } from '@/shared/component';
@@ -26,7 +27,7 @@ export default function SearchResultListSuspense() {
           fallbackRender={SearchResultListErrorFallback}
           resetKeys={[params]}
         >
-          <Suspense fallback={<FetchLoading>검색 중</FetchLoading>}>
+          <Suspense fallback={<FetchLoading />}>
             <SearchResultList />
             {/* <SearchResultListWrapper /> */}
           </Suspense>

--- a/src/shared/component/loading/FetchLoading/FetchLoading.module.css
+++ b/src/shared/component/loading/FetchLoading/FetchLoading.module.css
@@ -14,14 +14,21 @@
   font-size: 1.3rem;
 }
 
-.icon {
-  animation: rotateAndPause 1s linear infinite;
-  width: 2.5rem;
-  height: 1.6rem;
+.icon,
+.iconStatic {
+  width: 4.4rem;
+  height: 2.7rem;
 }
 
-.iconStatic {
-  animation: none;
+.icon {
+  animation: rotateAndPause 1s linear infinite;
+}
+
+.icon img,
+.iconStatic img {
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 @keyframes rotateAndPause {


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1727

## 🎯 변경 사항

- 검색 결과 로딩 문구 `검색 중` 제거
- 공통 로딩 아이콘 크기 기존 `2.5rem × 1.6rem` → `4.4rem × 2.7rem` 적용
- SVG 이미지가 지정된 아이콘 영역을 채우도록 조정

## 📸 스크린샷 (선택 사항)


| Before | After |
| :----: | :---: |
| <img width="780" height="1688" alt="image" src="https://github.com/user-attachments/assets/2737fa6a-ab7a-4c04-93bd-5751f20f84f6" /> |<img width="780" height="1688" alt="image" src="https://github.com/user-attachments/assets/e308db3a-5662-451b-adad-c095aea3eaf2" /> |


## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)

검색 결과와 게시글 작성 중 로딩 아이콘의 크기 및 표시 상태를 확인해주세요.