### PR TITLE
[SNO-489] #1731 서버 점검 일정 및 표시 형식 변경

### DIFF
--- a/src/feature/maintenance/hook/useMaintenance.jsx
+++ b/src/feature/maintenance/hook/useMaintenance.jsx
@@ -1,7 +1,7 @@
 import { DateTime } from '@/shared/lib';
 
-export const MAINTENANCE_START = new Date('2026-06-28T15:00:00+09:00'); // 서버 점검 시작(년-월-일THH:MM:SS+한국기준)
-export const MAINTENANCE_END = new Date('2026-06-28T16:00:00+09:00'); // 서버 점검 끝
+export const MAINTENANCE_START = new Date('2026-07-31T20:00:00+09:00'); // 서버 점검 시작(년-월-일THH:MM:SS+한국기준)
+export const MAINTENANCE_END = new Date('2026-07-31T23:00:00+09:00'); // 서버 점검 끝
 
 export function useMaintenance(MAINTENANCE_START, MAINTENANCE_END) {
   const isSameDate =
@@ -14,6 +14,6 @@ export function useMaintenance(MAINTENANCE_START, MAINTENANCE_END) {
 
   // YYYY/MM/DD (Day) HH:MM ~ HH:MM
   return isSameDate
-    ? `${startDateStr} ${startTime} - ${endTime}`
-    : [`${startDateStr} ${startTime}`, <br />, `- ${endDateStr} ${endTime}`];
+    ? `${startDateStr} ${startTime} ~ ${endTime}`
+    : [`${startDateStr} ${startTime}`, <br />, `~ ${endDateStr} ${endTime}`];
 }


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1731

## 🎯 변경 사항

- 서버 점검 일정 `2026/07/31(금) 20:00 ~ 23:00` 적용
- 점검 페이지 시간 표시 형식 `-` → `~` 변경

## 📸 스크린샷 (선택 사항)

<img width="1768" height="2206" alt="image" src="https://github.com/user-attachments/assets/46ff4cba-8395-49c2-8030-d324937491f9" />

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)

서버 점검 페이지의 노출 시간과 안내 문구 표시를 확인해주세요.