### PR TITLE
[SNO-493] #1741 PR 자동화 트리거 및 라벨 복사 예외 처리 보완

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -4,8 +4,7 @@ on:
   issues:
     types: [opened, reopened]
   pull_request:
-    types: [opened, reopened]
-
+    types: [opened, reopened, synchronize, edited, ready_for_review]
 permissions:
   issues: write
   pull-requests: write
@@ -19,7 +18,7 @@ jobs:
         id: app-token
         continue-on-error: true
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
 
       - name: Auto Assign and Set Issue Type
@@ -94,9 +93,11 @@ jobs:
               }
             }
 
-            // 3. PR 라벨 복사 (PR 제목에 #이슈번호가 있는 경우)
+            // 3. PR 라벨 복사 (PR 제목/브랜치명/본문에 #이슈번호가 있는 경우)
             if (context.payload.pull_request) {
-              const issueMatch = title.match(/#(\d+)/);
+              const branchName = context.payload.pull_request.head.ref || '';
+              const body = context.payload.pull_request.body || '';
+              const issueMatch = `${title} ${branchName} ${body}`.match(/#(\d+)/);
               if (issueMatch) {
                 const linkedIssueNumber = parseInt(issueMatch[1]);
                 try {


### PR DESCRIPTION
## 🔎 What is this PR?

Close #1741

- [Notion](https://app.notion.com/p/snorose/PR-3b37ef0aa3bf8008bf8cf7d03dadad11?source=copy_link)

## 🎯 변경 사항

- PR 자동 할당 워크플로우가 `opened`, `reopened` 외에도 `synchronize`, `edited`, `ready_for_review` 이벤트에서 실행되도록 수정했습니다.
- `actions/create-github-app-token@v3` 입력값을 `app-id`에서 `client-id`로 변경했습니다.
- PR 라벨 복사 대상 이슈 번호를 PR 제목뿐 아니라 브랜치명과 본문에서도 찾도록 수정했습니다.

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)

- GitHub App 토큰 생성 시 사용하는 secret 이름이 `BOT_CLIENT_ID`로 맞게 등록되어 있는지 확인해주세요.
- PR 제목/브랜치명/본문 중 `#이슈번호`가 포함된 경우 해당 이슈의 라벨이 정상 복사되는지 확인해주세요.