### PR TITLE
[SNO-484] #1729 사이드바 메뉴 호버 색상 제거

### DIFF
--- a/src/shared/component/layout/Sidebar/Sidebar.module.css
+++ b/src/shared/component/layout/Sidebar/Sidebar.module.css
@@ -42,10 +42,6 @@
   color: var(--grey-4);
 }
 
-.title:hover {
-  color: var(--blue-3);
-}
-
 /* menu list */
 .list {
   display: flex;
@@ -61,10 +57,6 @@
 
 .item li {
   padding: 0.6rem 0;
-}
-
-.item > li:hover {
-  color: var(--blue-3);
 }
 
 .item:first-child > li {


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1729


## 🎯 변경 사항

- 사이드바 제목과 메뉴 항목의 호버 색상 제거

## 📸 스크린샷 (선택 사항)


| Before | After |
| :----: | :---: |
| <img width="596" alt="image" src="https://github.com/user-attachments/assets/7fe848bb-7b1c-4e18-9aef-6e11c7915d1e" /> | <img width="596" height="711" alt="image" src="https://github.com/user-attachments/assets/449c2f79-0b89-48e0-b429-e74c417d95dc" /> |
## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)

사이드바 메뉴 호버 시 색상 변화가 제거되었는지 확인해 주세요.